### PR TITLE
cmd/govim: make testscript scripts truly concurrent

### DIFF
--- a/_scripts/runDockerRun.sh
+++ b/_scripts/runDockerRun.sh
@@ -8,8 +8,9 @@ cd "${BASH_SOURCE%/*}/../"
 
 # The ARTEFACTS variable set by .travis.yml cannot expand
 # variables so we do that here
-ARTEFACTS=$(echo $ARTEFACTS)
+ARTEFACTS=$(echo ${ARTEFACTS:-})
 
+artefacts=""
 proxy=""
 
 if [ "${CI:-}" != "true" ]

--- a/cmd/govim/cleanup1.14_test.go
+++ b/cmd/govim/cleanup1.14_test.go
@@ -1,0 +1,11 @@
+// +build go1.14
+
+package main
+
+import "testing"
+
+func cleanup(t *testing.T, f func()) {
+	// TODO when there is a 1.14 release which includes CL 214822 we can
+	// uncomment the next line
+	// t.Cleanup(f)
+}

--- a/cmd/govim/cleanup_pre1.14_test.go
+++ b/cmd/govim/cleanup_pre1.14_test.go
@@ -1,0 +1,9 @@
+// +build !go1.14
+
+package main
+
+import "testing"
+
+func cleanup(t *testing.T, f func()) {
+	// This is a no-op pre 1.14
+}

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 golang.org/x/crypto v0.0.0-20181106171534-e4dc69e5b2fd/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e h1:JgcxKXxCjrA2tyDP/aNU9K0Ck5Czfk6C7e2tMw7+bSI=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=


### PR DESCRIPTION
Our cmd/govim testscript tests are split across a number of directories.
This grouping allows us to have separate configuration per directory.

Currently we do not call t.Parallel in each directory's subtest. This
means that we run directory scipts in serial, one directory after
another. Therefore, if there is a particularly slow test in one
directory, we can end up with flat spots where we do not fully utilise
the -test.parallel concurrency limit.

Making directory subtests parallel removes these flat spots. But we do
so at the cost of leaving beind gopls install artefacts. When we start
testing against a Go 1.14 release that includes CL 214822 we can enable
that cleanup, but Go version pre 1.14 will unfortunately continue to
leak these artefacts.