### PR TITLE
cmd/govim: make user busy autocmd nested

### DIFF
--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -211,8 +211,8 @@ function s:define(channel, msg)
       " doautoall BufRead also triggers ftplugin stuff
       doautoall BufRead
       doautoall FileType
-      au CursorMoved,CursorMovedI *.go :call s:userBusy(1)
-      au CursorHold,CursorHoldI *.go :call s:userBusy(0)
+      au CursorMoved,CursorMovedI *.go ++nested :call s:userBusy(1)
+      au CursorHold,CursorHoldI *.go ++nested :call s:userBusy(0)
       for F in s:loadStatusCallbacks
         call call(F, [s:govim_status])
       endfor


### PR DESCRIPTION
We have, over time, seen a number of flakes where we appear to be
missing autocmd callbacks. The most prominent of these is in the rename
tests where we fail to see autocmd callbacks for an unopen file we have
just split/vsplit etc. This could point towards a Vim bug, but more
likely is that fact that each of these flakes is interacting with the
user-busy logic.

Key in this analysis is a callstack from a recent flake:

    SNR>18_userBusy[3]..GOVIM_internal_SetUserBusy[2]..<SNR>18_callbackFunction[2]..<SNR>18_ch_evalexpr[15]..<SNR>18_drainScheduleBacklog[14]..<SNR>18_ch_evalexpr[10]..<SNR>18_define[40]..<SNR>18_callbackCommand[3]..<SNR>18_ch_evalexpr

Notice at the bottom (left) of the callstack is userBusy. Currently we
do not have ++nested on the definition of the autocmd that fires when
the user becomes/stops being busy. Hence for the entire duration of that
callback (GOVIM_internal_SetUserBusy) autocmds will not fire (because
this is a "global" flag in Vim, not a per autocmd thing).

We fix this by making the user-busy autocmd's ++nested (see :help
autocmd-nested). As a result we should see fewer (no?) more flakes of
this kind.