### PR TITLE
govim: refactor the way we schedule work in Vim

### DIFF
--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -104,11 +104,10 @@ func (g *govimplugin) PublishDiagnostics(ctxt context.Context, params *protocol.
 	defer absorbShutdownErr()
 	g.logGoplsClientf("PublishDiagnostics callback: %v", pretty.Sprint(params))
 	g.diagnosticsLock.Lock()
-	defer g.diagnosticsLock.Unlock()
-
 	uri := span.URI(params.URI)
 	curr, ok := g.diagnostics[uri]
 	g.diagnostics[uri] = params
+	g.diagnosticsLock.Unlock()
 	if !ok {
 		if len(params.Diagnostics) == 0 {
 			return nil

--- a/cmd/govim/watcher.go
+++ b/cmd/govim/watcher.go
@@ -106,7 +106,7 @@ func (m *modWatcher) watch() {
 				if !ofInterest(path) {
 					continue
 				}
-				m.Schedule(func(govim.Govim) error {
+				m.Enqueue(func(govim.Govim) error {
 					return m.vimstate.handleEvent(event)
 				})
 			case fswatcher.OpChanged:
@@ -122,7 +122,7 @@ func (m *modWatcher) watch() {
 					if !ofInterest(path) {
 						continue
 					}
-					m.Schedule(func(govim.Govim) error {
+					m.Enqueue(func(govim.Govim) error {
 						return m.vimstate.handleEvent(event)
 					})
 					continue

--- a/event_queue.go
+++ b/event_queue.go
@@ -45,7 +45,11 @@ func (e eventQueueInst) Scheduled() Govim {
 	return e
 }
 
-func (e eventQueueInst) Schedule(f func(Govim) error) chan struct{} {
+func (e eventQueueInst) Enqueue(f func(Govim) error) chan struct{} {
+	panic(fmt.Errorf("attempt to enqueue work on the event queue from the event queue itself"))
+}
+
+func (e eventQueueInst) Schedule(f func(Govim) error) (chan struct{}, error) {
 	panic(fmt.Errorf("attempt to schedule work on the event queue from the event queue itself"))
 }
 

--- a/testdriver/testdriver.go
+++ b/testdriver/testdriver.go
@@ -422,38 +422,45 @@ func (d *TestDriver) listenDriver() error {
 				}
 				res = append(res, toAdd)
 			}
+			schedule := func(f func(govim.Govim) error) chan struct{} {
+				ch, err := d.govim.Schedule(f)
+				if err != nil {
+					panic(err)
+				}
+				return ch
+			}
 			switch cmd {
 			case "redraw":
 				var force string
 				if len(args) == 2 {
 					force = args[1].(string)
 				}
-				<-d.govim.Schedule(func(g govim.Govim) error {
+				<-schedule(func(g govim.Govim) error {
 					add(g.ChannelRedraw(force == "force"))
 					return nil
 				})
 			case "ex":
 				expr := args[1].(string)
-				<-d.govim.Schedule(func(g govim.Govim) error {
+				<-schedule(func(g govim.Govim) error {
 					add(g.ChannelEx(expr))
 					return nil
 				})
 			case "normal":
 				expr := args[1].(string)
-				<-d.govim.Schedule(func(g govim.Govim) error {
+				<-schedule(func(g govim.Govim) error {
 					add(g.ChannelNormal(expr))
 					return nil
 				})
 			case "expr":
 				expr := args[1].(string)
-				<-d.govim.Schedule(func(g govim.Govim) error {
+				<-schedule(func(g govim.Govim) error {
 					resp, err := g.ChannelExpr(expr)
 					add(err, resp)
 					return nil
 				})
 			case "call":
 				fn := args[1].(string)
-				<-d.govim.Schedule(func(g govim.Govim) error {
+				<-schedule(func(g govim.Govim) error {
 					resp, err := g.ChannelCall(fn, args[2:]...)
 					add(err, resp)
 					return nil


### PR DESCRIPTION
Currently we have the concept of scheduling via Govim.Schedule, where
non-Vim events (e.g.  diagnostics being sent from gopls) can schedule
work to happen in the govim event queue.

However this approach leads to race conditions: non-Vim events and Vim
events are, by definition, not synchronised.

Calls from Vim -> govim use ch_evalexpr, meaning the caller (in Vim) is
blocked. But whilst blocked, Vim can (and does) process messages
received over the channel from govim. This can (and does) include messages from
govim that include function calls, expressions and commands. Similarly,
a call from govim -> Vim from the govim event queue (i.e. a scheduled
call or a callback from Vim) blocks. But govim can (and does) process
messages received over the channel from Vim. This includes autocommands,
commands, function calls and listener_add callbacks.

This leads to situations where non-Vim events and Vim events interleave.
For example the user happens to start editing at just the same time as
govim is trying to update quickfix diagnostics. The listener_add
callback fires in Vim which ultimately results in a ch_evalexpr to tell
govim of the change. This callback blocks. At the same time, govim calls
into Vim to update the quickfix list with a setqflist. The two calls
then interleave, with the major problem being that whilst Vim is blocked
handling the listener_add callback it can't do anything else, hence we
get the error "not allowed here".

This problem can (and does) also present itself in the testscript tests,
because the special vim command schedules calls, expression evaluations
and commands, in contrast to a user session where those events are all
Vim-triggered (via keyboard/mouse events). It's highly likely that a
number of the test flakes we have seen relate to this issue.

The fix here is to properly schedule calls to happen when it is next
safe to do so in Vim, i.e. govim synchronises with Vim. Govim.Schedule
makes a "schedule" call to Vim to schedule a callback when it is next
safe.

So what does "safe" mean here? When the "schedule" call is made from
govim -> Vim, the following logic applies:

* if there are no active ch_evalexpr calls from Vim -> govim, then we
are safe. Immediately callback from Vim -> govim and the function that
is being schedule can proceed
* if, however, there are active ch_evalexpr calls, add the request to
the end of a pending queue
* when the number of active ch_evalexpr calls reaches zero, process the
pending queue in order, calling back from Vim -> govim for each one in
turn

For more background on the conversation about "safe" scheduling see:

https://groups.google.com/d/msg/vim_dev/op_PKiE9iog/_cryg8R6AwAJ