### PR TITLE
cmd/govim: add completion tests for std lib and module cache definitions

### DIFF
--- a/cmd/govim/testdata/scenario_default/complete_module_cache.txt
+++ b/cmd/govim/testdata/scenario_default/complete_module_cache.txt
@@ -1,0 +1,42 @@
+# Test that ominfunc complete works for a definition with the module cache
+
+vim ex 'e main.go'
+vim ex 'call cursor(10,21)'
+vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<ESC>\", \"xt\")'
+vim ex 'w'
+cmp main.go main.go.golden
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+
+require example.com/blah v1.0.0
+-- main.go --
+package main
+
+import (
+	"fmt"
+
+	"example.com/blah"
+)
+
+func main() {
+	fmt.Println(blah.Na)
+}
+-- main.go.golden --
+package main
+
+import (
+	"fmt"
+
+	"example.com/blah"
+)
+
+func main() {
+	fmt.Println(blah.Name)
+}

--- a/cmd/govim/testdata/scenario_default/complete_std_lib.txt
+++ b/cmd/govim/testdata/scenario_default/complete_std_lib.txt
@@ -1,0 +1,38 @@
+# Test that ominfunc complete works for standard library definitions.
+
+vim ex 'e main.go'
+vim ex 'call cursor(9,22)'
+vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<ESC>\", \"xt\")'
+vim ex 'w'
+cmp main.go main.go.golden
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	fmt.Println(time.Kit)
+}
+-- main.go.golden --
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	fmt.Println(time.Kitchen)
+}


### PR DESCRIPTION
Extend our suite of completion tests by adding two new tests that
complete standard library and module cache definitions.