### PR TITLE
ci: never notify for successful builds, only notify on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
   email:
     recipients:
       - govim-dev+ci@googlegroups.com
-    on_success: always
+    on_success: never
     on_failure: always
 
 branches:

--- a/_scripts/genconfig.go
+++ b/_scripts/genconfig.go
@@ -207,7 +207,7 @@ notifications:
   email:
     recipients:
       - govim-dev+ci@googlegroups.com
-    on_success: always
+    on_success: never
     on_failure: always
 
 branches:


### PR DESCRIPTION
Further attempt to get our Travis email notification setup "right" now
that we are using the govim-dev+ci group for build notifications