### PR TITLE
tests: define a default value for errlogmatch -wait flag

### DIFF
--- a/cmd/govim/testdata/scenario_caseinsensitivecompletion/complete.txt
+++ b/cmd/govim/testdata/scenario_caseinsensitivecompletion/complete.txt
@@ -2,7 +2,7 @@
 # already has the relevant import required for the completion.
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 
 # lower completed from lo
 vim ex 'call cursor(7,1)'

--- a/cmd/govim/testdata/scenario_caseinsensitivecompletion/no_fuzzy_no_deep.txt
+++ b/cmd/govim/testdata/scenario_caseinsensitivecompletion/no_fuzzy_no_deep.txt
@@ -2,7 +2,7 @@
 
 cp main.go.orig main.go
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'call cursor(11,1)'
 vim ex 'execute \"normal A\\<C-X>\\<C-O>\"'
 vim ex 'w'

--- a/cmd/govim/testdata/scenario_casesensitivecompletion/complete.txt
+++ b/cmd/govim/testdata/scenario_casesensitivecompletion/complete.txt
@@ -2,7 +2,7 @@
 # already has the relevant import required for the completion.
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 
 # lower from lo
 vim ex 'call cursor(7,1)'

--- a/cmd/govim/testdata/scenario_completeunimported/complete.txt
+++ b/cmd/govim/testdata/scenario_completeunimported/complete.txt
@@ -1,7 +1,7 @@
 # Test that completing of unimported std library packages works.
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 
 # lower from lo
 vim ex 'call cursor(4,1)'

--- a/cmd/govim/testdata/scenario_default/complete.txt
+++ b/cmd/govim/testdata/scenario_default/complete.txt
@@ -2,7 +2,7 @@
 # already has the relevant import required for the completion.
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'call cursor(11,17)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<ESC>\", \"xt\")'
 vim ex 'w'

--- a/cmd/govim/testdata/scenario_default/complete_deep_fuzzy.txt
+++ b/cmd/govim/testdata/scenario_default/complete_deep_fuzzy.txt
@@ -1,7 +1,7 @@
 # Test that deep fuzzy complete works by default.
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'call cursor(11,1)'
 vim ex 'call feedkeys(\"A\\<C-X>\\<C-O>\\<ESC>\", \"xt\")'
 vim ex 'w'

--- a/cmd/govim/testdata/scenario_default/complete_watched.txt
+++ b/cmd/govim/testdata/scenario_default/complete_watched.txt
@@ -5,9 +5,9 @@
 # handled.
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 cp const.go.orig const.go
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/const.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/const.go
 vim ex 'call cursor(6,16)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<C-N>\\<ESC>\", \"x\")'
 vim ex 'w'

--- a/cmd/govim/testdata/scenario_default/go_to_def_usetab.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_usetab.txt
@@ -10,7 +10,7 @@ vim ex 'e '$WORK/q/q.go
 vim expr '[winnr(), tabpagenr()]'
 stdout '^\Q[1,1]\E$'
 vim ex 'tabnew '$WORK/p.go
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/p.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/p.go
 vim expr '[winnr(), tabpagenr()]'
 stdout '^\Q[1,2]\E$'
 vim ex 'call cursor(5,17)'

--- a/cmd/govim/testdata/scenario_default/gofmt.txt
+++ b/cmd/govim/testdata/scenario_default/gofmt.txt
@@ -7,9 +7,9 @@
 
 # :GOVIMGoFmt whole file
 vim ex 'e! file.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 vim ex 'GOVIMGoFmt'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 vim ex 'noautocmd w'
 cmp file.go file.go.gofmt
 
@@ -17,9 +17,9 @@ cmp file.go file.go.gofmt
 cp file.go.orig file.go
 vim call 'govim#config#Set' '["FormatOnSave", "gofmt"]'
 vim ex 'e! file.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 vim ex 'w'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 cmp file.go file.go.gofmt
 
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -28,7 +28,7 @@ cmp file.go file.go.gofmt
 # Format on save (bad syntax)
 cp file.go.bad file.go
 vim ex 'e! file.go'
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","setqflist",\[\{"filename":"file\.go","lnum":3,"col":1,"text":"expected declaration, found blah","buf":1\}\],"r"\]\]\]\]'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","setqflist",\[\{"filename":"file\.go","lnum":3,"col":1,"text":"expected declaration, found blah","buf":1\}\],"r"\]\]\]\]'
 vim ex 'w'
 cmp file.go file.go.bad
 vim expr 'getqflist()'
