### PR TITLE
testdriver: limit listening to local interface

### DIFF
--- a/testdriver/testdriver.go
+++ b/testdriver/testdriver.go
@@ -121,7 +121,7 @@ func NewTestDriver(c *Config) (*TestDriver, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create listener for govim: %v", err)
 	}
-	dl, err := net.Listen("tcp4", ":0")
+	dl, err := net.Listen("tcp4", "localhost:0")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create listener for driver: %v", err)
 	}


### PR DESCRIPTION
Running the tests in macOS will bring up a dialog from the firewall
prompting to allow an unsigned process to listen to network connections.

Using local loopback interface instead for the testdriver will please the
firewall and no dialog shows.