### PR TITLE
cmd/govim: change log file template to default to .log files

### DIFF
--- a/_scripts/afterFailure.sh
+++ b/_scripts/afterFailure.sh
@@ -17,7 +17,7 @@ cd $ARTEFACTS
 sudo find . -type d \( -name .vim -o -name gopath \) -prune -exec rm -rf '{}' \;
 
 # Now prune the files we don't want
-sudo find . -type f -not -path "*/_tmp/govim_log" -and -not -path "*/_tmp/gopls_log" -and -not -path "*/_tmp/vim_channel_log" -exec rm '{}' \;
+sudo find . -type f -not -path "*/_tmp/govim.log" -and -not -path "*/_tmp/gopls.log" -and -not -path "*/_tmp/vim_channel.log" -exec rm '{}' \;
 
 url=$(echo "{ \"public\": false, \"files\": { \"logs.base64\": { \"content\": \"$(find . -type f -print0 | tar -zc --null -T - | base64 | sed ':a;N;$!ba;s/\n/\\n/g')\" } } }" | curl -s -H "Content-Type: application/json" -u $GH_USER:$GH_TOKEN --request POST --data-binary "@-" https://api.github.com/gists | jq -r '.files."logs.base64".raw_url')
 echo 'cd $(mktemp -d) && curl -s '$url' | base64 -d | tar -zx'

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -106,7 +106,7 @@ func launch(goplspath string, in io.ReadCloser, out io.WriteCloser) error {
 
 	d := newplugin(goplspath, nil, nil, nil)
 
-	tf, err := d.createLogFile("govim_log")
+	tf, err := d.createLogFile("govim")
 	if err != nil {
 		return err
 	}
@@ -137,6 +137,7 @@ func (g *govimplugin) createLogFile(prefix string) (*os.File, error) {
 	if logfiletmpl == "" {
 		logfiletmpl = "%v_%v_%v"
 	}
+	logfiletmpl += ".log"
 	logfiletmpl = strings.Replace(logfiletmpl, "%v", prefix, 1)
 	logfiletmpl = strings.Replace(logfiletmpl, "%v", time.Now().Format("20060102_1504_05"), 1)
 	if strings.Contains(logfiletmpl, "%v") {
@@ -297,7 +298,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 
 	g.isGui = g.ParseInt(g.ChannelExpr(`has("gui_running")`)) == 1
 
-	logfile, err := g.createLogFile("gopls_log")
+	logfile, err := g.createLogFile("gopls")
 	if err != nil {
 		return err
 	}

--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -137,14 +137,14 @@ func TestScripts(t *testing.T) {
 					var err error
 					var tf *os.File
 					if workdir == "" {
-						tf, err = ioutil.TempFile(tmp, "govim_log*")
+						tf, err = ioutil.TempFile(tmp, "govim.log*")
 						if err != nil {
 							t.Fatalf("failed to create govim log file: %v", err)
 						}
 					} else {
 						// create a "plain"-named logfile because as above we set
 						// GOVIM_LOGFILE_TMPL=%v
-						tf, err = os.OpenFile(filepath.Join(tmp, "govim_log"), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0666)
+						tf, err = os.OpenFile(filepath.Join(tmp, "govim.log"), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0666)
 						if err != nil {
 							t.Fatalf("failed to create non-tmp govim log file: %v", err)
 						}

--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -22,7 +22,8 @@ let s:filetmpl = $GOVIM_LOGFILE_TMPL
 if s:filetmpl == ""
   let s:filetmpl = "%v_%v_%v"
 endif
-let s:filetmpl = substitute(s:filetmpl, "%v", "vim_channel_log", "")
+let s:filetmpl .= ".log"
+let s:filetmpl = substitute(s:filetmpl, "%v", "vim_channel", "")
 let s:filetmpl = substitute(s:filetmpl, "%v", strftime("%Y%m%d_%H%M_%S"), "")
 if s:filetmpl =~ "%v"
   let s:filetmpl = substitute(s:filetmpl, "%v", "XXXXXXXXXXXX", "")


### PR DESCRIPTION
A minor annoyance, but when reporting issues via GitHub, uploading log
files only works in the browser if the file has a .log extension. Our
log file templates do not currently have such an extension which means
manual renaming is required before the file can be uploaded.

Fix that.