### PR TITLE
[WIP] govim: refactor transport/protocol into new package

### DIFF
--- a/channel_cmds.go
+++ b/channel_cmds.go
@@ -5,116 +5,70 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/myitcv/govim/internal/transport"
 	"gopkg.in/tomb.v2"
 )
 
-func (g *govimImpl) handleChannelError(ch transport.UnscheduledCallback, err error, format string, args ...interface{}) error {
-	_, err = g.handleChannelValueAndError(ch, err, format, args)
-	return err
-}
-
-func (g *govimImpl) handleChannelValueAndError(ch transport.UnscheduledCallback, err error, format string, args ...interface{}) (json.RawMessage, error) {
-	if err != nil {
-		return nil, err
-	}
-	args = append([]interface{}{}, args...)
-	select {
-	case <-g.tomb.Dying():
-		panic(ErrShuttingDown)
-	case resp := <-ch:
-		if resp.ErrString != "" {
-			args = append(args, resp.ErrString)
-			return nil, fmt.Errorf(format, args...)
-		}
-		return resp.Val, nil
-	}
-}
-
 // ChannelRedraw implements Govim.ChannelRedraw
 func (g *govimImpl) ChannelRedraw(force bool) error {
-	ch := make(transport.UnscheduledCallback)
-	err := g.channelRedrawImpl(ch, force)
-	return g.handleChannelError(ch, err, channelRedrawErrMsg, force)
-}
-
-const channelRedrawErrMsg = "failed to redraw (force = %v) in Vim: %v"
-
-func (g *govimImpl) channelRedrawImpl(ch transport.Callback, force bool) error {
 	<-g.loaded
 	var sForce string
 	if force {
 		sForce = "force"
 	}
-	return g.DoProto(func() error {
-		return g.callVim(ch, "redraw", sForce)
-	})
+	if _, err := g.transport.SendAndReceive("redraw", sForce); err != nil {
+		return fmt.Errorf(channelRedrawErrMsg, sForce, err)
+	}
+	return nil
 }
+
+const channelRedrawErrMsg = "failed to redraw (force = %v) in Vim: %v"
 
 // ChannelEx implements Govim.ChannelEx
 func (g *govimImpl) ChannelEx(expr string) error {
-	ch := make(transport.UnscheduledCallback)
-	err := g.channelExImpl(ch, expr)
-	return g.handleChannelError(ch, err, channelExErrMsg, expr)
+	<-g.loaded
+	if _, err := g.transport.SendAndReceive("ex", expr); err != nil {
+		return fmt.Errorf(channelExErrMsg, expr, err)
+	}
+	return nil
 }
 
 const channelExErrMsg = "failed to ex(%v) in Vim: %v"
 
-func (g *govimImpl) channelExImpl(ch transport.Callback, expr string) error {
-	<-g.loaded
-	return g.DoProto(func() error {
-		return g.callVim(ch, "ex", expr)
-	})
-}
-
 // ChannelNormal implements Govim.ChannelNormal
 func (g *govimImpl) ChannelNormal(expr string) error {
-	ch := make(transport.UnscheduledCallback)
-	err := g.channelNormalImpl(ch, expr)
-	return g.handleChannelError(ch, err, channelNormalErrMsg, expr)
+	<-g.loaded
+	if _, err := g.transport.SendAndReceive("normal", expr); err != nil {
+		return fmt.Errorf(channelNormalErrMsg, expr, err)
+	}
+	return nil
 }
 
 const channelNormalErrMsg = "failed to normal(%v) in Vim: %v"
 
-func (g *govimImpl) channelNormalImpl(ch transport.Callback, expr string) error {
-	<-g.loaded
-	return g.DoProto(func() error {
-		return g.callVim(ch, "normal", expr)
-	})
-}
-
 // ChannelExpr implements Govim.ChannelExpr
 func (g *govimImpl) ChannelExpr(expr string) (json.RawMessage, error) {
-	ch := make(transport.UnscheduledCallback)
-	err := g.channelExprImpl(ch, expr)
-	return g.handleChannelValueAndError(ch, err, channelExprErrMsg, expr)
+	<-g.loaded
+	val, err := g.transport.SendAndReceive("expr", expr)
+	if err != nil {
+		return nil, fmt.Errorf(channelExprErrMsg, expr, err)
+	}
+	return val, nil
 }
 
 const channelExprErrMsg = "failed to expr(%v) in Vim: %v"
 
