### PR TITLE
govim: handle shutdown within Schedule

### DIFF
--- a/govim.go
+++ b/govim.go
@@ -254,6 +254,11 @@ func (g *govimImpl) Enqueue(f func(Govim) error) chan struct{} {
 }
 
 func (g *govimImpl) Schedule(f func(Govim) error) (chan struct{}, error) {
+	defer func() {
+		if r := recover(); r != nil && r != ErrShuttingDown {
+			panic(r)
+		}
+	}()
 	g.scheduledCallsLock.Lock()
 	id := g.scheduleVimNextID
 	g.scheduleVimNextID++


### PR DESCRIPTION
This change should have been made as part of e805441 because in making
the changes to change the scheduling approach, we effectively dropped
the fact that a scheduled call is "guarded" by a recover from a govim
shutdown. Hence we re-add that in this change.