### PR TITLE
all: drop any references to now-old Vim versions

### DIFF
--- a/cmd/govim/testdata/quickfix_config.txt
+++ b/cmd/govim/testdata/quickfix_config.txt
@@ -19,8 +19,6 @@ vim call 'govim#config#Set' '["QuickfixSignsDisable", 1]'
 vim ex 'cexpr []' # clear quickfix list
 vim expr 'sign_unplace(\"*\")' # clear signs
 vim call append '[10,""]'
-[vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChanged'
-[gvim] [!gvim:v8.1.1711] vim ex 'doautocmd TextChanged'
 errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'
@@ -53,8 +51,6 @@ vim call 'govim#config#Set' '["QuickfixAutoDiagnosticsDisable", 1]'
 vim ex 'cexpr []' # clear quickfix list
 vim expr 'sign_unplace(\"*\")' # clear signs
 vim call append '[10,""]'
-[vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChanged'
-[gvim] [!gvim:v8.1.1711] vim ex 'doautocmd TextChanged'
 errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'

--- a/cmd/govim/testdata/references.txt
+++ b/cmd/govim/testdata/references.txt
@@ -18,8 +18,6 @@ vim ex 'call win_gotoid(win_findbuf(bufnr(\"main.go\"))[0])'
 vim expr 'bufname(\"\")'
 vim ex 'call cursor(15,1)'
 vim ex 'call feedkeys(\"ofmt.Printf(\\\"%v\\\")\\<ESC>\", \"xt\")'
-[vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChanged'
-[gvim] [!gvim:v8.1.1711] vim ex 'doautocmd TextChanged'
 errlogmatch -wait 60s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w locations'

--- a/cmd/govim/testdata/signs.txt
+++ b/cmd/govim/testdata/signs.txt
@@ -24,8 +24,6 @@ cmp stdout placed_openfile.golden
 # Removing one of the two quickfix entires on one line shouldn't remove the sign
 vim ex 'call cursor(6,36)'
 vim ex 'call feedkeys(\"3x\", \"x\")' # Remove "i, " from Printf-line
-[vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
-[gvim] [!gvim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
 errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
@@ -37,8 +35,6 @@ cmp stdout placed_openfile.golden
 # Removing lines should also remove the signs
 vim ex 'call cursor(9,1)'
 vim ex 'call feedkeys(\"2dd\", \"x\")' # Remove line 9 & 10
-[vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
-[gvim] [!gvim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
 errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_unplacelist\"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
@@ -49,8 +45,6 @@ cmp stdout placed_onesign.golden
 
 # Fixing the last quickfix entry should remove the last sign
 vim call append '[5, "\tvar v string"]'
-[vim] [!vim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
-[gvim] [!gvim:v8.1.1711] vim ex 'doautocmd TextChangedI' # make sure gopls is notified if incremental buffer updates isn't supported
 errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_unplacelist\"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+


### PR DESCRIPTION
Follow up to 01d4e82; we missed dropping some condition references to
[!v8.1.1711] which is used to refer to versions prior to the now-minimum
version.

For #518