### PR TITLE
[DO NOT MERGE] add ability to specify working directory for testscripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,4 +54,8 @@ before_install:
   - ./_scripts/buildGovimImage.sh
 
 script:
+  - jq --version
   - ./_scripts/runDockerRun.sh
+
+after_failure:
+  - ./_scripts/afterFailure.sh

--- a/_scripts/afterFailure.sh
+++ b/_scripts/afterFailure.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE%/*}/common.bash"
+
+cd $HOME
+
+if [ ! -d ./artefacts ]
+then
+	exit
+fi
+
+sudo find ./artefacts \( -name .vim -o -name gopath \) -prune -exec rm -rf '{}' \;
+echo "=================================================================================="
+tar -zc ./artefacts | base64
+echo "=================================================================================="

--- a/_scripts/dockerRun.sh
+++ b/_scripts/dockerRun.sh
@@ -50,7 +50,7 @@ fi
 go vet $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
 go run honnef.co/go/tools/cmd/staticcheck $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
 
-if [ "${CI:-}" == "true" && "${TRAVIS_EVENT_TYPE:-}" != "cron" ]
+if [ "${CI:-}" == "true" ] && [ "${TRAVIS_EVENT_TYPE:-}" != "cron" ]
 then
 	go mod tidy
 	diff <(echo -n) <(go run golang.org/x/tools/cmd/goimports -d $(git ls-files '**/*.go' '*.go' | grep -v golang_org_x_tools))

--- a/_scripts/dockerRun.sh
+++ b/_scripts/dockerRun.sh
@@ -2,6 +2,8 @@
 
 source "${BASH_SOURCE%/*}/common.bash"
 
+trap 'set +ev' EXIT
+
 if [ "${VIM_COMMAND:-}" == "" ]
 then
 	eval "VIM_COMMAND=\"\$DEFAULT_${VIM_FLAVOR^^}_COMMAND\""
@@ -36,10 +38,11 @@ go install golang.org/x/tools/gopls
 # remove all generated files to ensure we are never stale
 rm -f $(git ls-files -- ':!:cmd/govim/internal/golang_org_x_tools' '**/gen_*.*' 'gen_*.*') .travis.yml
 
+go generate $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
+
 # run the install scripts
 export GOVIM_RUN_INSTALL_TESTSCRIPTS=true
 
-go generate $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
 go test $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
 
 if [ "${CI:-}" == "true" ] && [ "${TRAVIS_BRANCH:-}_${TRAVIS_PULL_REQUEST_BRANCH:-}" == "master_" ]

--- a/_scripts/runDockerRun.sh
+++ b/_scripts/runDockerRun.sh
@@ -8,11 +8,16 @@ cd "${BASH_SOURCE%/*}/../"
 
 proxy=""
 
+artefacts="$HOME/artefacts"
+
 if [ "${CI:-}" != "true" ]
 then
 	go mod download
 	modcache="$(go env GOPATH | sed -e 's/:/\n/' | head -n 1)/pkg/mod/cache/download"
 	proxy="-v $modcache:/cache -e GOPROXY=file:///cache"
+	artefacts="$(mktemp -d)"
 fi
 
