### PR TITLE
cmd/govim: apply AdditionalTextEdits on CompleteDone

### DIFF
--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -283,6 +283,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineCommand(string(config.CommandRename), g.vimstate.rename, govim.NArgsZeroOrOne)
 	g.DefineCommand(string(config.CommandStringFn), g.vimstate.stringfns, govim.RangeLine, govim.CompleteCustomList(PluginPrefix+config.FunctionStringFnComplete), govim.NArgsOneOrMore)
 	g.DefineFunction(string(config.FunctionStringFnComplete), []string{"ArgLead", "CmdLine", "CursorPos"}, g.vimstate.stringfncomplete)
+	g.DefineAutoCommand("", govim.Events{govim.EventCompleteDone}, govim.Patterns{"*.go"}, false, g.vimstate.completeDone, "eval(expand('<abuf>'))", "v:completed_item")
 	g.defineHighlights()
 	if err := g.vimstate.signDefine(); err != nil {
 		return fmt.Errorf("failed to define signs: %v", err)

--- a/cmd/govim/testdata/scenario_completeunimported/complete.txt
+++ b/cmd/govim/testdata/scenario_completeunimported/complete.txt
@@ -2,12 +2,28 @@
 
 vim ex 'e main.go'
 
-# lower from lo
+# Unimported completion
 vim ex 'call cursor(4,1)'
 vim normal Sfmt.Pr
-vim ex 'execute \"normal A\\<C-X>\\<C-O>\\<C-N>\\<C-N>\"'
+vim ex 'execute \"normal A\\<C-X>\\<C-O>\\<C-N>\\<C-N>(\\\"Hello\\\")\"'
+
+# Check import has been added
 vim ex 'noau w'
-cmp main.go main.go.golden
+cmp main.go main.go1.golden
+
+# Regular completion
+vim ex 'call cursor(7,1)'
+vim normal Sfmt.Pr
+vim ex 'execute \"normal A\\<C-X>\\<C-O>\\<C-N>(\\\"Hello\\\")\"'
+
+# Keyword complete
+vim ex 'call cursor(8,1)'
+vim normal Sfmt.Pr
+vim ex 'execute \"normal A\\<C-X>\\<C-N>(\\\"Hello\\\")\"'
+
+# Verify final result
+vim ex 'noau w'
+cmp main.go main.go2.golden
 
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
 # errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
@@ -21,10 +37,26 @@ package main
 
 func main() {
 
+
+
 }
--- main.go.golden --
+-- main.go1.golden --
 package main
 
+import "fmt"
+
 func main() {
-	fmt.Println
+	fmt.Println("Hello")
+
+
+}
+-- main.go2.golden --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello")
+	fmt.Printf("Hello")
+	fmt.Println("Hello")
 }

--- a/cmd/govim/testdata/scenario_default/complete_watched.txt
+++ b/cmd/govim/testdata/scenario_default/complete_watched.txt
@@ -37,7 +37,9 @@ const (
 -- main.go.golden --
 package main
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func main() {
 	fmt.Println(Const2)

--- a/complete.go
+++ b/complete.go
@@ -1,0 +1,34 @@
+package govim
+
+type CompleteMode string
+
+const (
+	CompleteModeNone          CompleteMode = ""
+	CompleteModeKeyword       CompleteMode = "keyword"
+	CompleteModeCtrl_x        CompleteMode = "ctrl_x"
+	CompleteModeWhole_line    CompleteMode = "whole_line"
+	CompleteModeFiles         CompleteMode = "files"
+	CompleteModeTags          CompleteMode = "tags"
+	CompleteModePath_defines  CompleteMode = "path_defines"
+	CompleteModePath_patterns CompleteMode = "path_patterns"
+	CompleteModeDictionary    CompleteMode = "dictionary"
+	CompleteModeThesaurus     CompleteMode = "thesaurus"
+	CompleteModeCmdline       CompleteMode = "cmdline"
+	CompleteModeFunction      CompleteMode = "function"
+	CompleteModeOmni          CompleteMode = "omni"
+	CompleteModeSpell         CompleteMode = "spell"
+	CompleteModeEval          CompleteMode = "eval"
+	CompleteModeUnknown       CompleteMode = "unknown"
+)
+
+type CompleteItem struct {
+	Abbr     string `json:"abbr"`
+	Word     string `json:"word"`
+	Info     string `json:"info"`
+	Menu     string `json:"menu"`
+	UserData string `json:"user_data"`
+}
+
+type CompleteInfo struct {
+	Mode CompleteMode `json:"mode"`
+}


### PR DESCRIPTION
Some completion candidates, most notably unimported completion
candidates, carry with them additional text edits. In the case of
unimported candidates, these represent the changes required to add the
missing import if the candidate is chosen.

This commit applies those text edits when we get the event CompleteDone.