### PR TITLE
cmd/govim: skip flakey test for GVim v8.1.1711

### DIFF
--- a/cmd/govim/testdata/scenario_goimports_local/existing_import.txt
+++ b/cmd/govim/testdata/scenario_goimports_local/existing_import.txt
@@ -1,5 +1,7 @@
 # Test that GoImportsLocalPrefix works for existing imports
 
+[gvim:v8.1.1711] skip 'Known to be flake with GVim v8.1.1711'
+
 # Verify that new imports get correctly placed
 go mod download
 vim ex 'e main.go'


### PR DESCRIPTION
Per https://github.com/vim/vim/issues/5507#issuecomment-576825067,
scenario_goimports_local/existing_import.txt is known to be flakey for
GVim v8.1.1711. Whilst we understand the underlying reason in that
thread, we choose to skip this test on the understanding the flake is
related to a Vim bug of some sort.