@@ -43,7 +43,7 @@ skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
 # :GOVIMGoFmt range
 cp file.go.orig file.go
 vim ex 'e! file.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 vim ex '3,5GOVIMGoFmt'
 vim ex 'noautocmd w'
 cmp file.go file.go.gofmt

--- a/cmd/govim/testdata/scenario_default/gofmt_eof.txt
+++ b/cmd/govim/testdata/scenario_default/gofmt_eof.txt
@@ -3,7 +3,7 @@
 # tests
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'w'
 cmp main.go main.go.golden
 

--- a/cmd/govim/testdata/scenario_default/goimports.txt
+++ b/cmd/govim/testdata/scenario_default/goimports.txt
@@ -7,9 +7,9 @@
 
 # :GOVIMGoImports whole file
 vim ex 'e! file.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 vim ex 'GOVIMGoImports'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 vim ex 'noautocmd w'
 cmp file.go file.go.goimports
 
@@ -17,9 +17,9 @@ cmp file.go file.go.goimports
 cp file.go.orig file.go
 vim call 'govim#config#Set' '["FormatOnSave", "goimports"]'
 vim ex 'e! file.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 vim ex 'w'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/file.go
 cmp file.go file.go.goimports
 
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -28,7 +28,7 @@ cmp file.go file.go.goimports
 # Format on save (bad syntax)
 cp file.go.bad file.go
 vim ex 'e! file.go'
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","setqflist",\[\{"filename":"file\.go","lnum":3,"col":1,"text":"expected declaration, found blah","buf":1\}\],"r"\]\]\]\]'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","setqflist",\[\{"filename":"file\.go","lnum":3,"col":1,"text":"expected declaration, found blah","buf":1\}\],"r"\]\]\]\]'
 vim ex 'w'
 cmp file.go file.go.bad
 vim expr 'getqflist()'

--- a/cmd/govim/testdata/scenario_default/goproxytest_usage.txt
+++ b/cmd/govim/testdata/scenario_default/goproxytest_usage.txt
@@ -1,7 +1,7 @@
 # A simple test that verifies the setup of goproxytest
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'w'
 cmp go.mod go.mod.golden
 

--- a/cmd/govim/testdata/scenario_default/mapping_defaults_go_to_def.txt
+++ b/cmd/govim/testdata/scenario_default/mapping_defaults_go_to_def.txt
@@ -9,7 +9,7 @@ vim ex 'call cursor(3,15)'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '^\Q[3,15]\E$'
 
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/p.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/p.go
 
 # Each block below is simply repeated for each of the default
 # mappings we have defined for GOVIMGoToDef and GOVIMGoToPrevDef

--- a/cmd/govim/testdata/scenario_default/quickfix.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix.txt
@@ -1,7 +1,7 @@
 # Test that the quickfix window gets populated with error messages from gopls
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'
 cmp errors errors.golden

--- a/cmd/govim/testdata/scenario_default/quickfix_config.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_config.txt
@@ -2,12 +2,12 @@
 
 # Default behaviour is quickfix autodiagnostics & sign placment enabled
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'
 vim ex 'cclose'
 cmp errors errors.golden
-errlogmatch -wait 30s 'sendJSONMsg:.*\"call\",.*,\"sign_placelist\"'
+errlogmatch 'sendJSONMsg:.*\"call\",.*,\"sign_placelist\"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 cmp stdout signs.golden
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -17,7 +17,7 @@ cmp stdout signs.golden
 vim call 'govim#config#Set' '["QuickfixAutoDiagnostics", 0]'
 vim call 'govim#config#Set' '["QuickfixSigns", 0]'
 vim call append '[10,""]'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'
 vim ex 'cclose'
@@ -40,14 +40,14 @@ vim ex 'copen'
 vim ex 'w errors'
 vim ex 'cclose'
 cmp errors errors.golden
-errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\S+,\"sign_placelist\"'
+errlogmatch 'sendJSONMsg: .*\"call\",\S+,\"sign_placelist\"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 cmp stdout signs.golden
 
 # Signs should be placed with quickfix autodiagnostics disabled
 vim call 'govim#config#Set' '["QuickfixAutoDiagnostics", 0]'
 vim call append '[10,""]'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'
 vim ex 'cclose'

