### PR TITLE
ci: fix master cron build to drop replace directives

### DIFF
--- a/_scripts/dockerRun.sh
+++ b/_scripts/dockerRun.sh
@@ -28,6 +28,7 @@ vim --version
 
 if [ "${TRAVIS_EVENT_TYPE:-}" == "cron" ]
 then
+	go mod edit -dropreplace=golang.org/x/tools -dropreplace=golang.org/x/tools/gopls
 	go get golang.org/x/tools/gopls@master golang.org/x/tools@master
 	go list -m golang.org/x/tools/gopls golang.org/x/tools
 fi


### PR DESCRIPTION
The master CRON build that happens on Travis should be checking against
master of x/tools and gopls. To ensure we actually test against x/tools
and gopls master we need to make sure that there are no replace
directives against either module.

This PR fixes that.