### PR TITLE
cmd/govim: leaving userbusy always updates text property highlighs

### DIFF
--- a/cmd/govim/buffer_events.go
+++ b/cmd/govim/buffer_events.go
@@ -34,7 +34,7 @@ func (v *vimstate) bufReadPost(args ...json.RawMessage) error {
 		// We shouldn't increase version in that case, but we have to redefine highlights
 		// since text properties are removed when a buffer is unloaded.
 		if bytes.Equal(nb.Contents(), cb.Contents()) {
-			if err := v.redefineHighlights(v.diagnostics()); err != nil {
+			if err := v.redefineHighlights(v.diagnostics(), true); err != nil {
 				v.Logf("failed to update highlights for buffer %d: %v", nb.Num, err)
 			}
 			return nil
@@ -61,7 +61,7 @@ func (v *vimstate) bufReadPost(args ...json.RawMessage) error {
 		v.Logf("failed to update signs for buffer %d: %v", nb.Num, err)
 	}
 
-	if err := v.redefineHighlights(v.diagnostics()); err != nil {
+	if err := v.redefineHighlights(v.diagnostics(), true); err != nil {
 		v.Logf("failed to update highlights for buffer %d: %v", nb.Num, err)
 	}
 

--- a/cmd/govim/diagnostics.go
+++ b/cmd/govim/diagnostics.go
@@ -94,7 +94,7 @@ func (v *vimstate) handleDiagnosticsChanged() error {
 		v.Logf("redefineDiagnostics: failed to place/remove signs: %v", err)
 	}
 
-	if err := v.redefineHighlights(diags); err != nil {
+	if err := v.redefineHighlights(diags, false); err != nil {
 		v.Logf("redefineDiagnostics: failed to apply highlights: %v", err)
 	}
 	return nil

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -179,6 +179,7 @@ func (g *govimplugin) PublishDiagnostics(ctxt context.Context, params *protocol.
 	g.diagnosticsChanged = true
 	g.diagnosticsChangedQuickfix = true
 	g.diagnosticsChangedSigns = true
+	g.diagnosticsChangedHighlights = true
 	g.diagnosticsChangedLock.Unlock()
 	if !ok {
 		if len(params.Diagnostics) == 0 {

--- a/cmd/govim/highlight.go
+++ b/cmd/govim/highlight.go
@@ -35,8 +35,15 @@ func (v *vimstate) textpropDefine() error {
 	return nil
 }
 
-func (v *vimstate) redefineHighlights(diags []types.Diagnostic) error {
-	if v.config.HighlightDiagnostics == nil || !*v.config.HighlightDiagnostics {
+func (v *vimstate) redefineHighlights(diags []types.Diagnostic, force bool) error {
+	if !force && (v.config.HighlightDiagnostics == nil || !*v.config.HighlightDiagnostics) {
+		return nil
+	}
+	v.diagnosticsChangedLock.Lock()
+	work := v.diagnosticsChangedHighlights
+	v.diagnosticsChangedHighlights = false
+	v.diagnosticsChangedLock.Unlock()
+	if !force && !work {
 		return nil
 	}
 

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -178,8 +178,8 @@ type govimplugin struct {
 	modWatcher *modWatcher
 
 	// diagnosticsChangedLock protects access to rawDiagnostics,
-	// diagnosticsChanged, diagnosticsChangedQuickfix and
-	// diagnosticsChangedSigns
+	// diagnosticsChanged, diagnosticsChangedQuickfix,
+	// diagnosticsChangedSigns and diagnosticsChangedHighlights
 	diagnosticsChangedLock sync.Mutex
 
 	// rawDiagnostics holds the current raw (LSP) diagnostics by URI
@@ -195,6 +195,10 @@ type govimplugin struct {
 	// diagnosticsChangedSigns indicates that the quickfix window needs to be updated with
 	// the latest diagnostics
 	diagnosticsChangedSigns bool
+
+	// diagnosticsChangedHighlights indicates that the text properties needs to be updated with
+	// the latest diagnostics
+	diagnosticsChangedHighlights bool
 
 	// diagnosticsCache isn't inteded to be used directly since it might
 	// contain old data. Call diagnostics() to get the latest instead.

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -113,9 +113,9 @@ func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {
 	if !vimconfig.EqualBool(v.config.HighlightDiagnostics, preConfig.HighlightDiagnostics) {
 		if v.config.HighlightDiagnostics == nil || !*v.config.HighlightDiagnostics {
 			// HighlightDiagnostics is now not on - remove existing text properties
-			v.redefineHighlights([]types.Diagnostic{})
+			v.redefineHighlights([]types.Diagnostic{}, true)
 		} else {
-			if err := v.redefineHighlights(v.diagnostics()); err != nil {
+			if err := v.redefineHighlights(v.diagnostics(), true); err != nil {
 				return nil, fmt.Errorf("failed to update diagnostic highlights: %v", err)
 			}
 		}


### PR DESCRIPTION
The diagnostic highlights were always updated when leaving userbusy.
If the buffer changed since the last diagnostic received from gopls,
we might end up with a buffer that doesn't contain the lines/cols
where we try to place text properties. That did thrown an error.

This fix adds the same logic that exists for other diagnostic
features, so that leaving userbusy only triggers text property
placment if there are new diagnostics.