--- a/cmd/govim/testdata/scenario_default/quickfix_eof.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_eof.txt
@@ -2,7 +2,7 @@
 # in the edge case of an error that references the end of file.
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'
 cmp errors errors.golden

--- a/cmd/govim/testdata/scenario_default/quickfix_retain_position.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_retain_position.txt
@@ -2,7 +2,7 @@
 
 # First ensure we get the expected errors
 vim ex 'e main.go'
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","setqflist",\[\{"filename":"main\.go","lnum":6,"col":2,"text":"undeclared name: asdf","buf":1\},\{"filename":"main\.go","lnum":8,"col":2,"text":"undeclared name: fdas","buf":1\}\],"r"\]\]\]\]'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","setqflist",\[\{"filename":"main\.go","lnum":6,"col":2,"text":"undeclared name: asdf","buf":1\},\{"filename":"main\.go","lnum":8,"col":2,"text":"undeclared name: fdas","buf":1\}\],"r"\]\]\]\]'
 vim ex 'copen'
 vim ex 'w errors'
 cmp errors errors.golden.orig
@@ -22,7 +22,7 @@ stdout '{"idx":2}'
 
 # Now add another error and check the index
 cp other.go.orig other.go
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","setqflist"'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustNothing","setqflist"'
 vim ex 'copen'
 vim ex 'w errors'
 cmp errors errors.golden.updated

--- a/cmd/govim/testdata/scenario_default/references.txt
+++ b/cmd/govim/testdata/scenario_default/references.txt
@@ -6,7 +6,7 @@ vim call 'govim#config#Set' '["QuickfixAutoDiagnostics", 1]'
 
 # Initial location population
 vim ex 'e main.go'
-errlogmatch -wait 60s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'call cursor(15,24)'
 vim ex 'GOVIMReferences'
 vim ex 'copen'
@@ -18,7 +18,7 @@ vim ex 'call win_gotoid(win_findbuf(bufnr(\"main.go\"))[0])'
 vim expr 'bufname(\"\")'
 vim ex 'call cursor(15,1)'
 vim ex 'call feedkeys(\"ofmt.Printf(\\\"%v\\\")\\<ESC>\", \"xt\")'
-errlogmatch -wait 60s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w locations'
 cmp locations locations.golden

--- a/cmd/govim/testdata/scenario_default/rename.txt
+++ b/cmd/govim/testdata/scenario_default/rename.txt
@@ -1,7 +1,7 @@
 # Test that renaming of identifiers works
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'call cursor(6,7)'
 vim ex 'call execute(\"GOVIMRename banana\")'
 vim ex 'silent noautocmd wall'

--- a/cmd/govim/testdata/scenario_default/show_message.txt
+++ b/cmd/govim/testdata/scenario_default/show_message.txt
@@ -4,7 +4,7 @@
 
 vim expr 'GOVIM_internal_ShowMessagePopup()'
 
-errlogmatch -wait 10s 'ShowMessage callback: Something went wrong'
+errlogmatch 'ShowMessage callback: Something went wrong'
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout popup.golden
 

--- a/cmd/govim/testdata/scenario_default/signs.txt
+++ b/cmd/govim/testdata/scenario_default/signs.txt
@@ -8,7 +8,7 @@
 # TODO: Add tests for two diagnostics with different severities on the same line. Currently not supported by gopls.
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_placelist\"'
+errlogmatch 'sendJSONMsg: .*\"call\",\"s:batchCall\",.*\"sign_placelist\"'
 
 # Assert that the different signs are defined
 vim -indent expr 'sign_getdefined()'