-func (g *govimImpl) channelExprImpl(ch transport.Callback, expr string) error {
-	<-g.loaded
-	return g.DoProto(func() error {
-		return g.callVim(ch, "expr", expr)
-	})
-}
-
 // ChannelCall implements Govim.ChannelCall
 func (g *govimImpl) ChannelCall(fn string, args ...interface{}) (json.RawMessage, error) {
-	ch := make(transport.UnscheduledCallback)
-	err := g.channelCallImpl(ch, fn, args...)
-	return g.handleChannelValueAndError(ch, err, channelCallErrMsg, fn, args)
-}
-
-const channelCallErrMsg = "failed to call(%v) in Vim: %v"
-
-func (g *govimImpl) channelCallImpl(ch transport.Callback, fn string, args ...interface{}) error {
 	<-g.loaded
 	args = append([]interface{}{fn}, args...)
-	return g.DoProto(func() error {
-		return g.callVim(ch, "call", args...)
-	})
+	val, err := g.transport.SendAndReceive("call", args...)
+	if err != nil {
+		return nil, fmt.Errorf(channelCallErrMsg, fn, args, err)
+	}
+	return val, nil
 }
+
+const channelCallErrMsg = "failed to call(%v(%v)) in Vim: %v"
 
 func (g *govimImpl) DoProto(f func() error) (err error) {
 	defer func() {

--- a/event_queue.go
+++ b/event_queue.go
@@ -15,32 +15,36 @@ type eventQueueInst struct {
 var _ Govim = eventQueueInst{}
 
 func (e eventQueueInst) ChannelRedraw(force bool) error {
-	ch := make(transport.ScheduledCallback)
-	err := e.govimImpl.channelRedrawImpl(ch, force)
+	var sForce string
+	if force {
+		sForce = "force"
+	}
+	ch, err := e.govimImpl.transport.SendAndReceiveAsync("redraw", sForce)
 	return e.handleUserQError(ch, err, channelRedrawErrMsg, force)
 }
 
 func (e eventQueueInst) ChannelEx(expr string) error {
 	ch := make(transport.ScheduledCallback)
-	err := e.govimImpl.channelExImpl(ch, expr)
+	ch, err := e.govimImpl.transport.SendAndReceiveAsync("ex", expr)
 	return e.handleUserQError(ch, err, channelExErrMsg, expr)
 }
 
 func (e eventQueueInst) ChannelNormal(expr string) error {
 	ch := make(transport.ScheduledCallback)
-	err := e.govimImpl.channelNormalImpl(ch, expr)
+	ch, err := e.govimImpl.transport.SendAndReceiveAsync("normal", expr)
 	return e.handleUserQError(ch, err, channelNormalErrMsg, expr)
 }
 
 func (e eventQueueInst) ChannelExpr(expr string) (json.RawMessage, error) {
 	ch := make(transport.ScheduledCallback)
-	err := e.govimImpl.channelExprImpl(ch, expr)
+	ch, err := e.govimImpl.transport.SendAndReceiveAsync("expr", expr)
 	return e.handleUserQValueAndError(ch, err, channelExprErrMsg, expr)
 }
 
 func (e eventQueueInst) ChannelCall(fn string, args ...interface{}) (json.RawMessage, error) {
 	ch := make(transport.ScheduledCallback)
-	err := e.govimImpl.channelCallImpl(ch, fn, args...)
+	args = append([]interface{}{fn}, args...)
+	ch, err := e.govimImpl.transport.SendAndReceiveAsync("call", args...)
 	return e.handleUserQValueAndError(ch, err, channelCallErrMsg, fn, args)
 }
 

--- a/govim.go
+++ b/govim.go
@@ -375,7 +375,7 @@ func (g *govimImpl) run() error {
 	// the read loop
 	for {
 		g.Logf("run: waiting to read a JSON message\n")
-		id, typ, args, err := g.transport.Read()
+		responseCallback, typ, args, err := g.transport.Read()
 		if err != nil {
 			panic(err)
 		}
@@ -452,8 +452,8 @@ func (g *govimImpl) run() error {
 				} else {
 					resp[1] = res
 				}
-				g.transport.SendJSON(id, resp)
-				return nil
+
+				return responseCallback(resp)
 			})
 		case "log":
 			var is []interface{}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -4,6 +4,10 @@ import (
 	"sync"
 )
 
+type Queuer interface {
+	Add(f func() error)
+}
+
 type Queue struct {
 	work    []func() error
 	lock    sync.Mutex

--- a/internal/transport/types.go
+++ b/internal/transport/types.go
@@ -20,7 +20,6 @@ type Transport interface {
 	Initialized() chan struct{}
 	IsShutdown() chan struct{}
 
-	Read() (responseFunc func(p2 interface{}, ps ...interface{}) error, messageType string, args []json.RawMessage, err error)
 	Send(callback Callback, callbackType string, params ...interface{}) error
 	SendAndReceive(messageType string, args ...interface{}) (json.RawMessage, error)
 	SendAndReceiveAsync(messageType string, args ...interface{}) (ScheduledCallback, error)

--- a/internal/transport/types.go
+++ b/internal/transport/types.go
@@ -1,0 +1,28 @@
+package transport
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+var (
+	ErrShuttingDown = errors.New("govim shutting down")
+)
+
+type errProto struct {
+	underlying error
+}
+
+type Transport interface {
+	Start() error
+	Close() error
+	Loaded() chan struct{}
+	Initialized() chan struct{}
+	IsShutdown() chan struct{}
+
+	Receive() (json.RawMessage, error)
+	Send(callback Callback, msgType string, params ...interface{}) error
+	SendJSON(p1, p2 interface{}, ps ...interface{})
+}
+
+type Callback struct{}

--- a/internal/transport/types.go
+++ b/internal/transport/types.go
@@ -20,8 +20,29 @@ type Transport interface {
 	Initialized() chan struct{}
 	IsShutdown() chan struct{}
 
-	Read() (int, json.RawMessage, error)
+	Read() (id int, messageType string, args []json.RawMessage, err error)
+	Send(callback Callback, callbackType string, params ...interface{}) error
 	SendJSON(p1, p2 interface{}, ps ...interface{})
 }
 
-type Callback struct{}
+type Callback interface {
+	isCallback()
+}
+
+// scheduledCallback is used for responses to calls to Vim made from the event queue
+type ScheduledCallback chan CallbackResp
+
+func (s ScheduledCallback) isCallback() {}
+
+// unscheduledCallback is used for responses to calls made from off the event queue,
+// i.e. as a result of a reponse from a process external to the plugin like gopls
+type UnscheduledCallback chan CallbackResp
+
+func (u UnscheduledCallback) isCallback() {}
+
+// callbackResp is the container for a response from a call to callVim. If the
+// call does not result in a value, e.g. ChannelEx, then val will be nil
+type CallbackResp struct {
+	ErrString string
+	Val       json.RawMessage
+}

--- a/internal/transport/types.go
+++ b/internal/transport/types.go
@@ -22,6 +22,8 @@ type Transport interface {
 
 	Read() (id int, messageType string, args []json.RawMessage, err error)
 	Send(callback Callback, callbackType string, params ...interface{}) error
+	SendAndReceive(messageType string, args ...interface{}) (json.RawMessage, error)
+	SendAndReceiveAsync(messageType string, args ...interface{}) (ScheduledCallback, error)
 	SendJSON(p1, p2 interface{}, ps ...interface{})
 }
 

--- a/internal/transport/types.go
+++ b/internal/transport/types.go
@@ -20,8 +20,7 @@ type Transport interface {
 	Initialized() chan struct{}
 	IsShutdown() chan struct{}
 
-	Receive() (json.RawMessage, error)
-	Send(callback Callback, msgType string, params ...interface{}) error
+	Read() (int, json.RawMessage, error)
 	SendJSON(p1, p2 interface{}, ps ...interface{})
 }
 

--- a/internal/transport/types.go
+++ b/internal/transport/types.go
@@ -20,11 +20,10 @@ type Transport interface {
 	Initialized() chan struct{}
 	IsShutdown() chan struct{}
 
-	Read() (id int, messageType string, args []json.RawMessage, err error)
+	Read() (responseFunc func(p2 interface{}, ps ...interface{}) error, messageType string, args []json.RawMessage, err error)
 	Send(callback Callback, callbackType string, params ...interface{}) error
 	SendAndReceive(messageType string, args ...interface{}) (json.RawMessage, error)
 	SendAndReceiveAsync(messageType string, args ...interface{}) (ScheduledCallback, error)
-	SendJSON(p1, p2 interface{}, ps ...interface{})
 }
 
 type Callback interface {

--- a/internal/transport/vim.go
+++ b/internal/transport/vim.go
@@ -1,0 +1,83 @@
+package transport
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+type vimTransport struct {
+	out *json.Encoder
+	log io.Writer
+}
+
+func NewVimTransport(in io.Reader, out io.Writer, log io.Writer) Transport {
+	return &vimTransport{
+		out: json.NewEncoder(out),
+		log: log,
+	}
+}
+
+func (v *vimTransport) Start() error {
+	return nil
+}
+func (v *vimTransport) Close() error {
+	return nil
+}
+
+func (v *vimTransport) Loaded() chan struct{} {
+	return nil
+}
+
+func (v *vimTransport) Initialized() chan struct{} {
+	return nil
+}
+
+func (v *vimTransport) IsShutdown() chan struct{} {
+	return nil
+}
+
+func (v *vimTransport) Receive() (json.RawMessage, error) {
+	return nil, nil
+}
+
+func (v *vimTransport) Send(callback Callback, msgType string, params ...interface{}) error {
+	return nil
+}
+
+// sendJSONMsg is a low-level protocol primitive for sending a JSON msg that will be
+// understood by Vim. See https://vimhelp.org/channel.txt.html#channel-use
+func (v *vimTransport) SendJSON(p1, p2 interface{}, ps ...interface{}) {
+	msg := []interface{}{p1, p2}
+	msg = append(msg, ps...)
+	// TODO could use a multi-writer here
+	logMsg, err := json.Marshal(msg)
+	if err != nil {
+		v.errProto("failed to create log message: %v", err)
+	}
+	v.logVimEventf("sendJSONMsg: %s\n", logMsg)
+	if err := v.out.Encode(msg); err != nil {
+		panic(ErrShuttingDown)
+	}
+}
+
+func (v *vimTransport) errProto(format string, args ...interface{}) {
+	panic(errProto{
+		underlying: fmt.Errorf(format, args...),
+	})
+}
+func (v *vimTransport) logVimEventf(format string, args ...interface{}) {
+	v.Logf("vim start =======================\n"+format+"vim end =======================\n", args...)
+}
+
+func (v *vimTransport) Logf(format string, args ...interface{}) {
+	s := fmt.Sprintf(format, args...)
+	if s[len(s)-1] == '\n' {
+		s = s[:len(s)-1]
+	}
+	t := time.Now().Format("2006-01-02T15:04:05.000000")
+	s = strings.Replace(s, "\n", "\n"+t+": ", -1)
+	fmt.Fprint(v.log, t+": "+s+"\n")
+}


### PR DESCRIPTION
This adds a new `github.com/myitcv/govim/internal/transport` package with a `Transport` interface. The aim here is to make `govim.Govim` generic enough that it can support both Vim and Neovim (#186) with as few code changes as possible, whilst handling the differences in protocol (JSON vs msgpack) as much as possible in the transport layer.

This should make it much easier to add support for Neovim, and minimising the amount of separate code we have to maintain for both should make things easier in the future.

This is still very much WIP, there's still quite a few things left to refactor/clean up:

- [x] The govim run loop still has the concept of a callback ID (to respond to Vim) - this should be hidden away in the transport layer
- [ ] Error handling. The original `Govim` interface has a nice distinction between user-level errors (e.g. "vim function called with wrong arguments) vs protocol-level errors (e.g. "RPC connection closed). We should find a way of keeping this
- [x] `transport.Transport` requires an event queue object passed in to queue things. It only needs this to enqueue responses to scheduled callbacks - perhaps we can just pass in a "schedule" function
- [ ] The `transport.Transport` interface should be wire-format agnostic - callees should pass in and receive Go objects rather than `json.RawMessage`

Early feedback welcomed.