### PR TITLE
[WIP] cmd/govim: create a test with expectations for diagnostic notifications

### DIFF
--- a/cmd/govim/testdata/scenario_default/diagnostics_expectations.txt
+++ b/cmd/govim/testdata/scenario_default/diagnostics_expectations.txt
@@ -1,0 +1,19 @@
+# Test to verify expectations on the what expectations are sent when
+# by gopls
+
+# Starting with an error in main.go we should receive one diagnostics notification
+vim ex 'e main.go'
+sleep $DEFAULT_ERRLOGMATCH_WAIT
+errlogmatch -start -count 1 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
+
+-- go.mod --
+module mod.com
+
+-- main.go --
+package main
+
+blah
+
+func main() {
+}
+


### PR DESCRIPTION
Now that gopls no longer sends duplicate notifications for a file (put
another way, we only get diagnostic notifications for a file when those
diagnostics change) we need to lock in our expectations in a test.

Reason being, we do lots of errlogmatch for diagnostic notifications so
our tests might appear flaky if our expectations are wrong.