### PR TITLE
ci: notify when the master build goes green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
   email:
     recipients:
       - govim-dev+ci@googlegroups.com
-    on_success: never
+    on_success: change
     on_failure: always
 
 branches:

--- a/_scripts/genconfig.go
+++ b/_scripts/genconfig.go
@@ -223,7 +223,7 @@ notifications:
   email:
     recipients:
       - govim-dev+ci@googlegroups.com
-    on_success: never
+    on_success: change
     on_failure: always
 
 branches:


### PR DESCRIPTION
Currently we never notify for a green build on master. This isn't very
helpful because it means we don't get a notification when the build
passes having previously failed, i.e. red -> green.

Fix that to notify on change.