### PR TITLE
cmd/govim: add go-to-def tests for std lib and module cache definitions

### DIFF
--- a/cmd/govim/testdata/scenario_default/go_to_def_module_cache.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_module_cache.txt
@@ -1,0 +1,37 @@
+# Test that GOVIMGoToDef works jumping to a definition within
+# the module cache
+
+# More natural to split below and to the right
+vim ex 'set splitbelow'
+vim ex 'set splitright'
+
+# Definition in same file
+vim ex 'e '$WORK/p.go
+vim ex 'call cursor(5,18)'
+vim ex 'GOVIMGoToDef'
+vim expr 'bufname(\"\")'
+stdout '^\Q"'$WORK'/.home/gopath/pkg/mod/example.com/blah@v1.0.0/main.go"\E$'
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '^\Q[3,7]\E$'
+vim ex 'GOVIMGoToPrevDef'
+vim expr 'bufname(\"\")'
+stdout '^\Q"'$WORK'/p.go"\E$'
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '^\Q[5,18]\E$'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+
+require example.com/blah v1.0.0
+-- p.go --
+package p
+
+import "example.com/blah"
+
+const sink = blah.Name

--- a/cmd/govim/testdata/scenario_default/go_to_def_std_lib.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_std_lib.txt
@@ -1,0 +1,37 @@
+# Test that GOVIMGoToDef works jumping to a standard library definition
+
+# More natural to split below and to the right
+vim ex 'set splitbelow'
+vim ex 'set splitright'
+
+# Definition in same file
+vim ex 'e '$WORK/p.go
+vim ex 'call cursor(5,18)'
+vim ex 'GOVIMGoToDef'
+vim expr 'bufname(\"\")'
+
+# Check that we end up somewhere in GOROOT/src/time
+stdout '^\Q"'$GOROOT'/src/time/'
+
+# Now jump back and check we are where we started
+vim ex 'GOVIMGoToPrevDef'
+vim expr 'bufname(\"\")'
+stdout '^\Q"'$WORK'/p.go"\E$'
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '^\Q[5,18]\E$'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+
+-- p.go --
+package p
+
+import "time"
+
+const sink = time.Kitchen


### PR DESCRIPTION
Extend our suite of go-to-def tests by adding two new tests that jump to
standard library and module cache definitions.