### PR TITLE
[WIP] cmd/govim: move to positive options and move defaults to constructor

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -42,14 +42,14 @@ function! s:validFormatOnSave(v)
   return [v:true, ""]
 endfunction
 
-function! s:validQuickfixAutoDiagnosticsDisable(v)
+function! s:validQuickfixAutoDiagnostics(v)
   if type(a:v) != 0  && type(a:v) != 6
     return [v:false, "must be of type number or bool"
   endif
   return [v:true, ""]
 endfunction
 
-function! s:validQuickfixSignsDisable(v)
+function! s:validQuickfixSigns(v)
   if type(a:v) != 0  && type(a:v) != 6
     return [v:false, "must be of type number or bool"
   endif
@@ -74,14 +74,14 @@ function! s:validExperimentalCursorTriggeredHoverPopupOptions(v)
   return s:validExperimentalMouseTriggeredHoverPopupOptions(a:v)
 endfunction
 
-function! s:validCompletionDeepCompletionsDisable(v)
+function! s:validCompletionDeepCompletions(v)
   if type(a:v) != 0  && type(a:v) != 6
     return [v:false, "must be of type number or bool"
   endif
   return [v:true, ""]
 endfunction
 
-function! s:validCompletionFuzzyMatchingDisable(v)
+function! s:validCompletionFuzzyMatching(v)
   if type(a:v) != 0  && type(a:v) != 6
     return [v:false, "must be of type number or bool"
   endif
@@ -90,12 +90,10 @@ endfunction
 
 let s:validators = {
       \ "FormatOnSave": function("s:validFormatOnSave"),
-      \ "QuickfixAutoDiagnosticsDisable": function("s:validQuickfixAutoDiagnosticsDisable"),
-      \ "CompletionDeepCompletionsDisable": function("s:validCompletionDeepCompletionsDisable"),
-      \ "CompletionFuzzyMatchingDisable": function("s:validCompletionFuzzyMatchingDisable"),
-      \ "QuickfixSignsDisable": function("s:validQuickfixSignsDisable"),
+      \ "QuickfixAutoDiagnostics": function("s:validQuickfixAutoDiagnostics"),
+      \ "CompletionDeepCompletions": function("s:validCompletionDeepCompletions"),
+      \ "CompletionFuzzyMatching": function("s:validCompletionFuzzyMatching"),
+      \ "QuickfixSigns": function("s:validQuickfixSigns"),
       \ "ExperimentalMouseTriggeredHoverPopupOptions": function("s:validExperimentalMouseTriggeredHoverPopupOptions"),
       \ "ExperimentalCursorTriggeredHoverPopupOptions": function("s:validExperimentalCursorTriggeredHoverPopupOptions"),
       \ }
-
-call govim#config#Set("FormatOnSave", "goimports")

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -22,33 +22,40 @@ const (
 type Config struct {
 	// FormatOnSave is a string value that configures which tool to use for
 	// formatting on save. Options are given by constants of type FormatOnSave.
+	//
 	// Default: FormatOnSaveGoImports.
-	FormatOnSave FormatOnSave
+	FormatOnSave *FormatOnSave
 
-	// QuickfixAutoDiagnosticsDisable is a boolean (0 or 1 in VimScript) that
-	// controls whether auto-population of the quickfix window with gopls
-	// diagnostics is disabled or not. When not disabled, govim waits for
-	// updatetime (help updatetime) before populating the quickfix window with
-	// the current gopls diagnostics. When disabled, the
-	// CommandQuickfixDiagnostics command can be used to manually trigger the
-	// population. Default: false (0)
-	QuickfixAutoDiagnosticsDisable bool
+	// QuickfixAutoDiagnostics is a boolean (0 or 1 in VimScript) that controls
+	// whether auto-population of the quickfix window with gopls diagnostics is
+	// enabled or not. When enabled, govim waits for updatetime (help
+	// updatetime) before populating the quickfix window with the current gopls
+	// diagnostics. When disabled, the CommandQuickfixDiagnostics command can be
+	// used to manually trigger the population.
+	//
+	// Default: true
+	QuickfixAutoDiagnostics *bool
 
-	// QuickfixSignsDisable is a boolean (0 or 1 in VimScript) that controls
-	// whether quickfix entries should be annotated with signs in the gutter.
-	// Signs are placed when gopls diagnostics updates the quickfix list, either
-	// automatically when QuickfixAutoDiagnosticsDisable is false, or when the
-	// user run :GOVIMQuickfixDiagnostics.
-	// Default: false (0)
-	QuickfixSignsDisable bool
+	// QuickfixSigns is a boolean (0 or 1 in VimScript) that controls whether
+	// quickfix entries should be annotated with signs in the gutter.  Signs are
+	// placed when gopls diagnostics updates the quickfix list, either
+	// automatically when QuickfixAutoDiagnostics is true, or when the user run
+	// :GOVIMQuickfixDiagnostics.
+	//
+	// Default: true
+	QuickfixSigns *bool
 
-	// CompletionDeepCompletiionsDisable disables gopls' deep completion option
+	// CompletionDeepCompletiions enables gopls' deep completion option
 	// in the derivation of completion candidates.
-	CompletionDeepCompletionsDisable bool
+	//
+	// Default: true
+	CompletionDeepCompletions *bool
 
-	// CompletionFuzzyMatchingDisable disables gopls' fuzzy matching in the
-	// derivation of completion candidates.
-	CompletionFuzzyMatchingDisable bool
+	// CompletionFuzzyMatching enables gopls' fuzzy matching in the derivation
+	// of completion candidates.
+	//
+	// Default: true
+	CompletionFuzzyMatching *bool
 
 	// ExperimentalMouseTriggeredHoverPopupOptions is a map of options to apply
 	// when creating hover-based popup windows triggered by the mouse hovering
@@ -69,7 +76,9 @@ type Config struct {
 	// This is an experimental feature designed to help iterate on
 	// the most sensible out-of-the-box defaults for hover popups. It might go
 	// away in the future, be renamed etc.
-	ExperimentalMouseTriggeredHoverPopupOptions map[string]interface{}
+	//
+	// Default: nil
+	ExperimentalMouseTriggeredHoverPopupOptions *map[string]interface{}
 
 	// ExperimentalCursorTriggeredHoverPopupOptions is a map of options to apply
 	// when creating hover-based popup windows triggered by a call to
@@ -91,7 +100,9 @@ type Config struct {
 	// This is an experimental feature designed to help iterate on the most
 	// sensible out-of-the-box defaults for hover popups. It might go away in
 	// the future, be renamed etc.
-	ExperimentalCursorTriggeredHoverPopupOptions map[string]interface{}
+	//
+	// Default: nil
+	ExperimentalCursorTriggeredHoverPopupOptions *map[string]interface{}
 }
 
 type Command string

--- a/cmd/govim/format.go
+++ b/cmd/govim/format.go
@@ -21,14 +21,14 @@ func (v *vimstate) formatCurrentBuffer(args ...json.RawMessage) (err error) {
 	}
 	tool := v.config.FormatOnSave
 	// TODO we should move this validation elsewhere...
-	switch tool {
+	switch *tool {
 	case config.FormatOnSaveNone:
 		return nil
 	case config.FormatOnSaveGoFmt, config.FormatOnSaveGoImports:
 	default:
 		return fmt.Errorf("unknown format tool specified: %v", tool)
 	}
-	return v.formatBufferRange(b, tool, govim.CommandFlags{})
+	return v.formatBufferRange(b, *tool, govim.CommandFlags{})
 }
 
 func (v *vimstate) gofmtCurrentBufferRange(flags govim.CommandFlags, args ...string) error {

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -12,10 +12,10 @@ import (
 )
 
 const (
-	goplsConfigNoDocsOnHover   = "noDocsOnHover"
-	goplsConfigHoverKind       = "hoverKind"
-	goplsDisableDeepCompletion = "disableDeepCompletion"
-	goplsDisableFuzzyMatching  = "disableFuzzyMatching"
+	goplsConfigNoDocsOnHover = "noDocsOnHover"
+	goplsConfigHoverKind     = "hoverKind"
+	goplsDeepCompletion      = "deepCompletion"
+	goplsFuzzyMatching       = "fuzzyMatching"
 )
 
 var _ protocol.Client = (*govimplugin)(nil)
@@ -84,8 +84,12 @@ func (g *govimplugin) Configuration(ctxt context.Context, params *protocol.Param
 	res := make([]interface{}, len(params.Items))
 	conf := make(map[string]interface{})
 	conf[goplsConfigHoverKind] = "FullDocumentation"
-	conf[goplsDisableDeepCompletion] = g.vimstate.config.CompletionDeepCompletionsDisable
-	conf[goplsDisableFuzzyMatching] = g.vimstate.config.CompletionFuzzyMatchingDisable
+	if g.vimstate.config.CompletionDeepCompletions != nil {
+		conf[goplsDeepCompletion] = *g.vimstate.config.CompletionDeepCompletions
+	}
+	if g.vimstate.config.CompletionFuzzyMatching != nil {
+		conf[goplsFuzzyMatching] = *g.vimstate.config.CompletionFuzzyMatching
+	}
 	res[0] = conf
 
 	g.logGoplsClientf("Configuration response: %v", pretty.Sprint(res))
@@ -121,7 +125,7 @@ func (g *govimplugin) PublishDiagnostics(ctxt context.Context, params *protocol.
 	g.Schedule(func(govim.Govim) error {
 		v := g.vimstate
 		v.diagnosticsChanged = true
-		if v.config.QuickfixAutoDiagnosticsDisable {
+		if !*v.config.QuickfixAutoDiagnostics {
 			return nil
 		}
 		if !v.quickfixIsDiagnostics {

--- a/cmd/govim/hover.go
+++ b/cmd/govim/hover.go
@@ -26,7 +26,7 @@ func (v *vimstate) hover(args ...json.RawMessage) (interface{}, error) {
 	return v.showHover(posExpr, opts, v.config.ExperimentalCursorTriggeredHoverPopupOptions)
 }
 
-func (v *vimstate) showHover(posExpr string, opts, userOpts map[string]interface{}) (interface{}, error) {
+func (v *vimstate) showHover(posExpr string, opts map[string]interface{}, userOpts *map[string]interface{}) (interface{}, error) {
 	if v.popupWinId > 0 {
 		v.ChannelCall("popup_close", v.popupWinId)
 		v.popupWinId = 0
@@ -68,7 +68,7 @@ func (v *vimstate) showHover(posExpr string, opts, userOpts map[string]interface
 	lines := strings.Split(msg, "\n")
 	if userOpts != nil {
 		opts = make(map[string]interface{})
-		for k, v := range userOpts {
+		for k, v := range *userOpts {
 			opts[k] = v
 		}
 		var line, col int64

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -1,0 +1,68 @@
+// Package vimconfig defines the mapping between Vim-specified config and
+// govim config
+package vimconfig
+
+import (
+	"github.com/govim/govim/cmd/govim/config"
+)
+
+type VimConfig struct {
+	FormatOnSave                                 *config.FormatOnSave
+	QuickfixAutoDiagnostics                      *int
+	QuickfixSigns                                *int
+	CompletionDeepCompletions                    *int
+	CompletionFuzzyMatching                      *int
+	ExperimentalMouseTriggeredHoverPopupOptions  *map[string]interface{}
+	ExperimentalCursorTriggeredHoverPopupOptions *map[string]interface{}
+}
+
+func (c *VimConfig) ToConfig(d config.Config) config.Config {
+	v := config.Config{
+		FormatOnSave:                                 c.FormatOnSave,
+		QuickfixSigns:                                boolVal(c.QuickfixSigns, d.QuickfixSigns),
+		QuickfixAutoDiagnostics:                      boolVal(c.QuickfixAutoDiagnostics, d.QuickfixAutoDiagnostics),
+		CompletionDeepCompletions:                    boolVal(c.CompletionDeepCompletions, d.CompletionDeepCompletions),
+		CompletionFuzzyMatching:                      boolVal(c.CompletionFuzzyMatching, d.CompletionFuzzyMatching),
+		ExperimentalMouseTriggeredHoverPopupOptions:  copyMap(c.ExperimentalMouseTriggeredHoverPopupOptions, d.ExperimentalMouseTriggeredHoverPopupOptions),
+		ExperimentalCursorTriggeredHoverPopupOptions: copyMap(c.ExperimentalCursorTriggeredHoverPopupOptions, d.ExperimentalCursorTriggeredHoverPopupOptions),
+	}
+	if v.FormatOnSave == nil {
+		v.FormatOnSave = d.FormatOnSave
+	}
+	return v
+}
+
+func boolVal(i *int, j *bool) *bool {
+	if i == nil {
+		return j
+	}
+	b := *i != 0
+	return &b
+}
+
+func copyMap(i, j *map[string]interface{}) *map[string]interface{} {
+	toCopy := i
+	if i == nil {
+		toCopy = j
+		if j == nil {
+			return nil
+		}
+	}
+	res := make(map[string]interface{})
+	for ck, cv := range *toCopy {
+		res[ck] = cv
+	}
+	return &res
+}
+
+func FormatOnSaveVal(v config.FormatOnSave) *config.FormatOnSave {
+	return &v
+}
+
+func BoolVal(v bool) *bool {
+	return &v
+}
+
+func MapVal(v map[string]interface{}) *map[string]interface{} {
+	return &v
+}

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	"github.com/govim/govim/cmd/govim/internal/types"
+	"github.com/govim/govim/cmd/govim/internal/vimconfig"
 	"github.com/govim/govim/internal/plugin"
 	"github.com/govim/govim/testsetup"
 	"gopkg.in/tomb.v2"
@@ -173,6 +174,11 @@ type govimplugin struct {
 }
 
 func newplugin(goplspath string) *govimplugin {
+	defaults := config.Config{
+		FormatOnSave:            vimconfig.FormatOnSaveVal(config.FormatOnSaveGoImports),
+		QuickfixAutoDiagnostics: vimconfig.BoolVal(true),
+		QuickfixSigns:           vimconfig.BoolVal(true),
+	}
 	d := plugin.NewDriver(PluginPrefix)
 	res := &govimplugin{
 		diagnostics: make(map[span.URI]*protocol.PublishDiagnosticsParams),
@@ -181,6 +187,8 @@ func newplugin(goplspath string) *govimplugin {
 		vimstate: &vimstate{
 			Driver:                d,
 			buffers:               make(map[int]*types.Buffer),
+			defaultConfig:         defaults,
+			config:                defaults,
 			watchedFiles:          make(map[string]*types.WatchedFile),
 			quickfixIsDiagnostics: true,
 		},

--- a/cmd/govim/signs.go
+++ b/cmd/govim/signs.go
@@ -105,7 +105,7 @@ func (v *vimstate) redefineSigns(fixes []quickfixEntry) error {
 		}
 	}
 
-	if v.config.QuickfixSignsDisable {
+	if !*v.config.QuickfixSigns {
 		return nil
 	}
 

--- a/cmd/govim/testdata/goimports.txt
+++ b/cmd/govim/testdata/goimports.txt
@@ -5,10 +5,6 @@
 # doing so triggers govim to consider the file change from a file watcher
 # perspective which throws the observed diagnostics etc.
 
-# Ensure the default is goimports
-vim expr 'govim#config#Get().FormatOnSave'
-stdout '^"goimports"$'
-
 # :GOVIMGoImports whole file
 vim ex 'e! file.go'
 errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go

--- a/cmd/govim/testdata/quickfix_config.txt
+++ b/cmd/govim/testdata/quickfix_config.txt
@@ -14,8 +14,8 @@ cmp stdout signs.golden
 # errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 # There must be no quickfix entries or signs when both are explicitly disabled
-vim call 'govim#config#Set' '["QuickfixAutoDiagnosticsDisable", 1]'
-vim call 'govim#config#Set' '["QuickfixSignsDisable", 1]'
+vim call 'govim#config#Set' '["QuickfixAutoDiagnostics", 0]'
+vim call 'govim#config#Set' '["QuickfixSigns", 0]'
 vim ex 'cexpr []' # clear quickfix list
 vim expr 'sign_unplace(\"*\")' # clear signs
 vim call append '[10,""]'
@@ -28,7 +28,7 @@ vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 cmp stdout nosigns.golden
 
 # Enabling quickfix autodiagnostics should give quickfix entries but no signs
-vim call 'govim#config#Set' '["QuickfixAutoDiagnosticsDisable", 0]'
+vim call 'govim#config#Set' '["QuickfixAutoDiagnostics", 1]'
 vim ex 'copen'
 vim ex 'w errors'
 vim ex 'cclose'
@@ -37,7 +37,7 @@ vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 cmp stdout nosigns.golden
 
 ## Enabling signs should place signs
-vim call 'govim#config#Set' '["QuickfixSignsDisable", 0]'
+vim call 'govim#config#Set' '["QuickfixSigns", 1]'
 vim ex 'copen'
 vim ex 'w errors'
 vim ex 'cclose'
@@ -47,7 +47,7 @@ vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 cmp stdout signs.golden
 
 # Signs should not be placed with quickfix autodiagnostics disabled
-vim call 'govim#config#Set' '["QuickfixAutoDiagnosticsDisable", 1]'
+vim call 'govim#config#Set' '["QuickfixAutoDiagnostics", 0]'
 vim ex 'cexpr []' # clear quickfix list
 vim expr 'sign_unplace(\"*\")' # clear signs
 vim call append '[10,""]'

--- a/cmd/govim/testdata/references.txt
+++ b/cmd/govim/testdata/references.txt
@@ -2,7 +2,7 @@
 # GOVIMReferences command
 
 # Ensure quickfix diagnostics are turned on
-vim call 'govim#config#Set' '["QuickfixAutoDiagnosticsDisable", 0]'
+vim call 'govim#config#Set' '["QuickfixAutoDiagnostics", 1]'
 
 # Initial location population
 vim ex 'e main.go'

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/govim/govim/cmd/govim/config"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/types"
+	"github.com/govim/govim/cmd/govim/internal/vimconfig"
 	"github.com/govim/govim/internal/plugin"
 )
 
@@ -33,7 +34,8 @@ type vimstate struct {
 	// state here
 	lastCompleteResults *protocol.CompletionList
 
-	config config.Config
+	defaultConfig config.Config
+	config        config.Config
 
 	// userBusy indicates the user is moving the cusor doing something
 	userBusy bool
@@ -64,38 +66,12 @@ type vimstate struct {
 
 func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {
 	preConfig := v.config
-	var c struct {
-		FormatOnSave                                 config.FormatOnSave
-		QuickfixAutoDiagnosticsDisable               int
-		QuickfixSignsDisable                         int
-		CompletionDeepCompletionsDisable             int
-		CompletionFuzzyMatchingDisable               int
-		ExperimentalMouseTriggeredHoverPopupOptions  map[string]json.RawMessage
-		ExperimentalCursorTriggeredHoverPopupOptions map[string]json.RawMessage
-	}
-	v.Parse(args[0], &c)
-	v.config = config.Config{
-		FormatOnSave:                     c.FormatOnSave,
-		QuickfixSignsDisable:             c.QuickfixSignsDisable != 0,
-		QuickfixAutoDiagnosticsDisable:   c.QuickfixAutoDiagnosticsDisable != 0,
-		CompletionDeepCompletionsDisable: c.CompletionDeepCompletionsDisable != 0,
-		CompletionFuzzyMatchingDisable:   c.CompletionFuzzyMatchingDisable != 0,
-	}
-	if len(c.ExperimentalMouseTriggeredHoverPopupOptions) > 0 {
-		v.config.ExperimentalMouseTriggeredHoverPopupOptions = make(map[string]interface{})
-		for ck, cv := range c.ExperimentalMouseTriggeredHoverPopupOptions {
-			v.config.ExperimentalMouseTriggeredHoverPopupOptions[ck] = cv
-		}
-	}
-	if len(c.ExperimentalCursorTriggeredHoverPopupOptions) > 0 {
-		v.config.ExperimentalCursorTriggeredHoverPopupOptions = make(map[string]interface{})
-		for ck, cv := range c.ExperimentalCursorTriggeredHoverPopupOptions {
-			v.config.ExperimentalCursorTriggeredHoverPopupOptions[ck] = cv
-		}
-	}
-	if v.config.QuickfixAutoDiagnosticsDisable != preConfig.QuickfixAutoDiagnosticsDisable ||
-		v.config.QuickfixSignsDisable != preConfig.QuickfixSignsDisable {
-		if v.config.QuickfixAutoDiagnosticsDisable {
+	var vc vimconfig.VimConfig
+	v.Parse(args[0], &vc)
+	v.config = vc.ToConfig(v.defaultConfig)
+	if *v.config.QuickfixAutoDiagnostics != *preConfig.QuickfixAutoDiagnostics ||
+		*v.config.QuickfixSigns != *preConfig.QuickfixSigns {
+		if !*v.config.QuickfixAutoDiagnostics {
 			v.lastQuickFixDiagnostics = []quickfixEntry{}
 			if v.quickfixIsDiagnostics {
 				v.ChannelCall("setqflist", v.lastQuickFixDiagnostics, "r")
@@ -126,7 +102,7 @@ func (v *vimstate) setUserBusy(args ...json.RawMessage) (interface{}, error) {
 	var isBusy int
 	v.Parse(args[0], &isBusy)
 	v.userBusy = isBusy != 0
-	if v.userBusy || v.config.QuickfixAutoDiagnosticsDisable || !v.quickfixIsDiagnostics {
+	if v.userBusy || !*v.config.QuickfixAutoDiagnostics || !v.quickfixIsDiagnostics {
 		return nil, nil
 	}
 	return nil, v.updateQuickfix()


### PR DESCRIPTION
This is a breaking change.

In line with a recent change in gopls, move from negative options like
QuickfixAutoDiagnosticsDisable to QuickfixAutoDiagnostics. This requires
that we introduce the concept of a config value not having been set,
hence the cmd/govim/config.Config type now has pointer type fields.