### PR TITLE
cmd/govim: add highlights for all LSP severities and use them for signs

### DIFF
--- a/cmd/govim/diagnostics.go
+++ b/cmd/govim/diagnostics.go
@@ -70,7 +70,7 @@ func (v *vimstate) redefineDiagnostics() error {
 				Range:    types.Range{Start: s, End: e},
 				Text:     d.Message,
 				Buf:      buf.Num,
-				Severity: int(d.Severity),
+				Severity: types.Severity(d.Severity),
 			})
 		}
 	}

--- a/cmd/govim/internal/types/types.go
+++ b/cmd/govim/internal/types/types.go
@@ -222,5 +222,23 @@ type Diagnostic struct {
 	Range    Range
 	Text     string
 	Buf      int
-	Severity int
+	Severity Severity
 }
+
+// Severity is the govim internal representation of the LSP DiagnosticSeverites
+type Severity int
+
+const (
+	SeverityErr  = Severity(protocol.SeverityError)
+	SeverityWarn = Severity(protocol.SeverityWarning)
+	SeverityInfo = Severity(protocol.SeverityInformation)
+	SeverityHint = Severity(protocol.SeverityHint)
+)
+
+// Highlight names as defined by ftplugin/go.vim.
+const (
+	HighlightErr  string = "govimErr"
+	HighlightWarn string = "govimWarn"
+	HighlightInfo string = "govimInfo"
+	HighlightHint string = "govimHint"
+)

--- a/cmd/govim/testdata/scenario_default/quickfix_config.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_config.txt
@@ -93,22 +93,22 @@ main.go|10 col 19| missing return
         "group": "govim",
         "id": 1,
         "lnum": 6,
-        "name": "govimerr",
-        "priority": 10
+        "name": "govimErrSign",
+        "priority": 14
       },
       {
         "group": "govim",
         "id": 2,
         "lnum": 9,
-        "name": "govimerr",
-        "priority": 10
+        "name": "govimErrSign",
+        "priority": 14
       },
       {
         "group": "govim",
         "id": 3,
         "lnum": 10,
-        "name": "govimerr",
-        "priority": 10
+        "name": "govimErrSign",
+        "priority": 14
       }
     ]
   }

--- a/cmd/govim/testdata/scenario_default/signs.txt
+++ b/cmd/govim/testdata/scenario_default/signs.txt
@@ -3,17 +3,20 @@
 #   main.go|6 col 39| undeclared name: v
 #   main.go|9 col 19| missing return
 #   main.go|10 col 19| missing return
+#
+# TODO: Add tests for diagnostics with info & hint severity. Currently there are no such diagnostics in gopls.
+# TODO: Add tests for two diagnostics with different severities on the same line. Currently not supported by gopls.
 
 vim ex 'e main.go'
 errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_placelist\"'
 
-# Assert that the error sign is defined
+# Assert that the different signs are defined
 vim -indent expr 'sign_getdefined()'
 ! stderr .+
 cmp stdout defined.golden
 
 
-# There must be only one sign per line
+# There must be only one sign per line (per prio)
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_openfile.golden
@@ -53,6 +56,16 @@ cmp stdout placed_nosign.golden
 # errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 
+# Two warnings on one line should place a single warning sign
+vim call append '[5, "\tvar x, y int\n\tx, y = x, y"]'
+errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_placelist\"'
+vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
+! stderr .+
+cmp stdout placed_twowarnings.golden
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+
 -- go.mod --
 module mod.com
 
@@ -71,9 +84,24 @@ func f2() string {}
 -- defined.golden --
 [
   {
-    "name": "govimerr",
+    "name": "govimErrSign",
     "text": "\u003e\u003e",
-    "texthl": "Error"
+    "texthl": "govimErr"
+  },
+  {
+    "name": "govimWarnSign",
+    "text": "\u003e\u003e",
+    "texthl": "govimWarn"
+  },
+  {
+    "name": "govimInfoSign",
+    "text": "\u003e\u003e",
+    "texthl": "govimInfo"
+  },
+  {
+    "name": "govimHintSign",
+    "text": "\u003e\u003e",
+    "texthl": "govimHint"
   }
 ]
 -- placed_openfile.golden --
@@ -85,22 +113,22 @@ func f2() string {}
         "group": "govim",
         "id": 1,
         "lnum": 6,
-        "name": "govimerr",
-        "priority": 10
+        "name": "govimErrSign",
+        "priority": 14
       },
       {
         "group": "govim",
         "id": 2,
         "lnum": 9,
-        "name": "govimerr",
-        "priority": 10
+        "name": "govimErrSign",
+        "priority": 14
       },
       {
         "group": "govim",
         "id": 3,
         "lnum": 10,
-        "name": "govimerr",
-        "priority": 10
+        "name": "govimErrSign",
+        "priority": 14
       }
     ]
   }
@@ -114,8 +142,8 @@ func f2() string {}
         "group": "govim",
         "id": 1,
         "lnum": 6,
-        "name": "govimerr",
-        "priority": 10
+        "name": "govimErrSign",
+        "priority": 14
       }
     ]
   }
@@ -125,5 +153,20 @@ func f2() string {}
   {
     "bufnr": 1,
     "signs": []
+  }
+]
+-- placed_twowarnings.golden --
+[
+  {
+    "bufnr": 1,
+    "signs": [
+      {
+        "group": "govim",
+        "id": 1,
+        "lnum": 7,
+        "name": "govimWarnSign",
+        "priority": 12
+      }
+    ]
   }
 ]

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -1,4 +1,10 @@
 if GOVIMPluginStatus() == "initcomplete"
+  " Highlights
+  highlight link govimErr Error
+  highlight govimWarn ctermfg=15 ctermbg=3 guisp=Orange guifg=Orange
+  highlight govimInfo ctermfg=15 ctermbg=6  guisp=Cyan guifg=Cyan
+  highlight link govimHint govimInfo
+
   " Hover
   setlocal balloonexpr=GOVIM_internal_BalloonExpr()
 


### PR DESCRIPTION
This change adds default highlights for the different LSP severities.
They can all be overridden in your .vimrc to match your theme. If you
for example would prefer blue background for errors in your color
terminal you'd add this line to your .vimrc:

hi govimErr ctermbg=Blue

The different highlight names are:
- govimErr
- govimWarn
- govimInfo
- govimHint

This is also a gardening change for diagnostics highlights that will
use the same defined highlights.