### PR TITLE
cmd/govim: tidy up Vim-side validation

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -42,18 +42,27 @@ function! s:validFormatOnSave(v)
   return [v:true, ""]
 endfunction
 
-function! s:validQuickfixAutoDiagnostics(v)
+function! s:validBool(v)
   if type(a:v) != 0  && type(a:v) != 6
     return [v:false, "must be of type number or bool"
   endif
   return [v:true, ""]
 endfunction
 
+function! s:validQuickfixAutoDiagnostics(v)
+  return s:validBool(a:v)
+endfunction
+
 function! s:validQuickfixSigns(v)
-  if type(a:v) != 0  && type(a:v) != 6
-    return [v:false, "must be of type number or bool"
-  endif
-  return [v:true, ""]
+  return s:validBool(a:v)
+endfunction
+
+function! s:validCompletionDeepCompletions(v)
+  return s:validBool(a:v)
+endfunction
+
+function! s:validCompletionFuzzyMatching(v)
+  return s:validBool(a:v)
 endfunction
 
 function! s:validExperimentalMouseTriggeredHoverPopupOptions(v)
@@ -72,20 +81,6 @@ endfunction
 
 function! s:validExperimentalCursorTriggeredHoverPopupOptions(v)
   return s:validExperimentalMouseTriggeredHoverPopupOptions(a:v)
-endfunction
-
-function! s:validCompletionDeepCompletions(v)
-  if type(a:v) != 0  && type(a:v) != 6
-    return [v:false, "must be of type number or bool"
-  endif
-  return [v:true, ""]
-endfunction
-
-function! s:validCompletionFuzzyMatching(v)
-  if type(a:v) != 0  && type(a:v) != 6
-    return [v:false, "must be of type number or bool"
-  endif
-  return [v:true, ""]
 endfunction
 
 let s:validators = {

--- a/cmd/govim/testdata/scenario_caseinsensitivecompletion/no_fuzzy_no_deep.txt
+++ b/cmd/govim/testdata/scenario_caseinsensitivecompletion/no_fuzzy_no_deep.txt
@@ -4,7 +4,7 @@ cp main.go.orig main.go
 vim ex 'e main.go'
 errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'call cursor(11,1)'
-vim ex 'call feedkeys(\"A\\<C-X>\\<C-O>\\<ESC>\", \"xt\")'
+vim ex 'execute \"normal A\\<C-X>\\<C-O>\"'
 vim ex 'w'
 cmp main.go main.go.orig
 # Disabled pending resolution to https://github.com/golang/go/issues/34103


### PR DESCRIPTION
Use helper functions where we can to reduce the boilerplate and
copy-paste in the autoloaded Vimscript used for validation on the Vim
side.