### PR TITLE
cmd/govim: add diagnostics to hover popup

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -68,6 +68,10 @@ function! s:validHighlightDiagnostics(v)
     return s:validBool(a:v)
 endfunction
 
+function! s:validHoverDiagnostics(v)
+    return s:validBool(a:v)
+endfunction
+
 function! s:validCompletionDeepCompletions(v)
   return s:validBool(a:v)
 endfunction
@@ -121,6 +125,7 @@ let s:validators = {
       \ "CompletionMatcher": function("s:validCompletionMatcher"),
       \ "QuickfixSigns": function("s:validQuickfixSigns"),
       \ "HighlightDiagnostics": function("s:validHighlightDiagnostics"),
+      \ "HoverDiagnostics": function("s:validHoverDiagnostics"),
       \ "Staticcheck": function("s:validStaticcheck"),
       \ "CompleteUnimported": function("s:validCompleteUnimported"),
       \ "GoImportsLocalPrefix": function("s:validGoImportsLocalPrefix"),

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -58,6 +58,19 @@ type Config struct {
 	// Default: true
 	HighlightDiagnostics *bool `json:",omitempty"`
 
+	// HoverDiagnostics is a boolean (0 or 1 in VimScript) that controls
+	// whether diagnostics should be shown in the hover popup. When enabled
+	// each diagnostic that covers the cursor/mouse position will be added
+	// to the popup and formatted using text properties with the following
+	// highlight groups: GOVIMHoverErr, GOVIMHoverWarn, GOVIMHoverInfo and
+	// GOVIMHoverHint. The diagnostic source part is formatted via highlight
+	// group GOVIMHoverDiagSrc.
+	// All text properties are combined into existing syntax (with diagnostic
+	// source being applied last) to provide a wide range of styles.
+	//
+	// Default: true
+	HoverDiagnostics *bool `json:",omitempty"`
+
 	// CompletionDeepCompletiions enables gopls' deep completion option
 	// in the derivation of completion candidates.
 	//
@@ -287,4 +300,16 @@ const (
 	HighlightSignInfo Highlight = "GOVIMSignInfo"
 	// HighlightSignHint is the group used to add hint signs in the gutter
 	HighlightSignHint Highlight = "GOVIMSignHint"
+
+	// HighlightHoverErr is ths group used to add errors to the hover popup
+	HighlightHoverErr Highlight = "GOVIMHoverErr"
+	// HighlightHoverWarn is ths group used to add warnings to the hover popup
+	HighlightHoverWarn Highlight = "GOVIMHoverWarn"
+	// HighlightHoverInfo is ths group used to add informations to the hover popup
+	HighlightHoverInfo Highlight = "GOVIMHoverInfo"
+	// HighlightHoverHint is ths group used to add hints to the hover popup
+	HighlightHoverHint Highlight = "GOVIMHoverHint"
+
+	// HighlightHoverDiagSrc is the group used to format the source part of a hover diagnostic
+	HighlightHoverDiagSrc Highlight = "GOVIMHoverDiagSrc"
 )

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -13,6 +13,9 @@ func (r *Config) Apply(v *Config) {
 	if v.HighlightDiagnostics != nil {
 		r.HighlightDiagnostics = v.HighlightDiagnostics
 	}
+	if v.HoverDiagnostics != nil {
+		r.HoverDiagnostics = v.HoverDiagnostics
+	}
 	if v.CompletionDeepCompletions != nil {
 		r.CompletionDeepCompletions = v.CompletionDeepCompletions
 	}

--- a/cmd/govim/diagnostics.go
+++ b/cmd/govim/diagnostics.go
@@ -60,6 +60,7 @@ func (v *vimstate) diagnostics() []types.Diagnostic {
 			}
 			diags = append(diags, types.Diagnostic{
 				Filename: fn,
+				Source:   d.Source,
 				Range:    types.Range{Start: s, End: e},
 				Text:     d.Message,
 				Buf:      buf.Num,

--- a/cmd/govim/internal/types/types.go
+++ b/cmd/govim/internal/types/types.go
@@ -235,6 +235,12 @@ func (p Point) ToPosition() protocol.Position {
 	}
 }
 
+// IsWithin returns true if a point is within the given range
+func (p Point) IsWithin(r Range) bool {
+	return r.Start.Offset() <= p.Offset() &&
+		p.Offset() <= r.End.Offset()
+}
+
 func f2int(f float64) int {
 	return int(math.Round(f))
 }
@@ -243,6 +249,7 @@ func f2int(f float64) int {
 // populate quickfix list, place signs, highlight text ranges etc.
 type Diagnostic struct {
 	Filename string
+	Source   string
 	Range    Range
 	Text     string
 	Buf      int
@@ -268,10 +275,18 @@ var SeverityPriority = map[Severity]int{
 	SeverityHint: 8,
 }
 
-// Highlight returns corresponding highlight name for a severity.
+// SeverityHighlight returns corresponding highlight name for a severity.
 var SeverityHighlight = map[Severity]config.Highlight{
 	SeverityErr:  config.HighlightErr,
 	SeverityWarn: config.HighlightWarn,
 	SeverityInfo: config.HighlightInfo,
 	SeverityHint: config.HighlightHint,
+}
+
+// SeverityHoverHighlight returns corresponding hover highlight name for a severity.
+var SeverityHoverHighlight = map[Severity]config.Highlight{
+	SeverityErr:  config.HighlightHoverErr,
+	SeverityWarn: config.HighlightHoverWarn,
+	SeverityInfo: config.HighlightHoverInfo,
+	SeverityHint: config.HighlightHoverHint,
 }

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -11,6 +11,7 @@ type VimConfig struct {
 	QuickfixAutoDiagnostics                      *int
 	QuickfixSigns                                *int
 	HighlightDiagnostics                         *int
+	HoverDiagnostics                             *int
 	CompletionDeepCompletions                    *int
 	CompletionMatcher                            *config.CompletionMatcher
 	Staticcheck                                  *int
@@ -27,6 +28,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		QuickfixSigns:             boolVal(c.QuickfixSigns, d.QuickfixSigns),
 		QuickfixAutoDiagnostics:   boolVal(c.QuickfixAutoDiagnostics, d.QuickfixAutoDiagnostics),
 		HighlightDiagnostics:      boolVal(c.HighlightDiagnostics, d.HighlightDiagnostics),
+		HoverDiagnostics:          boolVal(c.HoverDiagnostics, d.HoverDiagnostics),
 		CompletionDeepCompletions: boolVal(c.CompletionDeepCompletions, d.CompletionDeepCompletions),
 		CompletionMatcher:         c.CompletionMatcher,
 		Staticcheck:               boolVal(c.Staticcheck, d.Staticcheck),

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -225,6 +225,7 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 			QuickfixSigns:           vimconfig.BoolVal(true),
 			Staticcheck:             vimconfig.BoolVal(false),
 			HighlightDiagnostics:    vimconfig.BoolVal(true),
+			HoverDiagnostics:        vimconfig.BoolVal(true),
 		}
 	}
 	// Overlay the initial user values on the defaults
@@ -449,9 +450,11 @@ func (g *govimplugin) Shutdown() error {
 }
 
 func (g *govimplugin) defineHighlights() {
-	warnColor := 166 // Orange
+	warnColor := 166    // Orange
+	diagSrcColor := 245 // Grey #8a8a8a
 	if vimColors, err := strconv.Atoi(g.ParseString(g.ChannelExpr(`&t_Co`))); err != nil || vimColors < 256 {
-		warnColor = 3 // Yellow, fallback when the terminal doesn't support at least 256 colors
+		warnColor = 3    // Yellow, fallback when the terminal doesn't support at least 256 colors
+		diagSrcColor = 7 // Silver
 	}
 	g.vimstate.BatchStart()
 	for _, hi := range []string{
@@ -464,6 +467,13 @@ func (g *govimplugin) defineHighlights() {
 		fmt.Sprintf("highlight default %s ctermfg=15 ctermbg=%d guisp=Orange guifg=Orange", config.HighlightSignWarn, warnColor),
 		fmt.Sprintf("highlight default %s ctermfg=15 ctermbg=6 guisp=Cyan guifg=Cyan", config.HighlightSignInfo),
 		fmt.Sprintf("highlight default link %s %s", config.HighlightSignHint, config.HighlightSignInfo),
+
+		fmt.Sprintf("highlight default %s cterm=bold gui=bold ctermfg=1", config.HighlightHoverErr),
+		fmt.Sprintf("highlight default %s cterm=bold gui=bold ctermfg=%d", config.HighlightHoverWarn, warnColor),
+		fmt.Sprintf("highlight default %s cterm=bold gui=bold ctermfg=6", config.HighlightHoverInfo),
+		fmt.Sprintf("highlight default link %s %s", config.HighlightHoverHint, config.HighlightHoverInfo),
+
+		fmt.Sprintf("highlight default %s cterm=none gui=italic ctermfg=%d guifg=#8a8a8a", config.HighlightHoverDiagSrc, diagSrcColor),
 	} {
 		g.vimstate.BatchChannelCall("execute", hi)
 	}

--- a/cmd/govim/testdata/scenario_default/function_hover.txt
+++ b/cmd/govim/testdata/scenario_default/function_hover.txt
@@ -2,11 +2,52 @@
 
 [!vim] [!gvim] skip 'Test only known to work in Vim and GVim'
 
+# Docs as popup content
 vim ex 'e main.go'
 vim ex 'call cursor(6,6)'
 vim expr 'GOVIMHover()'
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout popup.golden
+! stderr .+
+
+
+# Single warning (unreachable code) + docs as popup content
+vim call append '[5,"\treturn"]'
+vim ex 'call feedkeys(\"\\<CursorHold>\", \"xt\")'
+vimexprwait warning.golden getqflist()
+vim expr 'GOVIMHover()'
+vim -stringout expr 'GOVIM_internal_DumpPopups()'
+cmp stdout warning_popup.golden
+! stderr .+
+
+
+# Two warnings (unreachable code + formatting directive %v) + docs
+vim ex '7s/Hello, world/%v/'
+vim ex 'call cursor(7,8)'
+vimexprwait warnings.golden getqflist()
+vim expr 'GOVIMHover()'
+vim -stringout expr 'GOVIM_internal_DumpPopups()'
+cmp stdout warnings_popup.golden
+! stderr .+
+
+
+# Two warnings, no docs
+vim ex 'call cursor(7,17)'
+vim expr 'GOVIMHover()'
+vim -stringout expr 'GOVIM_internal_DumpPopups()'
+cmp stdout warnings_nodoc_popup.golden
+! stderr .+
+
+
+# Error (compile error) as content content
+vim ex 'call cursor(6,1)'
+vim ex 'normal dd'
+vim ex 'call cursor(6,7)'
+vim ex 'normal x'
+vimexprwait error.golden getqflist()
+vim expr 'GOVIMHover()'
+vim -stringout expr 'GOVIM_internal_DumpPopups()'
+cmp stdout error_popup.golden
 ! stderr .+
 
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -29,3 +70,78 @@ func fmt.Println(a ...interface{}) (n int, err error)
 Println formats using the default formats for its operands and writes to standard output.
 Spaces are always added between operands and a newline is appended.
 It returns the number of bytes written and any write error encountered.
+-- warning_popup.golden --
+unreachable code unreachable
+func fmt.Println(a ...interface{}) (n int, err error)
+Println formats using the default formats for its operands and writes to standard output.
+Spaces are always added between operands and a newline is appended.
+It returns the number of bytes written and any write error encountered.
+-- warnings_popup.golden --
+Println call has possible formatting directive %v printf
+unreachable code unreachable
+func fmt.Println(a ...interface{}) (n int, err error)
+Println formats using the default formats for its operands and writes to standard output.
+Spaces are always added between operands and a newline is appended.
+It returns the number of bytes written and any write error encountered.
+-- warnings_nodoc_popup.golden --
+Println call has possible formatting directive %v printf
+unreachable code unreachable
+-- error_popup.golden --
+Pintln not declared by package fmt compiler
+-- warning.golden --
+[
+  {
+    "bufnr": 1,
+    "col": 2,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "unreachable code",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- warnings.golden --
+[
+  {
+    "bufnr": 1,
+    "col": 2,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Println call has possible formatting directive %v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufnr": 1,
+    "col": 2,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "unreachable code",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- error.golden --
+[
+  {
+    "bufnr": 1,
+    "col": 6,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Pintln not declared by package fmt",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]


### PR DESCRIPTION
When using the hover feature, either via keyboard or mouse, any
diagnostics with a range that covers the current position will
be added at the top of popup.

The diagnostics are formatted using text properties, and as a
consequence of this there are a few new highlight groups defined:

* GOVIMHoverErr
* GOVIMHoverWarn
* GOVIMHoverInfo
* GOVIMHoverHint

The diagnostic line also includes the diagnostic source (as
provided by gopls, e.g. "compiler", "printf", "unreachable").
To be able to format the source there is another highlight group
used for the source part:

* GOVIMHoverDiagSrc

All text properties are combined with existing syntax highlight
to enable a wide range of custom styles.

The feature is enabled by default, and can be disabled by setting
the config HoverDiagnostics to 0 (false).

Closes #468 