### PR TITLE
cmd/govim: text propoperty highlight diagnostics

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -64,6 +64,10 @@ function! s:validQuickfixSigns(v)
   return s:validBool(a:v)
 endfunction
 
+function! s:validHighlightDiagnostics(v)
+    return s:validBool(a:v)
+endfunction
+
 function! s:validCompletionDeepCompletions(v)
   return s:validBool(a:v)
 endfunction
@@ -116,6 +120,7 @@ let s:validators = {
       \ "CompletionDeepCompletions": function("s:validCompletionDeepCompletions"),
       \ "CompletionFuzzyMatching": function("s:validCompletionFuzzyMatching"),
       \ "QuickfixSigns": function("s:validQuickfixSigns"),
+      \ "HighlightDiagnostics": function("s:validHighlightDiagnostics"),
       \ "Staticcheck": function("s:validStaticcheck"),
       \ "CompletionCaseSensitive": function("s:validCompletionCaseSensitive"),
       \ "CompleteUnimported": function("s:validCompleteUnimported"),

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -50,6 +50,14 @@ type Config struct {
 	// Default: true
 	QuickfixSigns *bool `json:",omitempty"`
 
+	// HighlightDiagnostics enables in-code highlighting of diagnostics using
+	// text properties. Each diagnostic reported by gopls will be highlighted
+	// according to it's severity, using the following vim defined highlight
+	// groups: GOVIMErr, GOVIMWarn, GOVIMInfo & GOVIMHint.
+	//
+	// Default: true
+	HighlightDiagnostics *bool `json:",omitempty"`
+
 	// CompletionDeepCompletiions enables gopls' deep completion option
 	// in the derivation of completion candidates.
 	//
@@ -240,4 +248,30 @@ const (
 	// FormatOnSaveGoImports specifies that gopls should run a goimports-based
 	// formatting on a .go file before as it is saved.
 	FormatOnSaveGoImports FormatOnSave = "goimports"
+)
+
+// Highlight typed constants define the different highlight groups used by govim.
+// All highlights can be overridden in vimrc, e.g.:
+//
+// highlight GOVIMErr ctermfg=16 ctermbg=4
+type Highlight string
+
+const (
+	// HighlightErr is the group used to add text properties to errors
+	HighlightErr Highlight = "GOVIMErr"
+	// HighlightWarn is the group used to add text properties to warnings
+	HighlightWarn Highlight = "GOVIMWarn"
+	// HighlightInfo is the group used to add text properties to informations
+	HighlightInfo Highlight = "GOVIMInfo"
+	// HighlightHints is the group used to add text properties to hints
+	HighlightHint Highlight = "GOVIMHint"
+
+	// HighlightSignErr is the group used to add error signs in the gutter
+	HighlightSignErr Highlight = "GOVIMSignErr"
+	// HighlightSignWarn is the group used to add warning signs in the gutter
+	HighlightSignWarn Highlight = "GOVIMSignWarn"
+	// HighlightSignInfo is the group used to add info signs in the gutter
+	HighlightSignInfo Highlight = "GOVIMSignInfo"
+	// HighlightSignHint is the group used to add hint signs in the gutter
+	HighlightSignHint Highlight = "GOVIMSignHint"
 )

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -10,6 +10,9 @@ func (r *Config) Apply(v *Config) {
 	if v.QuickfixSigns != nil {
 		r.QuickfixSigns = v.QuickfixSigns
 	}
+	if v.HighlightDiagnostics != nil {
+		r.HighlightDiagnostics = v.HighlightDiagnostics
+	}
 	if v.CompletionDeepCompletions != nil {
 		r.CompletionDeepCompletions = v.CompletionDeepCompletions
 	}

--- a/cmd/govim/diagnostics.go
+++ b/cmd/govim/diagnostics.go
@@ -93,5 +93,9 @@ func (v *vimstate) handleDiagnosticsChanged() error {
 	if err := v.updateSigns(diags, false); err != nil {
 		v.Logf("redefineDiagnostics: failed to place/remove signs: %v", err)
 	}
+
+	if err := v.redefineHighlights(diags); err != nil {
+		v.Logf("redefineDiagnostics: failed to apply highlights: %v", err)
+	}
 	return nil
 }

--- a/cmd/govim/highlight.go
+++ b/cmd/govim/highlight.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/govim/govim/cmd/govim/internal/types"
+)
+
+type propDict struct {
+	Highlight string `json:"highlight"`
+	Combine   bool   `json:"combine,omitempty"`
+	Priority  int    `json:"priority,omitempty"`
+	StartIncl bool   `json:"start_incl,omitempty"`
+	EndIncl   bool   `json:"end_incl,omitempty"`
+}
+
+func (v *vimstate) textpropDefine() error {
+	v.BatchStart()
+	for _, s := range []types.Severity{types.SeverityErr, types.SeverityWarn, types.SeverityInfo, types.SeverityHint} {
+		hi := types.SeverityHighlight[s]
+
+		// Note that we reuse the highlight name as text property name, even if they aren't the same thing.
+		v.BatchChannelCall("prop_type_add", hi, propDict{
+			Highlight: string(hi),
+			Combine:   true, // Combine with syntax highlight
+			Priority:  types.SeverityPriority[s],
+		})
+	}
+	res := v.BatchEnd()
+	for i := range res {
+		if v.ParseInt(res[i]) != 0 {
+			return fmt.Errorf("call to prop_type_add() failed")
+		}
+	}
+	return nil
+}
+
+func (v *vimstate) redefineHighlights(diags []types.Diagnostic) error {
+	if v.config.HighlightDiagnostics == nil || !*v.config.HighlightDiagnostics {
+		return nil
+	}
+
+	v.BatchStart()
+	defer v.BatchCancelIfNotEnded()
+	for bufnr, buf := range v.buffers {
+		if !buf.Loaded {
+			continue // vim removes properties when a buffer is unloaded
+		}
+		v.BatchChannelCall("prop_remove", struct {
+			ID    int `json:"id"`
+			BufNr int `json:"bufnr"`
+			All   int `json:"all"`
+		}{0, bufnr, 1})
+	}
+
+	for _, d := range diags {
+		// Do not add textprops to unknown buffers
+		if d.Buf < 0 {
+			continue
+		}
+
+		// prop_add() can only be called for Loaded buffers, otherwise
+		// it will throw an "unknown line" error.
+		if buf, ok := v.buffers[d.Buf]; ok && !buf.Loaded {
+			continue
+		}
+
+		hi, ok := types.SeverityHighlight[d.Severity]
+		if !ok {
+			return fmt.Errorf("failed to find highlight for severity %v", d.Severity)
+		}
+
+		v.BatchChannelCall("prop_add",
+			d.Range.Start.Line(),
+			d.Range.Start.Col(),
+			struct {
+				Type    string `json:"type"`
+				EndLine int    `json:"end_lnum"`
+				EndCol  int    `json:"end_col"` // column just after the text
+				BufNr   int    `json:"bufnr"`
+			}{string(hi), d.Range.End.Line(), d.Range.End.Col(), d.Buf})
+	}
+
+	v.BatchEnd()
+	return nil
+}

--- a/cmd/govim/internal/types/types.go
+++ b/cmd/govim/internal/types/types.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"math"
 
+	"github.com/govim/govim/cmd/govim/config"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 )
@@ -258,10 +259,19 @@ const (
 	SeverityHint = Severity(protocol.SeverityHint)
 )
 
-// Highlight names as defined by ftplugin/go.vim.
-const (
-	HighlightErr  string = "govimErr"
-	HighlightWarn string = "govimWarn"
-	HighlightInfo string = "govimInfo"
-	HighlightHint string = "govimHint"
-)
+// SeverityPriority is used when placing signs and text property highlights.
+// Values are based on the default value for signs, 10.
+var SeverityPriority = map[Severity]int{
+	SeverityErr:  14,
+	SeverityWarn: 12,
+	SeverityInfo: 10,
+	SeverityHint: 8,
+}
+
+// Highlight returns corresponding highlight name for a severity.
+var SeverityHighlight = map[Severity]config.Highlight{
+	SeverityErr:  config.HighlightErr,
+	SeverityWarn: config.HighlightWarn,
+	SeverityInfo: config.HighlightInfo,
+	SeverityHint: config.HighlightHint,
+}

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -10,6 +10,7 @@ type VimConfig struct {
 	FormatOnSave                                 *config.FormatOnSave
 	QuickfixAutoDiagnostics                      *int
 	QuickfixSigns                                *int
+	HighlightDiagnostics                         *int
 	CompletionDeepCompletions                    *int
 	CompletionFuzzyMatching                      *int
 	Staticcheck                                  *int
@@ -26,6 +27,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		FormatOnSave:                                 c.FormatOnSave,
 		QuickfixSigns:                                boolVal(c.QuickfixSigns, d.QuickfixSigns),
 		QuickfixAutoDiagnostics:                      boolVal(c.QuickfixAutoDiagnostics, d.QuickfixAutoDiagnostics),
+		HighlightDiagnostics:                         boolVal(c.HighlightDiagnostics, d.HighlightDiagnostics),
 		CompletionDeepCompletions:                    boolVal(c.CompletionDeepCompletions, d.CompletionDeepCompletions),
 		CompletionFuzzyMatching:                      boolVal(c.CompletionFuzzyMatching, d.CompletionFuzzyMatching),
 		Staticcheck:                                  boolVal(c.Staticcheck, d.Staticcheck),

--- a/cmd/govim/signs.go
+++ b/cmd/govim/signs.go
@@ -3,32 +3,20 @@ package main
 import (
 	"fmt"
 
+	"github.com/govim/govim/cmd/govim/config"
 	"github.com/govim/govim/cmd/govim/internal/types"
 )
 
 // Using a sign group creates a separate namespace for all signs placed by govim
 const signGroup = "govim"
 
-// signSuffix is used when naming the different sign types. It is appended to each
-// highlight type and passed in as name to sign_define().
-const signSuffix = "Sign"
-
-// Each sign in vim has a priority. If there are multiple signs on the same line, it
-// is the one with highest priority that shows. For details see ":help sign-priority".
-// The default priority in vim, if not specified, is 10.
-var signPriority = map[types.Severity]int{
-	types.SeverityErr:  14,
-	types.SeverityWarn: 12,
-	types.SeverityInfo: 10,
-	types.SeverityHint: 8,
-}
-
 // signName is used to map a priority to the defined sign type (i.e. "sign name")
-var signName = map[int]string{
-	signPriority[types.SeverityErr]:  types.HighlightErr + signSuffix,
-	signPriority[types.SeverityWarn]: types.HighlightWarn + signSuffix,
-	signPriority[types.SeverityInfo]: types.HighlightInfo + signSuffix,
-	signPriority[types.SeverityHint]: types.HighlightHint + signSuffix,
+// Note that we reuse the highlight name as sign name even if they are not the same thing.
+var signName = map[int]config.Highlight{
+	types.SeverityPriority[types.SeverityErr]:  config.HighlightSignErr,
+	types.SeverityPriority[types.SeverityWarn]: config.HighlightSignWarn,
+	types.SeverityPriority[types.SeverityInfo]: config.HighlightSignInfo,
+	types.SeverityPriority[types.SeverityHint]: config.HighlightSignHint,
 }
 
 // defineDict is the representation of arguments used in vim's sign_define()
@@ -39,13 +27,13 @@ type defineDict struct {
 
 // signDefine defines the sign types (sign names) and must be called once before placing any signs
 func (v *vimstate) signDefine() error {
-	for _, hi := range []string{types.HighlightErr, types.HighlightWarn, types.HighlightInfo, types.HighlightHint} {
+	for _, hi := range []config.Highlight{config.HighlightSignErr, config.HighlightSignWarn, config.HighlightSignInfo, config.HighlightSignHint} {
 		arg := defineDict{
 			Text:          ">>",
-			TextHighlight: hi,
+			TextHighlight: string(hi),
 		}
 
-		if v.ParseInt(v.ChannelCall("sign_define", hi+signSuffix, arg)) != 0 {
+		if v.ParseInt(v.ChannelCall("sign_define", hi, arg)) != 0 {
 			return fmt.Errorf("sign_define failed")
 		}
 	}
@@ -110,7 +98,7 @@ func (v *vimstate) updateSigns(fixes []types.Diagnostic, force bool) error {
 			// i.e. there is no buffer. Do no try and place a sign
 			continue
 		}
-		priority, ok := signPriority[f.Severity]
+		priority, ok := types.SeverityPriority[f.Severity]
 		if !ok {
 			return fmt.Errorf("no sign priority defined for severity: %v", f.Severity)
 		}
@@ -123,7 +111,7 @@ func (v *vimstate) updateSigns(fixes []types.Diagnostic, force bool) error {
 			Group:    signGroup,
 			Lnum:     f.Range.Start.Line(),
 			Priority: priority,
-			Name:     name})
+			Name:     string(name)})
 	}
 	if len(placeList) > 0 {
 		v.BatchChannelCall("sign_placelist", placeList)

--- a/cmd/govim/testdata/scenario_default/diagnostic_highlights.txt
+++ b/cmd/govim/testdata/scenario_default/diagnostic_highlights.txt
@@ -1,0 +1,199 @@
+# Tests text property highlights of diagnostics. The test contains two files, main.go with errors and other.go with a warning.
+#
+# Since vim removes text properties when a buffer is unloaded, we also test that text properties are added back when the buffer
+# is loaded again.
+#
+# TODO: Add tests of hint & info severity when gopls reports diagnostics with other severities than error and warning.
+# TODO: Rewrite property listing when vim implements prop_find().
+
+# Errors are placed with ranges matching the diagnostic
+vim ex 'e main.go'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","prop_remove",\{"id":0,"bufnr":\d,"all":1\}\],\["call","s:mustNothing","prop_add"'
+# prop_find() isn't implemented in vim (as of 8.1.2389) so call prop_list on each line.
+vim -indent expr 'map(range(1,line(\"$\")), \"prop_list(v:val)\")'
+cmp stdout main_go_errors.golden
+
+
+# Removing the two empty funcs, should remove those errors.
+vim ex 'call cursor(9,1)'
+vim ex 'normal 2dd'
+vim ex 'call feedkeys(\"\\<CursorHold>\", \"xt\")'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","prop_remove",\{"id":0,"bufnr":\d,"all":1\}\],\["call","s:mustNothing","prop_add"'
+vim -indent expr 'map(range(1,line(\"$\")), \"prop_list(v:val)\")'
+cmp stdout main_go_errors2.golden
+
+
+# Adding declaration of i and v should remove the last errors and instead add warnings for main.go (since other.go isn't loaded)
+vim call append '[5, "\tvar i, v string"]'
+vim ex 'w'
+errlogmatch -count 2 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","prop_remove",\{"id":0,"bufnr":\d,"all":1\}\],\["call","s:mustNothing","prop_add"'
+vim -indent expr 'map(range(1,line(\"$\")), \"prop_list(v:val)\")'
+cmp stdout main_go_warning.golden
+
+
+# Switching to a new buffer (other.go) should add warnings in that buffer
+vim ex 'split other.go'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","prop_remove",\{"id":0,"bufnr":\d,"all":1\}\],\["call","s:mustNothing","prop_remove",\{"id":0,"bufnr":\d,"all":1\}\],\["call","s:mustNothing","prop_add"'
+vim -indent expr 'map(range(1,line(\"$\")), \"prop_list(v:val)\")'
+cmp stdout other_go_warning.golden
+
+
+# Closing the split shouldn't remove warnings in main.go
+vim ex 'bwipe'
+vim -indent expr 'map(range(1,line(\"$\")), \"prop_list(v:val)\")'
+cmp stdout main_go_warning.golden
+
+
+# Open without split should also add warnings in the new buffer
+vim ex 'e other.go'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","prop_remove",\{"id":0,"bufnr":\d,"all":1\}\],\["call","s:mustNothing","prop_add"'
+vim -indent expr 'map(range(1,line(\"$\")), \"prop_list(v:val)\")'
+cmp stdout other_go_warning.golden
+
+
+# Closing the other.go buffer shouldn't remove warnings in main.go
+vim ex 'bwipe'
+vim -indent expr 'map(range(1,line(\"$\")), \"prop_list(v:val)\")'
+cmp stdout main_go_warning.golden
+
+
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("This is a test %v\n", i, v)
+}
+
+func f1() string {}
+func f2() string {}
+-- other.go --
+package main
+
+import "fmt"
+
+func foo() {
+    fmt.Println("%v")
+}
+-- main_go_errors.golden --
+[
+  [],
+  [],
+  [],
+  [],
+  [],
+  [
+    {
+      "col": 36,
+      "end": 1,
+      "id": 0,
+      "length": 1,
+      "start": 1,
+      "type": "GOVIMErr"
+    },
+    {
+      "col": 39,
+      "end": 1,
+      "id": 0,
+      "length": 1,
+      "start": 1,
+      "type": "GOVIMErr"
+    }
+  ],
+  [],
+  [],
+  [
+    {
+      "col": 19,
+      "end": 1,
+      "id": 0,
+      "length": 1,
+      "start": 1,
+      "type": "GOVIMErr"
+    }
+  ],
+  [
+    {
+      "col": 19,
+      "end": 1,
+      "id": 0,
+      "length": 1,
+      "start": 1,
+      "type": "GOVIMErr"
+    }
+  ]
+]
+-- main_go_errors2.golden --
+[
+  [],
+  [],
+  [],
+  [],
+  [],
+  [
+    {
+      "col": 36,
+      "end": 1,
+      "id": 0,
+      "length": 1,
+      "start": 1,
+      "type": "GOVIMErr"
+    },
+    {
+      "col": 39,
+      "end": 1,
+      "id": 0,
+      "length": 1,
+      "start": 1,
+      "type": "GOVIMErr"
+    }
+  ],
+  [],
+  []
+]
+-- main_go_warning.golden --
+[
+  [],
+  [],
+  [],
+  [],
+  [],
+  [],
+  [
+    {
+      "col": 2,
+      "end": 1,
+      "id": 0,
+      "length": 39,
+      "start": 1,
+      "type": "GOVIMWarn"
+    }
+  ],
+  []
+]
+-- other_go_warning.golden --
+[
+  [],
+  [],
+  [],
+  [],
+  [],
+  [
+    {
+      "col": 5,
+      "end": 1,
+      "id": 0,
+      "length": 17,
+      "start": 1,
+      "type": "GOVIMWarn"
+    }
+  ],
+  []
+]

--- a/cmd/govim/testdata/scenario_default/quickfix_config.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_config.txt
@@ -86,28 +86,28 @@ main.go|10 col 19| missing return
         "group": "govim",
         "id": 2,
         "lnum": 6,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 1,
         "lnum": 6,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 3,
         "lnum": 9,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 4,
         "lnum": 10,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       }
     ]

--- a/cmd/govim/testdata/scenario_default/signs.txt
+++ b/cmd/govim/testdata/scenario_default/signs.txt
@@ -83,24 +83,24 @@ func f2() string {}
 -- defined.golden --
 [
   {
-    "name": "govimErrSign",
+    "name": "GOVIMSignErr",
     "text": "\u003e\u003e",
-    "texthl": "govimErr"
+    "texthl": "GOVIMSignErr"
   },
   {
-    "name": "govimWarnSign",
+    "name": "GOVIMSignWarn",
     "text": "\u003e\u003e",
-    "texthl": "govimWarn"
+    "texthl": "GOVIMSignWarn"
   },
   {
-    "name": "govimInfoSign",
+    "name": "GOVIMSignInfo",
     "text": "\u003e\u003e",
-    "texthl": "govimInfo"
+    "texthl": "GOVIMSignInfo"
   },
   {
-    "name": "govimHintSign",
+    "name": "GOVIMSignHint",
     "text": "\u003e\u003e",
-    "texthl": "govimHint"
+    "texthl": "GOVIMSignHint"
   }
 ]
 -- placed_openfile1.golden --
@@ -112,28 +112,28 @@ func f2() string {}
         "group": "govim",
         "id": 2,
         "lnum": 6,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 1,
         "lnum": 6,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 3,
         "lnum": 9,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 4,
         "lnum": 10,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       }
     ]
