### PR TITLE
cmd/govim: fix incorrect motion mapping

### DIFF
--- a/cmd/govim/testdata/motion.txt
+++ b/cmd/govim/testdata/motion.txt
@@ -3,12 +3,12 @@
 vim ex 'e main.go'
 
 # Next start of File.Decl
-vim ex 'normal ]['
+vim ex 'normal ]]'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '\[3,1\]'
 
 # Next end of File.Decl
-vim ex 'normal ]]'
+vim ex 'normal ]['
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '\[5,1\]'
 

--- a/cmd/govim/testdata/motion_bad_ast.txt
+++ b/cmd/govim/testdata/motion_bad_ast.txt
@@ -3,8 +3,8 @@
 vim ex 'e main.go'
 
 # Next start of File.Decl
-vim ex 'normal ]]'
-vim ex 'normal ]]'
+vim ex 'normal ]['
+vim ex 'normal ]['
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '\[8,29\]'
 

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -17,6 +17,6 @@ if GOVIMPluginStatus() == "initcomplete"
   " Motions
   nnoremap <buffer> <silent> [[ :call GOVIMMotion("prev", "File.Decls.Pos()")<cr>
   nnoremap <buffer> <silent> [] :call GOVIMMotion("prev", "File.Decls.End()")<cr>
-  nnoremap <buffer> <silent> ][ :call GOVIMMotion("next", "File.Decls.Pos()")<cr>
-  nnoremap <buffer> <silent> ]] :call GOVIMMotion("next", "File.Decls.End()")<cr>
+  nnoremap <buffer> <silent> ]] :call GOVIMMotion("next", "File.Decls.Pos()")<cr>
+  nnoremap <buffer> <silent> ][ :call GOVIMMotion("next", "File.Decls.End()")<cr>
 endif


### PR DESCRIPTION
```
Currently we have ]] mapped to:

:call GOVIMMotion("next", "File.Decls.End()")

and ][ mapped to:

:call GOVIMMotion("next", "File.Decls.Pos()")

But this is the inverse of the Vim-default mappings we are looking to
"emulate":

]]  [count] sections forward or to the next '{' in the
    first column.  When used after an operator, then also
    stops below a '}' in the first column.  exclusive
    Note that exclusive-linewise often applies.

][  [count] sections forward or to the next '}' in the
    first column.  |exclusive|
    Note that |exclusive-linewise| often applies.

Fix this by invertig our mapping.
```