### PR TITLE
cmd/govim: place signs for existing diagnostics in new buffers

### DIFF
--- a/cmd/govim/diagnostics.go
+++ b/cmd/govim/diagnostics.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io/ioutil"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -28,9 +27,6 @@ func (v *vimstate) diagnostics() []types.Diagnostic {
 	v.diagnosticsChanged = false
 	v.rawDiagnosticsLock.Unlock()
 
-	// TODO: this will become fragile at some point
-	cwd := v.ParseString(v.ChannelCall("getcwd"))
-
 	// must be non-nil
 	diags := []types.Diagnostic{}
 
@@ -50,12 +46,6 @@ func (v *vimstate) diagnostics() []types.Diagnostic {
 			}
 			// create a temp buffer
 			buf = types.NewBuffer(-1, fn, byts, false)
-		}
-		// make fn relative for reporting purposes
-		fn, err := filepath.Rel(cwd, fn)
-		if err != nil {
-			v.Logf("redefineDiagnostics: failed to call filepath.Rel(%q, %q): %v", cwd, fn, err)
-			continue
 		}
 		for _, d := range lspDiags {
 			s, err := types.PointFromPosition(buf, d.Range.Start)

--- a/cmd/govim/quickfix.go
+++ b/cmd/govim/quickfix.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"path/filepath"
+
 	"github.com/govim/govim"
 	"github.com/govim/govim/cmd/govim/internal/types"
 )
@@ -24,8 +26,15 @@ func (v *vimstate) updateQuickfix(diags []types.Diagnostic) error {
 	fixes := []quickfixEntry{}
 
 	for _, d := range diags {
+		// make fn relative for reporting purposes
+		fn, err := filepath.Rel(v.workingDirectory, d.Filename)
+		if err != nil {
+			v.Logf("redefineDiagnostics: failed to call filepath.Rel(%q, %q): %v", v.workingDirectory, fn, err)
+			continue
+		}
+
 		fixes = append(fixes, quickfixEntry{
-			Filename: d.Filename,
+			Filename: fn,
 			Lnum:     d.Range.Start.Line(),
 			Col:      d.Range.Start.Col(),
 			Text:     d.Text,

--- a/cmd/govim/references.go
+++ b/cmd/govim/references.go
@@ -32,9 +32,6 @@ func (v *vimstate) references(flags govim.CommandFlags, args ...string) error {
 		},
 	}
 
-	// TODO this will become fragile at some point
-	cwd := v.ParseString(v.ChannelCall("getcwd"))
-
 	// must be non-nil
 	locs := []quickfixEntry{}
 
@@ -64,9 +61,9 @@ func (v *vimstate) references(flags govim.CommandFlags, args ...string) error {
 			buf = types.NewBuffer(-1, fn, byts, false)
 		}
 		// make fn relative for reporting purposes
-		fn, err := filepath.Rel(cwd, fn)
+		fn, err := filepath.Rel(v.workingDirectory, fn)
 		if err != nil {
-			v.Logf("references: failed to call filepath.Rel(%q, %q): %v", cwd, fn, err)
+			v.Logf("references: failed to call filepath.Rel(%q, %q): %v", v.workingDirectory, fn, err)
 			continue
 		}
 		p, err := types.PointFromPosition(buf, ref.Range.Start)

--- a/cmd/govim/testdata/scenario_default/signs.txt
+++ b/cmd/govim/testdata/scenario_default/signs.txt
@@ -65,7 +65,6 @@ cmp stdout placed_twowarnings.golden
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
 # errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
-
 -- go.mod --
 module mod.com
 

--- a/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
+++ b/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
@@ -1,0 +1,45 @@
+# Test that signs are placed when opening a file that already has diagnostics.
+vim ex 'e main.go'
+errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_placelist\"'
+vim ex 'e other.go'
+errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_placelist\"'
+vim -indent expr 'sign_getplaced(\"other.go\", {\"group\": \"*\"})'
+! stderr .+
+cmp stdout placed.golden
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+-- main.go --
+package main
+
+func main() {
+    var z int
+    z = z
+}
+-- other.go --
+package main
+
+import "fmt"
+
+func foo() {
+    fmt.Printf("%v")
+}
+
+-- placed.golden --
+[
+  {
+    "bufnr": 2,
+    "signs": [
+      {
+        "group": "govim",
+        "id": 1,
+        "lnum": 6,
+        "name": "govimWarnSign",
+        "priority": 12
+      }
+    ]
+  }
+]

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -68,6 +68,10 @@ type vimstate struct {
 	// currently defined popups (both hidden and visible) and have a lifespan of single
 	// codeAction call.
 	suggestedFixesPopups map[int][]*protocol.WorkspaceEdit
+
+	// working directory (when govim was started)
+	// TODO: handle changes to current working directory during runtime
+	workingDirectory string
 }
 
 func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {


### PR DESCRIPTION
If gopls report diagnostics for files that aren't opened in vim
they won't get any signs placed when they are opened.

A typical use case is when staticcheck report diagnostics for
a file that isn't opened, and the user uses quickfix to jump
directly to the issue (effectively opening a new buffer).

This change updates the internal diagnostics cache when a buffer
is read or closed so existing diagnostics will have signs placed.