@@ -148,21 +148,21 @@ func f2() string {}
         "group": "govim",
         "id": 1,
         "lnum": 6,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 2,
         "lnum": 9,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 3,
         "lnum": 10,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       }
     ]
@@ -177,7 +177,7 @@ func f2() string {}
         "group": "govim",
         "id": 1,
         "lnum": 6,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       }
     ]
@@ -199,14 +199,14 @@ func f2() string {}
         "group": "govim",
         "id": 2,
         "lnum": 7,
-        "name": "govimWarnSign",
+        "name": "GOVIMSignWarn",
         "priority": 12
       },
       {
         "group": "govim",
         "id": 1,
         "lnum": 7,
-        "name": "govimWarnSign",
+        "name": "GOVIMSignWarn",
         "priority": 12
       }
     ]

--- a/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
+++ b/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
@@ -39,7 +39,7 @@ func foo() {
         "group": "govim",
         "id": 1,
         "lnum": 6,
-        "name": "govimWarnSign",
+        "name": "GOVIMSignWarn",
         "priority": 12
       }
     ]

--- a/cmd/govim/testdata/scenario_no_quickfixautodiagnostics/signs.txt
+++ b/cmd/govim/testdata/scenario_no_quickfixautodiagnostics/signs.txt
@@ -30,28 +30,28 @@ func f2() string {}
         "group": "govim",
         "id": 2,
         "lnum": 6,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 1,
         "lnum": 6,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 3,
         "lnum": 9,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       },
       {
         "group": "govim",
         "id": 4,
         "lnum": 10,
-        "name": "govimErrSign",
+        "name": "GOVIMSignErr",
         "priority": 14
       }
     ]

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -110,6 +110,17 @@ func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {
 		}
 	}
 
