### PR TITLE
cmd/govim: prevent non-batch calls being called when in batch

### DIFF
--- a/cmd/govim/testdata/batch.txt
+++ b/cmd/govim/testdata/batch.txt
@@ -34,3 +34,8 @@ stderr 'failed to call GOVIMAssertFailedBatch\(\[\]\) in Vim: Caught ''got error
 vim call GOVIMSimpleBatch
 stdout [5,4]
 ! stderr .+
+
+# Test that calling a non-batch method within a batch fails
+! vim call GOVIMNonBatchCallInBatch
+! stdout .+
+stderr 'called ChannelExprf when in batch'

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -198,3 +198,52 @@ func (v *vimstate) BatchEnd() (res []json.RawMessage) {
 	b.results = res
 	return
 }
+
+func (v *vimstate) ChannelCall(name string, args ...interface{}) json.RawMessage {
+	if v.currBatch != nil {
+		panic(fmt.Errorf("called ChannelCall when in batch"))
+	}
+	return v.Driver.ChannelCall(name, args...)
+}
+
+func (v *vimstate) ChannelEx(expr string) {
+	if v.currBatch != nil {
+		panic(fmt.Errorf("called ChannelEx when in batch"))
+	}
+	v.Driver.ChannelEx(expr)
+}
+
+func (v *vimstate) ChannelExf(format string, args ...interface{}) {
+	if v.currBatch != nil {
+		panic(fmt.Errorf("called ChannelExf when in batch"))
+	}
+	v.Driver.ChannelExf(format, args...)
+}
+
+func (v *vimstate) ChannelExpr(expr string) json.RawMessage {
+	if v.currBatch != nil {
+		panic(fmt.Errorf("called ChannelExpr when in batch"))
+	}
+	return v.Driver.ChannelExpr(expr)
+}
+
+func (v *vimstate) ChannelExprf(format string, args ...interface{}) json.RawMessage {
+	if v.currBatch != nil {
+		panic(fmt.Errorf("called ChannelExprf when in batch"))
+	}
+	return v.Driver.ChannelExprf(format, args...)
+}
+
+func (v *vimstate) ChannelNormal(expr string) {
+	if v.currBatch != nil {
+		panic(fmt.Errorf("called ChannelNormal when in batch"))
+	}
+	v.Driver.ChannelNormal(expr)
+}
+
+func (v *vimstate) ChannelRedraw(force bool) {
+	if v.currBatch != nil {
+		panic(fmt.Errorf("called ChannelRedraw when in batch"))
+	}
+	v.Driver.ChannelRedraw(force)
+}


### PR DESCRIPTION
We should panic if we attempt to call a non-batch channel method when in a batch.

Fixes #438