### PR TITLE
cmd/govim: add config to enable staticcheck within gopls

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -65,6 +65,10 @@ function! s:validCompletionFuzzyMatching(v)
   return s:validBool(a:v)
 endfunction
 
+function! s:validStaticcheck(v)
+  return s:validBool(a:v)
+endfunction
+
 function! s:validExperimentalMouseTriggeredHoverPopupOptions(v)
   if has_key(a:v, "line")
     if type(a:v["line"]) != 0
@@ -89,6 +93,7 @@ let s:validators = {
       \ "CompletionDeepCompletions": function("s:validCompletionDeepCompletions"),
       \ "CompletionFuzzyMatching": function("s:validCompletionFuzzyMatching"),
       \ "QuickfixSigns": function("s:validQuickfixSigns"),
+      \ "Staticcheck": function("s:validStaticcheck"),
       \ "ExperimentalMouseTriggeredHoverPopupOptions": function("s:validExperimentalMouseTriggeredHoverPopupOptions"),
       \ "ExperimentalCursorTriggeredHoverPopupOptions": function("s:validExperimentalCursorTriggeredHoverPopupOptions"),
       \ }

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -57,6 +57,9 @@ type Config struct {
 	// Default: true
 	CompletionFuzzyMatching *bool `json:",omitempty"`
 
+	// Staticcheck enables staticcheck analyses in gopls
+	Staticcheck *bool `json:",omitempty"`
+
 	// ExperimentalMouseTriggeredHoverPopupOptions is a map of options to apply
 	// when creating hover-based popup windows triggered by the mouse hovering
 	// over an identifier. It corresponds to the second argument to popup_create

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -16,6 +16,7 @@ const (
 	goplsConfigHoverKind     = "hoverKind"
 	goplsDeepCompletion      = "deepCompletion"
 	goplsFuzzyMatching       = "fuzzyMatching"
+	goplsStaticcheck         = "staticcheck"
 )
 
 var _ protocol.Client = (*govimplugin)(nil)
@@ -96,6 +97,9 @@ func (g *govimplugin) Configuration(ctxt context.Context, params *protocol.Param
 	}
 	if g.vimstate.config.CompletionFuzzyMatching != nil {
 		conf[goplsFuzzyMatching] = *g.vimstate.config.CompletionFuzzyMatching
+	}
+	if g.vimstate.config.Staticcheck != nil {
+		conf[goplsStaticcheck] = *g.vimstate.config.Staticcheck
 	}
 	res[0] = conf
 

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -12,17 +12,19 @@ type VimConfig struct {
 	QuickfixSigns                                *int
 	CompletionDeepCompletions                    *int
 	CompletionFuzzyMatching                      *int
+	Staticcheck                                  *int
 	ExperimentalMouseTriggeredHoverPopupOptions  *map[string]interface{}
 	ExperimentalCursorTriggeredHoverPopupOptions *map[string]interface{}
 }
 
 func (c *VimConfig) ToConfig(d config.Config) config.Config {
 	v := config.Config{
-		FormatOnSave:                                 c.FormatOnSave,
-		QuickfixSigns:                                boolVal(c.QuickfixSigns, d.QuickfixSigns),
-		QuickfixAutoDiagnostics:                      boolVal(c.QuickfixAutoDiagnostics, d.QuickfixAutoDiagnostics),
-		CompletionDeepCompletions:                    boolVal(c.CompletionDeepCompletions, d.CompletionDeepCompletions),
-		CompletionFuzzyMatching:                      boolVal(c.CompletionFuzzyMatching, d.CompletionFuzzyMatching),
+		FormatOnSave:              c.FormatOnSave,
+		QuickfixSigns:             boolVal(c.QuickfixSigns, d.QuickfixSigns),
+		QuickfixAutoDiagnostics:   boolVal(c.QuickfixAutoDiagnostics, d.QuickfixAutoDiagnostics),
+		CompletionDeepCompletions: boolVal(c.CompletionDeepCompletions, d.CompletionDeepCompletions),
+		CompletionFuzzyMatching:   boolVal(c.CompletionFuzzyMatching, d.CompletionFuzzyMatching),
+		Staticcheck:               boolVal(c.Staticcheck, d.Staticcheck),
 		ExperimentalMouseTriggeredHoverPopupOptions:  copyMap(c.ExperimentalMouseTriggeredHoverPopupOptions, d.ExperimentalMouseTriggeredHoverPopupOptions),
 		ExperimentalCursorTriggeredHoverPopupOptions: copyMap(c.ExperimentalCursorTriggeredHoverPopupOptions, d.ExperimentalCursorTriggeredHoverPopupOptions),
 	}

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -179,6 +179,7 @@ func newplugin(goplspath string, defaults *config.Config) *govimplugin {
 			FormatOnSave:            vimconfig.FormatOnSaveVal(config.FormatOnSaveGoImports),
 			QuickfixAutoDiagnostics: vimconfig.BoolVal(true),
 			QuickfixSigns:           vimconfig.BoolVal(true),
+			Staticcheck:             vimconfig.BoolVal(false),
 		}
 	}
 	d := plugin.NewDriver(PluginPrefix)

--- a/cmd/govim/testdata/scenario_staticcheck/default_config.json
+++ b/cmd/govim/testdata/scenario_staticcheck/default_config.json
@@ -1,0 +1,3 @@
+{
+	"Staticcheck": true
+}

--- a/cmd/govim/testdata/scenario_staticcheck/staticcheck.txt
+++ b/cmd/govim/testdata/scenario_staticcheck/staticcheck.txt
@@ -1,0 +1,32 @@
+# Verify that staticcheck is enabled by default and works
+
+# Note: errors.golden effectively contains a duplicate diagnostic below. This is
+# being tracked in https://github.com/golang/go/issues/34494 but we "allow" it
+# for now in this test to give exposure to the staticcheck work
+
+vim ex 'e main.go'
+errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+vim ex 'copen'
+vim ex 'w errors'
+cmp errors errors.golden
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	var s string
+	s = fmt.Sprintf("%s", s)
+	fmt.Println(s)
+	fmt.Printf("%v")
+}
+-- errors.golden --
+main.go|7 col 6| the argument is already a string, there's no need to use fmt.Sprintf
+main.go|9 col 2| Printf format %v reads arg #1, but call has 0 args
+main.go|9 col 12| Printf format %v reads arg #1, but call has only 0 args


### PR DESCRIPTION
Disable staticcheck by default for now whilst we iron out inevitable
issues.

Add a test to verify it works.
