### PR TITLE
cmd/govim: extract text property removal to own func

### DIFF
--- a/cmd/govim/internal/types/types.go
+++ b/cmd/govim/internal/types/types.go
@@ -290,3 +290,10 @@ var SeverityHoverHighlight = map[Severity]config.Highlight{
 	SeverityInfo: config.HighlightHoverInfo,
 	SeverityHint: config.HighlightHoverHint,
 }
+
+// TextPropID is the govim internal mapping of ID used when adding/removing text properties
+type TextPropID int
+
+const (
+	DiagnosticTextPropID = 0
+)


### PR DESCRIPTION
This change extracts text property removal to it's own func.

It acts as gardening for implementing references highlights where we'll
start using another text property ID, and therefore it is added as an
internal type.