### PR TITLE
[WIP] cmd/govim: refactor diagnostics handling

### DIFF
--- a/cmd/govim/diagnostics.go
+++ b/cmd/govim/diagnostics.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
+	"github.com/govim/govim/cmd/govim/internal/types"
+)
+
+func (v *vimstate) redefineDiagnostics() error {
+	v.diagnosticsLock.Lock()
+	filediags := make(map[span.URI][]protocol.Diagnostic)
+	for k, v := range v.diagnostics {
+		filediags[k] = v.Diagnostics
+	}
+	doWork := v.diagnosticsChanged
+	v.diagnosticsChanged = false
+	v.diagnosticsLock.Unlock()
+
+	if !doWork {
+		return nil
+	}
+
+	// TODO: this will become fragile at some point
+	cwd := v.ParseString(v.ChannelCall("getcwd"))
+
+	// must be non-nil
+	diags := []types.Diagnostic{}
+
+	for uri, lspDiags := range filediags {
+		fn := uri.Filename()
+		var buf *types.Buffer
+		for _, b := range v.buffers {
+			if b.URI() == uri {
+				buf = b
+			}
+		}
+		if buf == nil {
+			byts, err := ioutil.ReadFile(fn)
+			if err != nil {
+				v.Logf("redefineDiagnostics: failed to read contents of %v: %v", fn, err)
+				continue
+			}
+			// create a temp buffer
+			buf = types.NewBuffer(-1, fn, byts)
+		}
+		// make fn relative for reporting purposes
+		fn, err := filepath.Rel(cwd, fn)
+		if err != nil {
+			v.Logf("redefineDiagnostics: failed to call filepath.Rel(%q, %q): %v", cwd, fn, err)
+			continue
+		}
+		for _, d := range lspDiags {
+			s, err := types.PointFromPosition(buf, d.Range.Start)
+			if err != nil {
+				v.Logf("redefineDiagnostics: failed to resolve start position: %v", err)
+				continue
+			}
+			e, err := types.PointFromPosition(buf, d.Range.End)
+			if err != nil {
+				v.Logf("redefineDiagnostics: failed to resolve end position: %v", err)
+				continue
+			}
+			diags = append(diags, types.Diagnostic{
+				Filename: fn,
+				Range:    types.Range{Start: s, End: e},
+				Text:     d.Message,
+				Buf:      buf.Num,
+				Severity: int(d.Severity),
+			})
+		}
+	}
+
+	sort.Slice(diags, func(i, j int) bool {
+		lhs, rhs := diags[i], diags[j]
+		cmp := strings.Compare(lhs.Filename, rhs.Filename)
+		if cmp == 0 {
+			cmp = lhs.Range.Start.Line() - rhs.Range.Start.Line()
+		}
+		if cmp == 0 {
+			cmp = lhs.Range.Start.Col() - rhs.Range.Start.Col()
+		}
+		return cmp < 0
+	})
+
+	if err := v.updateQuickfix(diags); err != nil {
+		return err
+	}
+
+	if v.placeSigns() {
+		if err := v.redefineSigns(diags); err != nil {
+			v.Logf("redefineDiagnostics: failed to place/remove signs: %v", err)
+		}
+	}
+	return nil
+}

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -125,7 +125,7 @@ func (g *govimplugin) PublishDiagnostics(ctxt context.Context, params *protocol.
 		if v.userBusy {
 			return nil
 		}
-		return v.updateQuickfix()
+		return v.redefineDiagnostics()
 	})
 	return nil
 }

--- a/cmd/govim/internal/types/types.go
+++ b/cmd/govim/internal/types/types.go
@@ -214,3 +214,13 @@ func (p Point) ToPosition() protocol.Position {
 func f2int(f float64) int {
 	return int(math.Round(f))
 }
+
+// Diagnostic is the govim internal representation of a LSP diagnostic, used to
+// populate quickfix list, place signs, highlight text ranges etc.
+type Diagnostic struct {
+	Filename string
+	Range    Range
+	Text     string
+	Buf      int
+	Severity int
+}

--- a/cmd/govim/signs.go
+++ b/cmd/govim/signs.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+
+	"github.com/govim/govim/cmd/govim/internal/types"
 )
 
 // Using a sign group creates a separate namespace for all signs placed by govim
@@ -67,11 +69,12 @@ type unplaceDict struct {
 
 // redefineSigns ensures that there is only one govim sign per buffer line
 // by calculating a difference between current state and the list of quickfix entries
-func (v *vimstate) redefineSigns(fixes []quickfixEntry) error {
+func (v *vimstate) redefineSigns(fixes []types.Diagnostic) error {
 	type bufLine struct {
 		buf  int
 		line int
 	}
+
 	remove := make(map[bufLine]int) // Value is sign ID, used to unplace duplicates
 	place := make(map[bufLine]int)  // Value is insert order, used to avoid sorting
 
@@ -113,7 +116,7 @@ func (v *vimstate) redefineSigns(fixes []quickfixEntry) error {
 	// delete existing entries from the list of signs to removed
 	inx := 0
 	for _, f := range fixes {
-		bl := bufLine{f.Buf, f.Lnum}
+		bl := bufLine{f.Buf, f.Range.Start.Line()}
 		if _, exist := remove[bl]; exist {
 			delete(remove, bl)
 			continue

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -100,7 +100,7 @@ func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {
 			v.diagnosticsLock.Lock()
 			v.diagnosticsChanged = true
 			v.diagnosticsLock.Unlock()
-			return nil, v.updateQuickfix()
+			return nil, v.redefineDiagnostics()
 		}
 	}
 	return nil, nil
@@ -113,7 +113,7 @@ func (v *vimstate) setUserBusy(args ...json.RawMessage) (interface{}, error) {
 	if v.userBusy || v.config.QuickfixAutoDiagnosticsDisable || !v.quickfixIsDiagnostics {
 		return nil, nil
 	}
-	return nil, v.updateQuickfix()
+	return nil, v.redefineDiagnostics()
 }
 
 type batch struct {


### PR DESCRIPTION
To be able to add highlighting of diagnostics (over the entire range), diagnostics hovering, etc. we need to extract more things from the LSP diagnostics, like range and severity.

Much of the current logic take place inside the quickfix handling today, and the idea with this change is to move the generic stuff out from the quickfix specific code. That includes sign placement as well, but we still want to ensure a consistent state where signs always represents what is shown in the quickfix list.