### PR TITLE
cmd/govim: create a test demonstrating failing completion

### DIFF
--- a/cmd/govim/testdata/scenario_default/complete.txt
+++ b/cmd/govim/testdata/scenario_default/complete.txt
@@ -3,8 +3,11 @@
 
 vim ex 'e main.go'
 errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
-vim ex 'call cursor(11,17)'
-vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<ESC>\", \"xt\")'
+vim ex 'call cursor(11,1)'
+vim ex 'call feedkeys(\"A\\<C-X>\\<C-O>\\<C-N>\\<C-N>\\<ESC>\", \"xt\")'
+vim ex 'call feedkeys(\"A(Con\", \"xt\")'
+vim ex 'call feedkeys(\"A\\<C-X>\\<C-O>\\<C-N>\\<ESC>\", \"xt\")'
+vim ex 'call feedkeys(\"A)\", \"xt\")'
 vim ex 'w'
 cmp main.go main.go.golden
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -24,7 +27,7 @@ const (
 )
 
 func main() {
-	fmt.Println(Con)
+	fmt.Print
 }
 -- main.go.golden --
 package main


### PR DESCRIPTION
As previously discovered (and also raised in #658), 11eb9c7 caused
completion to break in govim because placeholder values are now included
in the completion result. This has now been fixed in:

  https://go-review.googlesource.com/c/tools/+/213640

However, because of a bug introduced in:

  https://go-review.googlesource.com/c/tools/+/212102

we can't simply upgrade to the latest x/tools and gopls.

In any case we want to add a test to demonstrate the problem and prevent
and future regressions. A subsequent PR will upgrade the version of
x/tools and gopls to a commit (in a temporary fork) that has the fix for
the completion bug but does not have the bug for the parallel initial
load.

Updates #658