### PR TITLE
cmd/govim: Ensure text prop highlights aren't placed when disabled

### DIFF
--- a/cmd/govim/highlight.go
+++ b/cmd/govim/highlight.go
@@ -51,7 +51,7 @@ func (v *vimstate) textpropDefine() error {
 }
 
 func (v *vimstate) redefineHighlights(diags []types.Diagnostic, force bool) error {
-	if !force && (v.config.HighlightDiagnostics == nil || !*v.config.HighlightDiagnostics) {
+	if v.config.HighlightDiagnostics == nil || !*v.config.HighlightDiagnostics {
 		return nil
 	}
 	v.diagnosticsChangedLock.Lock()


### PR DESCRIPTION
The config HighlightDiagnostics can be used to disable in-code
highlights. PR #700 accidently broke that feature so that it was
possible to get highlights even when disabled.

This PR ensures that text prop highlights aren't placed when they
are disabled by the config.

Fixes #724