### PR TITLE
cmd/govim: fix a rogue use of getqflist in a testscript test

### DIFF
--- a/cmd/govim/testdata/scenario_tempmodfile/modfile_changes.txt
+++ b/cmd/govim/testdata/scenario_tempmodfile/modfile_changes.txt
@@ -16,7 +16,7 @@ sleep $GOVIM_ERRLOGMATCH_WAIT
 cmp go.mod go.mod.golden
 
 # Verify that we have no diagnostics for any files
-vimexprwait errors.empty getqflist()
+vimexprwait errors.empty GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103


### PR DESCRIPTION
Make sure we are consistent in our use of GOVIMTest_getqflist