### PR TITLE
cmd/govim: skip empty text edits

### DIFF
--- a/cmd/govim/testdata/scenario_bugs/bug_govim_688.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_govim_688.txt
@@ -1,0 +1,27 @@
+# Test case that verifies we have a fix for github.com/govim/govim/issues/688
+
+vim ex 'e main.go'
+vim ex 'w'
+
+-- main.go --
+package main
+
+import (
+	"log"
+	"time"
+)
+
+func main() {
+    for {
+    time.Sleep(time.Second*5)
+
+	log.Println("History:")
+	for _, h := range []string{"a","b"} {
+		log.Printf("%s",h)
+		for i := range []int{} {
+			log.Printf("%v",i)
+		}
+	}
+}
+}
+

--- a/cmd/govim/textedit.go
+++ b/cmd/govim/textedit.go
@@ -38,6 +38,10 @@ func (v *vimstate) applyProtocolTextEdits(b *types.Buffer, edits []protocol.Text
 		if err != nil {
 			return fmt.Errorf("failed to derive end point from position: %v", err)
 		}
+		// Skip empty edits
+		if start == end && e.NewText == "" {
+			continue
+		}
 		// special case deleting of complete lines
 		if start.Col() == 1 && end.Col() == 1 && e.NewText == "" {
 			delstart := min(start.Line(), len(blines))


### PR DESCRIPTION
Add a test to ensure (at least against the current behaviour of gopls)
we don't regress here.

Fixes #688