### PR TITLE
cmd/govim: keep track of if buffers are "Loaded" or not

### DIFF
--- a/cmd/govim/buffer_events.go
+++ b/cmd/govim/buffer_events.go
@@ -106,6 +106,15 @@ func (v *vimstate) bufChanged(args ...json.RawMessage) (interface{}, error) {
 	return nil, v.server.DidChange(context.Background(), params)
 }
 
+func (v *vimstate) bufUnload(args ...json.RawMessage) error {
+	bufnr := v.ParseInt(args[0])
+	if _, ok := v.buffers[bufnr]; !ok {
+		return nil
+	}
+	v.buffers[bufnr].Loaded = false
+	return nil
+}
+
 func (v *vimstate) handleBufferEvent(b *types.Buffer) error {
 	v.triggerBufferASTUpdate(b)
 	if b.Version == 0 {

--- a/cmd/govim/diagnostics.go
+++ b/cmd/govim/diagnostics.go
@@ -46,7 +46,7 @@ func (v *vimstate) redefineDiagnostics() error {
 				continue
 			}
 			// create a temp buffer
-			buf = types.NewBuffer(-1, fn, byts)
+			buf = types.NewBuffer(-1, fn, byts, false)
 		}
 		// make fn relative for reporting purposes
 		fn, err := filepath.Rel(cwd, fn)

--- a/cmd/govim/internal/types/types.go
+++ b/cmd/govim/internal/types/types.go
@@ -23,6 +23,9 @@ type Buffer struct {
 	Version  int
 	Listener int
 
+	// Loaded reflects vim's "loaded" buffer state. See :help bufloaded() for details.
+	Loaded bool
+
 	// AST is the parsed result of the Buffer. Buffer events (i.e. changes to
 	// the buffer contents) trigger an asynchronous re-parse of the buffer.
 	// These events are triggered from the *vimstate thread. Any subsequent
@@ -47,11 +50,12 @@ type Buffer struct {
 	cc *span.TokenConverter
 }
 
-func NewBuffer(num int, name string, contents []byte) *Buffer {
+func NewBuffer(num int, name string, contents []byte, loaded bool) *Buffer {
 	return &Buffer{
 		Num:      num,
 		Name:     name,
 		contents: contents,
+		Loaded:   loaded,
 	}
 }
 

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -208,6 +208,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.ChannelEx(`augroup govim`)
 	g.ChannelEx(`augroup END`)
 	g.DefineFunction(string(config.FunctionBalloonExpr), []string{}, g.vimstate.balloonExpr)
+	g.DefineAutoCommand("", govim.Events{govim.EventBufUnload}, govim.Patterns{"*.go"}, false, g.vimstate.bufUnload, "eval(expand('<abuf>'))")
 	g.DefineAutoCommand("", govim.Events{govim.EventBufRead, govim.EventBufNewFile}, govim.Patterns{"*.go"}, false, g.vimstate.bufReadPost, exprAutocmdCurrBufInfo)
 	g.DefineAutoCommand("", govim.Events{govim.EventBufWritePre}, govim.Patterns{"*.go"}, false, g.vimstate.formatCurrentBuffer, "eval(expand('<abuf>'))")
 	g.DefineFunction(string(config.FunctionComplete), []string{"findarg", "base"}, g.vimstate.complete)

--- a/cmd/govim/references.go
+++ b/cmd/govim/references.go
@@ -61,7 +61,7 @@ func (v *vimstate) references(flags govim.CommandFlags, args ...string) error {
 				continue
 			}
 			// create a temp buffer
-			buf = types.NewBuffer(-1, fn, byts)
+			buf = types.NewBuffer(-1, fn, byts, false)
 		}
 		// make fn relative for reporting purposes
 		fn, err := filepath.Rel(cwd, fn)

--- a/cmd/govim/util.go
+++ b/cmd/govim/util.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	exprAutocmdCurrBufInfo = `{"Num": eval(expand('<abuf>')), "Name": fnamemodify(bufname(eval(expand('<abuf>'))),':p'), "Contents": join(getbufline(eval(expand('<abuf>')), 0, "$"), "\n")."\n"}`
+	exprAutocmdCurrBufInfo = `{"Num": eval(expand('<abuf>')), "Name": fnamemodify(bufname(eval(expand('<abuf>'))),':p'), "Contents": join(getbufline(eval(expand('<abuf>')), 0, "$"), "\n")."\n", "Loaded": bufloaded(eval(expand('<abuf>')))}`
 )
 
 // currentBufferInfo is a helper function to unmarshal autocmd current
@@ -18,9 +18,10 @@ func (v *vimstate) currentBufferInfo(expr json.RawMessage) *types.Buffer {
 		Num      int
 		Name     string
 		Contents string
+		Loaded   int
 	}
 	v.Parse(expr, &buf)
-	return types.NewBuffer(buf.Num, buf.Name, []byte(buf.Contents))
+	return types.NewBuffer(buf.Num, buf.Name, []byte(buf.Contents), buf.Loaded == 1)
 }
 
 func (v *vimstate) cursorPos() (b *types.Buffer, p types.Point, err error) {


### PR DESCRIPTION
To be able to use textprops for highlighting, we must be aware of
if a buffer is loaded or not. Text properties can't be added to
unloaded buffers, and trying to do so will throw an "invalid line"
error.

This change keeps track of if buffers are loaded or not.