@@ -27,7 +27,7 @@ cmp stdout placed_openfile1.golden
 # Removing one of the two quickfix entires on one line shouldn't remove the sign
 vim ex 'call cursor(6,36)'
 vim ex 'call feedkeys(\"3x\", \"x\")' # Remove "i, " from Printf-line
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\],\["call","s:mustNothing","sign_placelist",\[\{"buffer":1,"group":"govim"'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\],\["call","s:mustNothing","sign_placelist",\[\{"buffer":1,"group":"govim"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_openfile2.golden
@@ -38,7 +38,7 @@ cmp stdout placed_openfile2.golden
 # Removing lines should also remove the signs
 vim ex 'call cursor(9,1)'
 vim ex 'call feedkeys(\"2dd\", \"x\")' # Remove line 9 & 10
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\],\["call","s:mustNothing","sign_placelist",\[\{"buffer":1,"group":"govim"'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\],\["call","s:mustNothing","sign_placelist",\[\{"buffer":1,"group":"govim"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_onesign.golden
@@ -48,7 +48,7 @@ cmp stdout placed_onesign.golden
 
 # Fixing the last quickfix entry should remove the last sign
 vim call append '[5, "\tvar v string"]'
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\]\]\]\]'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\]\]\]\]'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_nosign.golden
@@ -58,7 +58,7 @@ cmp stdout placed_nosign.golden
 
 # Two warnings on one line should place two warnings
 vim call append '[5, "\tvar x, y int\n\tx, y = x, y"]'
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\],\["call","s:mustNothing","sign_placelist",\[\{"buffer":1,"group":"govim"'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\],\["call","s:mustNothing","sign_placelist",\[\{"buffer":1,"group":"govim"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed_twowarnings.golden

--- a/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
+++ b/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
@@ -1,10 +1,10 @@
 # Test that signs are placed when opening a file that already has diagnostics.
 
 vim ex 'e main.go'
-errlogmatch -wait 30s -start 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
-errlogmatch -wait 30s -start 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/other.go
+errlogmatch -start 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch -start 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/other.go
 vim ex 'e other.go'
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\],\["call","s:mustNothing","sign_placelist",\[.*\{"buffer":3,"group":"govim"'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\],\["call","s:mustNothing","sign_placelist",\[.*\{"buffer":3,"group":"govim"'
 vim -indent expr 'sign_getplaced(\"other.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed.golden

--- a/cmd/govim/testdata/scenario_default/suggested_fixes.txt
+++ b/cmd/govim/testdata/scenario_default/suggested_fixes.txt
@@ -8,24 +8,24 @@
 # Tests basic case with a single diagnostic, no fix selected
 cp main.go.single main.go
 vim ex 'e main.go'
-errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\S+,\"sign_placelist\"'
+errlogmatch 'sendJSONMsg: .*\"call\",\S+,\"sign_placelist\"'
 
 vim ex 'call cursor(6,2)'
 vim ex 'GOVIMSuggestedFixes'
-errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"title\":\"self-assignment of x to x\"'
+errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"title\":\"self-assignment of x to x\"'
 ! stderr .+
 # Can't do vim ex 'normal .. here since the key press must reach the popup menu
 vim ex 'call feedkeys(\"\\<ESC>\", \"xt\")'
-errlogmatch -wait 30s 'recvJSONMsg: .*GOVIM_internal_PopupSelection'
+errlogmatch 'recvJSONMsg: .*GOVIM_internal_PopupSelection'
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout no_popup.golden
 
 
 # Tests basic case with a single diagnostic, fix applied
 vim ex 'GOVIMSuggestedFixes'
-errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"title\":\"self-assignment of x to x\"'
+errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"title\":\"self-assignment of x to x\"'
 vim ex 'call feedkeys(\"\\<Enter>\", \"xt\")'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'w'
 cmp main.go main.go.single.golden
 
@@ -35,11 +35,11 @@ cmp main.go main.go.single.golden
 cp main.go.different_lines main.go
 vim ex 'e! main.go'
 vim ex 'call feedkeys(\"\\<CursorHold>\", \"xt\")'
-errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\S+,\"sign_placelist\"'
+errlogmatch 'sendJSONMsg: .*\"call\",\S+,\"sign_placelist\"'
 
 vim ex 'call cursor(7,2)'
 vim ex 'GOVIMSuggestedFixes'
-errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"title\":\"self-assignment of y to y\"'
+errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"title\":\"self-assignment of y to y\"'
 ! stderr .+
 
 
@@ -48,25 +48,25 @@ errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{
 cp main.go.same_line main.go
 vim ex 'e! main.go'
 vim ex 'call feedkeys(\"\\<CursorHold>\", \"xt\")'
-errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\S+,\"sign_placelist\"'
+errlogmatch 'sendJSONMsg: .*\"call\",\S+,\"sign_placelist\"'
 
 vim ex 'call cursor(6,2)'
 vim ex 'GOVIMSuggestedFixes'
-errlogmatch -wait 30s -peek 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"title\":\"self-assignment of a to a \[1/4\]\"'
-errlogmatch -wait 30s -peek 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"hidden\":1.*\"title\":\"self-assignment of b to b \[2/4\]\"'
-errlogmatch -wait 30s -peek 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"hidden\":1.*\"title\":\"self-assignment of x to x \[3/4\]\"'
-errlogmatch -wait 30s 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"hidden\":1.*\"title\":\"self-assignment of y to y \[4/4\]\"'
+errlogmatch -peek 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"title\":\"self-assignment of a to a \[1/4\]\"'
+errlogmatch -peek 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"hidden\":1.*\"title\":\"self-assignment of b to b \[2/4\]\"'
+errlogmatch -peek 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"hidden\":1.*\"title\":\"self-assignment of x to x \[3/4\]\"'
+errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"hidden\":1.*\"title\":\"self-assignment of y to y \[4/4\]\"'
 
 # TODO: when it's possible to get the popup title of the visible popup, we can also verify that the cycle buttons really do cycle to the next popup
 # What we can do now is to ensure that nothing breaks when we cycle popups
 
 vim ex 'call feedkeys(\"\\<c-n>\", \"xt\")'
-errlogmatch -wait 30s -peek 'sendJSONMsg: .*\"call\",\"popup_hide\"'
-errlogmatch -wait 30s  'sendJSONMsg: .*\"call\",\"popup_show\"'
+errlogmatch -peek 'sendJSONMsg: .*\"call\",\"popup_hide\"'
+errlogmatch  'sendJSONMsg: .*\"call\",\"popup_show\"'
 
 vim ex 'call feedkeys(\"\\<c-p>\", \"xt\")'
-errlogmatch -wait 30s -peek 'sendJSONMsg: .*\"call\",\"popup_hide\"'
-errlogmatch -wait 30s  'sendJSONMsg: .*\"call\",\"popup_show\"'
+errlogmatch -peek 'sendJSONMsg: .*\"call\",\"popup_hide\"'
+errlogmatch  'sendJSONMsg: .*\"call\",\"popup_show\"'
 
 vim ex 'call feedkeys(\"\\<c-p>\", \"xt\")'
 vim ex 'call feedkeys(\"\\<c-p>\", \"xt\")'
@@ -74,8 +74,8 @@ vim ex 'call feedkeys(\"\\<c-p>\", \"xt\")'
 vim ex 'call feedkeys(\"\\<c-p>\", \"xt\")'
 vim ex 'call feedkeys(\"\\<c-p>\", \"xt\")'
 
-errlogmatch -wait 30s -peek -count 5 'sendJSONMsg: .*\"call\",\"popup_hide\"'
-errlogmatch -wait 30s -count 5 'sendJSONMsg: .*\"call\",\"popup_show\"'
+errlogmatch -peek -count 5 'sendJSONMsg: .*\"call\",\"popup_hide\"'
+errlogmatch -count 5 'sendJSONMsg: .*\"call\",\"popup_show\"'
 
 # TODO: add tests of diagnostics that have multiple suggested fixes, when added to gopls
 

--- a/cmd/govim/testdata/scenario_default/watcher.txt
+++ b/cmd/govim/testdata/scenario_default/watcher.txt
@@ -2,14 +2,14 @@
 
 # New file in the same package
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 cp const.go.orig const.go
-errlogmatch -wait 30s '&protocol.DidOpenTextDocumentParams{\n\S+:\s+TextDocument: protocol.TextDocumentItem{URI:"file://'$WORK/const.go
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/const.go
+errlogmatch '&protocol.DidOpenTextDocumentParams{\n\S+:\s+TextDocument: protocol.TextDocumentItem{URI:"file://'$WORK/const.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/const.go
 vim ex 'call cursor(6,16)'
 vim ex 'call feedkeys(\"iConst2\\<ESC>\", \"x\")'
 vim ex 'w'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'
 vim ex 'cclose'
@@ -21,13 +21,13 @@ skip 'Temporary disabled due to https://github.com/govim/govim/issues/492'
 # New package, note that this is currently handled by a separate lib in darwin
 vim ex 'call cursor(7,1)'
 vim ex 'call feedkeys(\"ifmt.Println(foo.Bar)\n\\<ESC>\",\"x\")'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 mkdir foo
 cp foo_foo.go.orig foo/foo.go
-errlogmatch -wait 30s '&protocol.DidOpenTextDocumentParams{\n\S+:\s+TextDocument: protocol.TextDocumentItem{URI:"file://'$WORK/foo/foo.go
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/foo/foo.go
+errlogmatch '&protocol.DidOpenTextDocumentParams{\n\S+:\s+TextDocument: protocol.TextDocumentItem{URI:"file://'$WORK/foo/foo.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/foo/foo.go
 vim ex 'w'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'
 vim ex 'cclose'

--- a/cmd/govim/testdata/scenario_goimports_local/existing_import.txt
+++ b/cmd/govim/testdata/scenario_goimports_local/existing_import.txt
@@ -3,7 +3,7 @@
 # Verify that new imports get correctly placed
 exec go mod download
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'GOVIMGoImports'
 vim ex 'noautocmd w'
 cmp main.go main.go.golden

--- a/cmd/govim/testdata/scenario_goimports_local/new_import.txt
+++ b/cmd/govim/testdata/scenario_goimports_local/new_import.txt
@@ -3,10 +3,10 @@
 # Verify that new imports get correctly placed
 exec go mod download
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'call cursor(10,1)'
 vim ex 'call feedkeys(\"$i, useless.Name\\<ESC>\", \"xt\")'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'GOVIMGoImports'
 vim ex 'noautocmd w'
 cmp main.go main.go.golden

--- a/cmd/govim/testdata/scenario_no_quickfixautodiagnostics/signs.txt
+++ b/cmd/govim/testdata/scenario_no_quickfixautodiagnostics/signs.txt
@@ -1,7 +1,7 @@
 # Check that signs are still placed despite QuickfixAutoDiagnostics being turned off
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\],\["call","s:mustNothing","sign_placelist",\[\{"buffer":1,"group":"govim"'
+errlogmatch 'sendJSONMsg: \[0,\[\d+,"call","s:batchCall",\[\["call","s:mustBeZero","sign_unplace","govim"\],\["call","s:mustNothing","sign_placelist",\[\{"buffer":1,"group":"govim"'
 vim -indent expr 'sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 ! stderr .+
 cmp stdout placed.golden

--- a/cmd/govim/testdata/scenario_staticcheck/staticcheck.txt
+++ b/cmd/govim/testdata/scenario_staticcheck/staticcheck.txt
@@ -5,7 +5,7 @@
 # for now in this test to give exposure to the staticcheck work
 
 vim ex 'e main.go'
-errlogmatch -wait 30s 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 vim ex 'copen'
 vim ex 'w errors'
 cmp errors errors.golden

--- a/testdriver/testdriver.go
+++ b/testdriver/testdriver.go
@@ -796,6 +796,11 @@ func ErrLogMatch(ts *testscript.TestScript, neg bool, args []string) {
 		ts.Fatalf("errlogmatch %v was not the right type", KeyErrLog)
 	}
 
+	defaultWait := os.Getenv("GOVIM_ERRLOGMATCH_WAIT")
+	if defaultWait == "" {
+		defaultWait = "30s"
+	}
+
 	fs := flag.NewFlagSet("errlogmatch", flag.ContinueOnError)
 	fStart := fs.Bool("start", false, "search from beginning, not last snapshot")
 	fPeek := fs.Bool("peek", false, "do not adjust the NextSearchInx field on the errlog")
@@ -805,8 +810,18 @@ func ErrLogMatch(ts *testscript.TestScript, neg bool, args []string) {
 		ts.Fatalf("errlogmatch: failed to parse args %v: %v", args, err)
 	}
 
-	if *fWait != "" && neg {
+	var waitSet bool
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "wait" {
+			waitSet = true
+		}
+	})
+
+	if neg && waitSet {
 		ts.Fatalf("-wait is not compatible with negating the command")
+	}
+	if !neg && *fWait == "" {
+		fWait = &defaultWait
 	}
 
 	switch {


### PR DESCRIPTION
errlogmatch's -wait flag is now optional. It's value is taken from
os.Getenv("GOVIM_ERRLOGMATCH_WAIT") else it is 30s, the current value.

Closes #607