-docker run $proxy --env-file ./_scripts/.docker_env_file -e "VIM_FLAVOR=${VIM_FLAVOR:-vim}" -v $PWD:/home/$USER/govim -w /home/$USER/govim --rm govim ./_scripts/dockerRun.sh
+mkdir -p $artefacts
+
+docker run $proxy --env-file ./_scripts/.docker_env_file -e "VIM_FLAVOR=${VIM_FLAVOR:-vim}" -v $artefacts:/artefacts -e GOTMPDIR=/artefacts -v $PWD:/home/$USER/govim -w /home/$USER/govim --rm govim ./_scripts/dockerRun.sh

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -106,7 +106,7 @@ func launch(goplspath string, in io.ReadCloser, out io.WriteCloser) error {
 
 	d := newplugin(goplspath, nil, nil, nil)
 
-	tf, err := createLogFile("govim_log")
+	tf, err := d.createLogFile("govim_log")
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func launch(goplspath string, in io.ReadCloser, out io.WriteCloser) error {
 	return d.tomb.Wait()
 }
 
-func createLogFile(prefix string) (*os.File, error) {
+func (g *govimplugin) createLogFile(prefix string) (*os.File, error) {
 	var tf *os.File
 	var err error
 	logfiletmpl := os.Getenv(testsetup.EnvLogfileTmpl)
@@ -141,10 +141,10 @@ func createLogFile(prefix string) (*os.File, error) {
 	logfiletmpl = strings.Replace(logfiletmpl, "%v", time.Now().Format("20060102_1504_05"), 1)
 	if strings.Contains(logfiletmpl, "%v") {
 		logfiletmpl = strings.Replace(logfiletmpl, "%v", "*", 1)
-		tf, err = ioutil.TempFile("", logfiletmpl)
+		tf, err = ioutil.TempFile(g.tmpDir, logfiletmpl)
 	} else {
 		// append to existing file
-		tf, err = os.OpenFile(filepath.Join(os.TempDir(), logfiletmpl), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		tf, err = os.OpenFile(filepath.Join(g.tmpDir, logfiletmpl), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	}
 	if err != nil {
 		err = fmt.Errorf("failed to create log file: %v", err)
@@ -155,6 +155,9 @@ func createLogFile(prefix string) (*os.File, error) {
 type govimplugin struct {
 	plugin.Driver
 	vimstate *vimstate
+
+	// tmpDir is the temp directory within which log files will be created
+	tmpDir string
 
 	// goplsEnv is the environment with which to start gopls. This is
 	// set in os/exec.Command.Env
@@ -207,6 +210,21 @@ type govimplugin struct {
 }
 
 func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Config) *govimplugin {
+	if goplsEnv == nil {
+		goplsEnv = os.Environ()
+	}
+	var tmpDir string
+	if len(goplsEnv) > 0 {
+		for i := len(goplsEnv) - 1; i >= 0; i-- {
+			if strings.HasPrefix(goplsEnv[i], "TMPDIR=") {
+				tmpDir = strings.TrimPrefix(goplsEnv[i], "TMPDIR=")
+				break
+			}
+		}
+	}
+	if tmpDir == "" {
+		tmpDir = os.TempDir()
+	}
 	if defaults == nil {
 		defaults = &config.Config{
 			FormatOnSave:            vimconfig.FormatOnSaveVal(config.FormatOnSaveGoImports),
@@ -222,6 +240,7 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 	}
 	d := plugin.NewDriver(PluginPrefix)
 	res := &govimplugin{
+		tmpDir:                    tmpDir,
 		rawDiagnostics:            make(map[span.URI]*protocol.PublishDiagnosticsParams),
 		goplsEnv:                  goplsEnv,
 		goplspath:                 goplspath,
@@ -286,7 +305,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 
 	g.isGui = g.ParseInt(g.ChannelExpr(`has("gui_running")`)) == 1
 
-	logfile, err := createLogFile("gopls_log")
+	logfile, err := g.createLogFile("gopls_log")
 	if err != nil {
 		return err
 	}

--- a/cmd/govim/testdata/scenario_default/quickfix.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix.txt
@@ -8,6 +8,8 @@ cmp errors errors.golden
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
 # errlogmatch -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
+fail
+
 -- go.mod --
 module mod.com
 

--- a/govim_test.go
+++ b/govim_test.go
@@ -40,7 +40,8 @@ func TestScripts(t *testing.T) {
 
 	t.Run("scripts", func(t *testing.T) {
 		testscript.Run(t, testscript.Params{
-			Dir: "testdata",
+			TestWork: os.Getenv("GOTMPDIR") != "",
+			Dir:      "testdata",
 			Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
 				"sleep":       testdriver.Sleep,
 				"errlogmatch": testdriver.ErrLogMatch,


### PR DESCRIPTION
This means we can, via a govim environment variable, specify where the
artefacts of a testscript run are placed.