### PR TITLE
scripts: add captureLogs.sh to easily run tests and capture all logs

### DIFF
--- a/_scripts/afterFailure.sh
+++ b/_scripts/afterFailure.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 source "${BASH_SOURCE%/*}/common.bash"
+source "${BASH_SOURCE%/*}/tidyUp.bash"
 
 if [ "${CI:-}" != "true" ]
 then
@@ -13,11 +14,7 @@ ARTEFACTS=$(echo $ARTEFACTS)
 
 cd $ARTEFACTS
 
-# Remove all the big directories first
-sudo find . -type d \( -name .vim -o -name gopath \) -prune -exec rm -rf '{}' \;
-
-# Now prune the files we don't want
-sudo find . -type f -not -path "*/_tmp/govim.log" -and -not -path "*/_tmp/gopls.log" -and -not -path "*/_tmp/vim_channel.log" -exec rm '{}' \;
+tidyUp .
 
 url=$(echo "{ \"public\": false, \"files\": { \"logs.base64\": { \"content\": \"$(find . -type f -print0 | tar -zc --null -T - | base64 | sed ':a;N;$!ba;s/\n/\\n/g')\" } } }" | curl -s -H "Content-Type: application/json" -u $GH_USER:$GH_TOKEN --request POST --data-binary "@-" https://api.github.com/gists | jq -r '.files."logs.base64".raw_url')
 echo 'cd $(mktemp -d) && curl -s '$url' | base64 -d | tar -zx'

--- a/_scripts/captureLogs.sh
+++ b/_scripts/captureLogs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE%/*}/common.bash"
+source "${BASH_SOURCE%/*}/tidyUp.bash"
+
+if [[ $# -eq 0 ]] ; then
+    echo 'usage: captureLogs.sh dir command [args...]
+
+captureLogs.sh simplifies the capture of logs from a run of testscript tests.
+
+For example, given:
+
+    captureLogs.sh /tmp/blah go test -count=1 ./...
+
+gopls, govim and Vim logs will then be found beneath /tmp/blah according to
+the directory structure of testscript scripts in the packages matched by ./...'
+    exit -2
+fi
+
+dir="$1"
+shift
+
+if [ -d "$dir" ]
+then
+	now=$(date +%Y%m%d%H%M%S_%N)
+	mv "$dir" "${dir}_${now}"
+	echo "Moved existing $dir to ${dir}_${now}"
+fi
+
+mkdir -p "$dir"
+
+# Run whatever commands were supplied, deliberately allowing failure
+GOVIM_TESTSCRIPT_WORKDIR_ROOT="$dir" "$@" || true
+
+tidyUp "$dir"
+

--- a/_scripts/tidyUp.bash
+++ b/_scripts/tidyUp.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+source "${BASH_SOURCE%/*}/common.bash"
+
+tidyUp() {
+	# Fix up everything to be user-writable
+	chmod -R u+w "$1"
+
+	# Remove all the big directories first
+	find "$1" -type d \( -name .vim -o -name gopath \) -prune -exec rm -rf '{}' \;
+
+	# Now prune the files we don't want
+	find "$1" -type f -not -path "*/_tmp/govim.log" -and -not -path "*/_tmp/gopls.log" -and -not -path "*/_tmp/vim_channel.log" -exec rm '{}' \;
+}
+


### PR DESCRIPTION
When the CI build fails and generates artefacts we capture logs.
Sometimes it's useful to be able to do that locally.

_scripts/captureLogs.sh makes that trivial by wrapping the relevant
commands.