### PR TITLE
cmd/govim: add tests for gopls features where files are initially empty

### DIFF
--- a/cmd/govim/testdata/scenario_completeunimported/complete_empty_file.txt
+++ b/cmd/govim/testdata/scenario_completeunimported/complete_empty_file.txt
@@ -1,0 +1,41 @@
+# Test that completing of unimported std library packages works for where
+# files on disk are initially empty
+
+# Setup new buffer and verify contents are as expected
+vim ex 'e main.go'
+vim ex 'r main.go.orig | 0d_'
+vim ex 'noau w! check'
+cmp check main.go.orig
+
+# Unimported completion
+vim ex 'call cursor(4,1)'
+vim normal Sfmt.Pr
+vim ex 'execute \"normal A\\<C-X>\\<C-O>\\<C-N>\\<C-N>(\\\"Hello\\\")\"'
+
+# Check import has been added
+vim ex 'noau w'
+cmp main.go main.go1.golden
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+-- main.go.orig --
+package main
+
+func main() {
+
+}
+-- main.go1.golden --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello")
+}

--- a/cmd/govim/testdata/scenario_default/format_on_save_empty_original_file.txt
+++ b/cmd/govim/testdata/scenario_default/format_on_save_empty_original_file.txt
@@ -1,4 +1,4 @@
-# Test format on save for a file that does not initially exist on disk
+# Test format on save for a file that is initially empty
 
 vim ex 'e main.go'
 vim ex 'r main.txt | 0d_'
@@ -13,6 +13,7 @@ cmp main.go main.txt
 module mod.com
 
 go 1.12
+-- main.go --
 -- main.txt --
 package main
 

--- a/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
@@ -1,0 +1,131 @@
+# Test that we get diagnostics for when there are empty files on disk but
+# in the editor we fill in the content.
+#
+# The scenario involves creating a package p with a simple function DoIt. p is
+# imported by a main package. p also has a test file that exercises DoIt, and
+# an external test file that does the same.
+#
+# Initially all call sites for DoIt incorrectly pass an integer argument,
+# meaning we should have error diagnostics for all call sites. Then we correct
+# the definition of DoIt to take an integer argument at which point all
+# diagnostics should disappear.
+
+# Create all the new files
+vim ex 'e p/p.go'
+vim ex 'r p/p.go.orig | 0d_'
+vim ex 'noau w! check'
+cmp check p/p.go.orig
+vim ex 'sp main.go'
+vim ex 'r main.go.orig | 0d_'
+vim ex 'noau w! check'
+cmp check main.go.orig
+vim ex 'sp p/p_test.go'
+vim ex 'r p/p_test.go.orig | 0d_'
+vim ex 'noau w! check'
+cmp check p/p_test.go.orig
+vim ex 'sp p/x_test.go'
+vim ex 'r p/x_test.go.orig | 0d_'
+vim ex 'noau w! check'
+cmp check p/x_test.go.orig
+
+# Expect the errors
+vimexprwait errors.golden GOVIMTest_getqflist()
+
+# Change p.DoIt to accept an integer
+vim ex 'sp p/p.go'
+vim ex 'call setline(3, \"func DoIt(i int) {}\")'
+vim ex 'noau w! check'
+cmp check p/p.go.new
+
+# Expect no errors
+vimexprwait errors.empty GOVIMTest_getqflist()
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+-- main.go.orig --
+package main
+
+import "mod.com/p"
+
+func main() {
+	p.DoIt(5)
+}
+-- p/p.go --
+-- p/p.go.orig --
+package p
+
+func DoIt(s string) {}
+-- p/p.go.new --
+package p
+
+func DoIt(i int) {}
+-- p/p_test.go --
+-- p/p_test.go.orig --
+package p
+
+import "testing"
+
+func TestDoIt(t *testing.T) {
+	DoIt(5)
+}
+-- p/x_test.go --
+-- p/x_test.go.orig --
+package p_test
+
+import (
+	"testing"
+
+	"mod.com/p"
+)
+
+func TestDoIt(t *testing.T) {
+	p.DoIt(5)
+}
+-- errors.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 9,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot convert 5 (untyped int constant) to string",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "p/p_test.go",
+    "col": 7,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot convert 5 (untyped int constant) to string",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "p/x_test.go",
+    "col": 9,
+    "lnum": 10,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot convert 5 (untyped int constant) to string",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.empty --
+[]


### PR DESCRIPTION
We have a number of tests that check gopls behaviour where files do not
exist on disk, i.e. they are just buffers in memory. But we are missing
tests to verify that if .go files on disk are empty and then "filled in"
by changes in the editor, that things work as expected.

Add some tests of that sort.