### PR TITLE
Detect go.mod as a 'gomod' filetype; add syntax and indent

### DIFF
--- a/ftdetect/go.vim
+++ b/ftdetect/go.vim
@@ -1,0 +1,6 @@
+" For now, rely on the .go detection, syntax, indent, etc. provided in recent
+" Vim distributions.
+
+" By default, vim associates .mod files with filetypes lprolog or modsim3.
+" Override these rather than using setfiletype.
+autocmd BufNewFile,BufRead go.mod setlocal filetype=gomod

--- a/indent/gomod.vim
+++ b/indent/gomod.vim
@@ -1,0 +1,33 @@
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+setlocal indentexpr=GomodIndent(v:lnum)
+
+if exists("*GomodIndent")
+  finish
+endif
+
+function! GomodIndent(lnum)
+  let prevnum = prevnonblank(a:lnum-1)
+  if prevnum == 0
+    return 0
+  endif
+
+  " Take the current and previous lines, trimming end-of-line spaces
+  " and comments.
+  let line = substitute(getline(a:lnum), '\v\s+(//.*)?$', '', '')
+  let prev = substitute(getline(prevnum), '\v\s+(//.*)?$', '', '')
+  let ind = indent(prevnum)
+
+  if prev =~ '\v^(require|replace|exclude).*\($'
+    let ind += shiftwidth()
+  endif
+
+  if line =~ ')$'
+    let ind -= shiftwidth()
+  endif
+
+  return ind
+endfunction

--- a/syntax/gomod.vim
+++ b/syntax/gomod.vim
@@ -1,0 +1,123 @@
+" This file is part of vim-go (https://github.com/fatih/vim-go) and is used here
+" under the terms of the 3-clause BSD license.
+"
+" Copyright (c) 2015, Fatih Arslan
+" All rights reserved.
+"
+" Redistribution and use in source and binary forms, with or without
+" modification, are permitted provided that the following conditions are met:
+"
+" * Redistributions of source code must retain the above copyright notice, this
+"   list of conditions and the following disclaimer.
+"
+" * Redistributions in binary form must reproduce the above copyright notice,
+"   this list of conditions and the following disclaimer in the documentation
+"   and/or other materials provided with the distribution.
+"
+" * Neither the name of vim-go nor the names of its
+"   contributors may be used to endorse or promote products derived from
+"   this software without specific prior written permission.
+"
+" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+" DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+" SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+" CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+" OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+" OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+" gomod.vim: Vim syntax file for go.mod file
+"
+" Quit when a (custom) syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+syntax case match
+
+" match keywords
+syntax keyword gomodModule  module
+syntax keyword gomodGo      go      contained
+syntax keyword gomodRequire require
+syntax keyword gomodExclude exclude
+syntax keyword gomodReplace replace
+
+" require, exclude, replace, and go can be also grouped into block
+syntax region gomodRequire start='require (' end=')' transparent contains=gomodRequire,gomodVersion
+syntax region gomodExclude start='exclude (' end=')' transparent contains=gomodExclude,gomodVersion
+syntax region gomodReplace start='replace (' end=')' transparent contains=gomodReplace,gomodVersion
+syntax match  gomodGo            '^go .*$'           transparent contains=gomodGo,gomodGoVersion
+
+" set highlights
+highlight default link gomodModule  Keyword
+highlight default link gomodGo      Keyword
+highlight default link gomodRequire Keyword
+highlight default link gomodExclude Keyword
+highlight default link gomodReplace Keyword
+
+" comments are always in form of // ...
+syntax region gomodComment  start="//" end="$" contains=@Spell
+highlight default link gomodComment Comment
+
+" make sure quoted import paths are higlighted
+syntax region gomodString start=+"+ skip=+\\\\\|\\"+ end=+"+
+highlight default link gomodString  String
+
+" replace operator is in the form of '=>'
+syntax match gomodReplaceOperator "\v\=\>"
+highlight default link gomodReplaceOperator Operator
+
+" match go versions
+syntax match gomodGoVersion "1\.\d\+" contained
+highlight default link gomodGoVersion Identifier
+
+
+" highlight versions:
+"  * vX.Y.Z-pre
+"  * vX.Y.Z
+"  * vX.0.0-yyyyymmddhhmmss-abcdefabcdef
+"  * vX.Y.Z-pre.0.yyyymmddhhmmss-abcdefabcdef
+"  * vX.Y.(Z+1)-0.yyyymmddhhss-abcdefabcdef
+"  see https://godoc.org/golang.org/x/tools/internal/semver for more
+"  information about how semantic versions are parsed and
+"  https://golang.org/cmd/go/ for how pseudo-versions and +incompatible
+"  are applied.
+
+
+" match vX.Y.Z and their prereleases
+syntax match gomodVersion "v\d\+\.\d\+\.\d\+\%(-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?"
+"                          ^--- version ---^^------------ pre-release  ---------------------^^--------------- metadata ---------------------^
+"   	                     ^--------------------------------------- semantic version -------------------------------------------------------^
+
+" match pseudo versions
+" without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef)
+syntax match gomodVersion  "v\d\+\.0\.0-\d\{14\}-\x\+"
+" when most recent version before target is a pre-release
+syntax match gomodVersion  "v\d\+\.\d\+\.\d\+-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?\.0\.\d\{14}-\x\+"
+"                          ^--- version ---^^--- ------ pre-release -----------------^^--------------- metadata ---------------------^
+"                     	   ^------------------------------------- semantic version --------------------------------------------------^
+" most recent version before the target is X.Y.Z
+syntax match gomodVersion "v\d\+\.\d\+\.\d\+\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?-0\.\d\{14}-\x\+"
+"                          ^--- version ---^^--------------- metadata ---------------------^
+
+" match incompatible vX.Y.Z and their prereleases
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+\%(-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?+incompatible"
+"                          ^------- version -------^^------------- pre-release ---------------------^^--------------- metadata ---------------------^
+"               	         ^------------------------------------------- semantic version -----------------------------------------------------------^
+
+" match incompatible pseudo versions
+" incompatible without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef)
+syntax match gomodVersion "v[2-9]\{1}\d*\.0\.0-\d\{14\}-\x\++incompatible"
+" when most recent version before target is a pre-release
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?\.0\.\d\{14}-\x\++incompatible"
+"                          ^------- version -------^^---------- pre-release -----------------^^--------------- metadata ---------------------^
+"                     	   ^---------------------------------------- semantic version ------------------------------------------------------^
+" most recent version before the target is X.Y.Z
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+\%(+\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?-0\.\d\{14}-\x\++incompatible"
+"                          ^------- version -------^^---------------- metadata ---------------------^
+highlight default link gomodVersion Identifier
+
+let b:current_syntax = "gomod"


### PR DESCRIPTION
First, add ftdetect configuration to detect go.mod files as the 'gomod' filetype.

Then add syntax and indent files for this filetype.

The gomod syntax file is reused from the vim-go project under the terms of its 3-clause BSD license. The indent file is new work.