+	if !vimconfig.EqualBool(v.config.HighlightDiagnostics, preConfig.HighlightDiagnostics) {
+		if v.config.HighlightDiagnostics == nil || !*v.config.HighlightDiagnostics {
+			// HighlightDiagnostics is now not on - remove existing text properties
+			v.redefineHighlights([]types.Diagnostic{})
+		} else {
+			if err := v.redefineHighlights(v.diagnostics()); err != nil {
+				return nil, fmt.Errorf("failed to update diagnostic highlights: %v", err)
+			}
+		}
+	}
+
 	// v.server will be nil when we are Init()-ing govim. The init process
 	// triggers a "manual" call of govim#config#Set() and hence this function
 	// gets called before we have even started gopls.

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -1,10 +1,4 @@
 if GOVIMPluginStatus() == "initcomplete"
-  " Highlights
-  highlight link govimErr Error
-  highlight govimWarn ctermfg=15 ctermbg=3 guisp=Orange guifg=Orange
-  highlight govimInfo ctermfg=15 ctermbg=6  guisp=Cyan guifg=Cyan
-  highlight link govimHint govimInfo
-
   " Hover
   setlocal balloonexpr=GOVIM_internal_BalloonExpr()
 


### PR DESCRIPTION
Diagnostics from gopls will now be highlighted directly in the code. There are four different highlights that can be overridden in vim to use different styles/colors for each of the LSP severities Error, Warning, Info and Hint.

Note that this change also renames sign highlights, which is a breaking change for anyone that use custom colors for their signs.

[![asciicast](https://asciinema.org/a/33WJNxjZs1vdZQYWv4DwVy6qr.svg)](https://asciinema.org/a/33WJNxjZs1vdZQYWv4DwVy6qr)

