### PR TITLE
cmd/govim: add info popup config to minimal.vimrc; add minimal.gvimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Install `govim` via:
 * [Vundle](https://github.com/VundleVim/Vundle.vim)
   * `Plugin 'govim/govim'`
 
-You might need some `.vimrc` settings to get all features working: see the [minimal `.vimrc`](cmd/govim/config/minimal.vimrc) for an
-commented explanation of the required settings. For more details on `.vimrc`/`.gvimrc` settings as well as some tips and
-tricks, see [here](https://github.com/govim/govim/wiki/vimrc-tips).
+You might need some `.vimrc`/`.gvimrc` settings to get all features working: see the minimal
+[`.vimrc`](cmd/govim/config/minimal.vimrc) or [`.gvimrc`](cmd/govim/config/minimal.gvimrc) for an commented explanation
+of the required settings. For more details on `.vimrc`/`.gvimrc` settings as well as some tips and tricks, see
+[here](https://github.com/govim/govim/wiki/vimrc-tips).
 
 ### What can `govim` do?
 

--- a/cmd/govim/config/minimal.gvimrc
+++ b/cmd/govim/config/minimal.gvimrc
@@ -1,26 +1,7 @@
-" This file represents the minimal .vimrc needed to work with govim.
+" This file represents the minimal .gvimrc needed to work with govim.
 "
 " We also include a number of suggested settings that we think the majority of
 " users will like/prefer.
-
-set nocompatible
-set nobackup
-set nowritebackup
-set noswapfile
-
-filetype plugin on
-
-set mouse=a
-
-" To get hover working in the terminal we need to set ttymouse. See
-"
-" :help ttymouse
-"
-" for the appropriate setting for your terminal. Note that despite the
-" automated tests using xterm as the terminal, a setting of ttymouse=xterm
-" does not work correctly beyond a certain column number (citation needed)
-" hence we use ttymouse=sgr
-set ttymouse=sgr
 
 " Suggestion: By default, govim populates the quickfix window with diagnostics
 " reported by gopls after a period of inactivity, the time period being
@@ -52,11 +33,6 @@ autocmd! BufLeave *.go syntax off
 " include this by default in govim.
 set autoindent
 set smartindent
-filetype indent on
-
-" Suggestion: define sensible backspace behaviour. See :help backspace for
-" more details
-set backspace=2
 
 " Suggestion: show info for completion candidates in a popup menu
 if has("patch-8.1.1904")


### PR DESCRIPTION
Now that Vim supports popups for the info of a completion candidate, and
that popup window can be positioned relative to the candidates menu,
provide a version-guarded suggestion in the minimal.vimrc.

Also create a minimal.gvimrc so that Gvim users don't miss out on this
suggestions. This will require a tweak to the wiki in a couple of
places.

Fixes #392