### PR TITLE
cmd/govim: refactor diagnostics handling to use lazy conversion

### DIFF
--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -126,11 +126,11 @@ func (g *govimplugin) Event(context.Context, *interface{}) error {
 func (g *govimplugin) PublishDiagnostics(ctxt context.Context, params *protocol.PublishDiagnosticsParams) error {
 	defer absorbShutdownErr()
 	g.logGoplsClientf("PublishDiagnostics callback: %v", pretty.Sprint(params))
-	g.diagnosticsLock.Lock()
+	g.rawDiagnosticsLock.Lock()
 	uri := span.URI(params.URI)
-	curr, ok := g.diagnostics[uri]
-	g.diagnostics[uri] = params
-	g.diagnosticsLock.Unlock()
+	curr, ok := g.rawDiagnostics[uri]
+	g.rawDiagnostics[uri] = params
+	g.rawDiagnosticsLock.Unlock()
 	if !ok {
 		if len(params.Diagnostics) == 0 {
 			return nil

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -167,9 +167,13 @@ type govimplugin struct {
 
 	modWatcher *modWatcher
 
-	// diagnostics gives us the current diagnostics by URI
-	diagnostics     map[span.URI]*protocol.PublishDiagnosticsParams
-	diagnosticsLock sync.Mutex
+	// rawDiagnostics holds the current raw (LSP) diagnostics by URI
+	rawDiagnostics     map[span.URI]*protocol.PublishDiagnosticsParams
+	rawDiagnosticsLock sync.Mutex
+
+	// diagnosticsCache isn't inteded to be used directly since it might
+	// contain old data. Call diagnostics() to get the latest instead.
+	diagnosticsCache []types.Diagnostic
 
 	bufferUpdates chan *bufferUpdate
 }
@@ -185,9 +189,9 @@ func newplugin(goplspath string, defaults *config.Config) *govimplugin {
 	}
 	d := plugin.NewDriver(PluginPrefix)
 	res := &govimplugin{
-		diagnostics: make(map[span.URI]*protocol.PublishDiagnosticsParams),
-		goplspath:   goplspath,
-		Driver:      d,
+		rawDiagnostics: make(map[span.URI]*protocol.PublishDiagnosticsParams),
+		goplspath:      goplspath,
+		Driver:         d,
 		vimstate: &vimstate{
 			Driver:                d,
 			buffers:               make(map[int]*types.Buffer),

--- a/cmd/govim/suggested_fixes.go
+++ b/cmd/govim/suggested_fixes.go
@@ -67,8 +67,8 @@ func (v *vimstate) suggestFixes(flags govim.CommandFlags, args ...string) error 
 	textDoc := cb.ToTextDocumentIdentifier()
 
 	var coveredDiags []protocol.Diagnostic
-	v.diagnosticsLock.Lock()
-	if diags, ok := v.diagnostics[cb.URI()]; ok {
+	v.rawDiagnosticsLock.Lock()
+	if diags, ok := v.rawDiagnostics[cb.URI()]; ok {
 		for _, d := range diags.Diagnostics {
 			// TODO: should we go for "current line" as default?
 			if int(pos.ToPosition().Line) >= int(d.Range.Start.Line) &&
@@ -77,7 +77,7 @@ func (v *vimstate) suggestFixes(flags govim.CommandFlags, args ...string) error 
 			}
 		}
 	}
-	v.diagnosticsLock.Unlock()
+	v.rawDiagnosticsLock.Unlock()
 
 	params := &protocol.CodeActionParams{
 		TextDocument: textDoc,

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -83,9 +83,9 @@ func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {
 				v.ChannelCall("setqflist", v.lastQuickFixDiagnostics, "r")
 			}
 		} else {
-			v.diagnosticsLock.Lock()
+			v.rawDiagnosticsLock.Lock()
 			v.diagnosticsChanged = true
-			v.diagnosticsLock.Unlock()
+			v.rawDiagnosticsLock.Unlock()
 			return nil, v.redefineDiagnostics()
 		}
 	}


### PR DESCRIPTION
This change will use lazy conversion of incoming LSP diagnostics.

We use incoming diagnostics for both quickfix and sign placement,
and will also use them for highlighting. Vim handles each of them
differently when it comes to removing entities so we need a way
to get the latest diagnostics that doesn't perform conversion each
call.