### PR TITLE
cmd/govim: ensure that GOPATH is in a hidden directory

### DIFF
--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -117,6 +117,7 @@ func TestScripts(t *testing.T) {
 						"GOPROXY="+proxy.URL,
 						"GONOSUMDB=*",
 						"HOME="+home,
+						"GOPATH="+filepath.Join(home, "gopath"),
 						"PLUGIN_PATH="+govimPath,
 					)
 					if workdir != "" {


### PR DESCRIPTION
In testscript tests, Vim is opened with a working directory of the
workdir. This means that the govim file watcher is watching every file
beneath that directory (every file not hidden, that is).

GOPATH is currently $WORK/gopath which means that the govim file watcher
will, incorrectly, be spotting .go files that change within the module
cache.

Fix this be explicitly putting GOPATH within $HOME which is already
defined as $WORK/.home