### PR TITLE
cmg/govim: add env var to pass flags to gopls

### DIFF
--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -17,6 +17,10 @@ const (
 	// we have no guarantees that the gopls version found in PATH works with
 	// govim.
 	EnvVarUseGoplsFromPath EnvVar = "GOVIM_USE_GOPLS_FROM_PATH"
+
+	// EnvVarGoplsDebug is an environment variable which, when set, will be
+	// used to pass the value as flags to gopls.
+	EnvVarGoplsFlags EnvVar = "GOVIM_GOPLS_FLAGS"
 )
 
 type Config struct {

--- a/cmd/govim/internal/util/util.go
+++ b/cmd/govim/internal/util/util.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Split breaks the line into words, evaluating quoted
+// strings and evaluating environment variables.
+// Implementation is a slightly modified version of go generate's
+// split(), from src/cmd/go/internal/generate/generate.go in stdlib
+func Split(line string) ([]string, error) {
+	// Parse line, obeying quoted strings.
+	var words []string
+	// There may still be a carriage return.
+	if len(line) > 0 && line[len(line)-1] == '\r' {
+		line = line[:len(line)-1]
+	}
+	// One (possibly quoted) word per iteration.
+Words:
+	for {
+		line = strings.TrimLeft(line, " \t")
+		if len(line) == 0 {
+			break
+		}
+		if line[0] == '"' {
+			for i := 1; i < len(line); i++ {
+				c := line[i] // Only looking for ASCII so this is OK.
+				switch c {
+				case '\\':
+					if i+1 == len(line) {
+						return words, fmt.Errorf("bad backslash")
+					}
+					i++ // Absorb next byte (If it's a multibyte we'll get an error in Unquote).
+				case '"':
+					word, err := strconv.Unquote(line[0 : i+1])
+					if err != nil {
+						return words, fmt.Errorf("bad quoted string")
+					}
+					words = append(words, word)
+					line = line[i+1:]
+					// Check the next character is space or end of line.
+					if len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
+						return words, fmt.Errorf("expect space after quoted argument")
+					}
+					continue Words
+				}
+			}
+			return words, fmt.Errorf("mismatched quoted string")
+		}
+		i := strings.IndexAny(line, " \t")
+		if i < 0 {
+			i = len(line)
+		}
+		words = append(words, line[0:i])
+		line = line[i:]
+	}
+
+	return words, nil
+}

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	"github.com/govim/govim/cmd/govim/internal/types"
+	"github.com/govim/govim/cmd/govim/internal/util"
 	"github.com/govim/govim/cmd/govim/internal/vimconfig"
 	"github.com/govim/govim/internal/plugin"
 	"github.com/govim/govim/testsetup"
@@ -246,7 +247,14 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 
 	g.ChannelExf("let s:gopls_logfile=%q", logfile.Name())
 
-	gopls := exec.Command(g.goplspath, "-rpc.trace", "-logfile", logfile.Name())
+	goplsArgs := []string{"-rpc.trace", "-logfile", logfile.Name()}
+	if flags, err := util.Split(os.Getenv(string(config.EnvVarGoplsFlags))); err != nil {
+		g.Logf("invalid env var %s: %v", config.EnvVarGoplsFlags, err)
+	} else {
+		goplsArgs = append(goplsArgs, flags...)
+	}
+
+	gopls := exec.Command(g.goplspath, goplsArgs...)
 	g.Logf("Running gopls: %v", strings.Join(gopls.Args, " "))
 	stderr, err := gopls.StderrPipe()
 	if err != nil {


### PR DESCRIPTION
This change adds a new environment variable, GOVIM_GOPLS_FLAGS, that is used to pass additional flags to gopls.