### PR TITLE
test: unset GOPATH before test

### DIFF
--- a/_scripts/dockerRun.sh
+++ b/_scripts/dockerRun.sh
@@ -23,6 +23,9 @@ fi
 go version
 vim --version
 
+# ensure GOPATH isn't set, to detect issues like https://golang.org/issues/33918. Also see govim/#472.
+export -n GOPATH
+
 ./_scripts/revendorToolsInternal.sh
 
 go install golang.org/x/tools/gopls


### PR DESCRIPTION
To be able to detect issues with default GOPATH (like in https://github.com/govim/govim/issues/466), the tests should run w/o GOPATH set. This change un-exports it before running the tests.

Closes #472 