### PR TITLE
tests: add testscript condition for issues

### DIFF
--- a/cmd/govim/testdata/scenario_completeunimported/complete_new_file.txt
+++ b/cmd/govim/testdata/scenario_completeunimported/complete_new_file.txt
@@ -1,7 +1,7 @@
 # Test that completing of unimported std library packages works for new files
 # that are not saved to disk.
 
-skip 'Pending fix for golang.org/issues/36671'
+[golang.org/issues/36671] skip
 
 # Setup new buffer and verify contents are as expected
 vim ex 'e main.go'

--- a/cmd/govim/testdata/scenario_default/quickfix_new_files.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_new_files.txt
@@ -9,7 +9,7 @@
 # the definition of DoIt to take an integer argument at which point all
 # diagnostics should disappear.
 
-skip 'Pending fix for golang.org/issues/36661'
+[golang.org/issues/36661] skip
 
 # Create all the new files
 vim ex 'e p/p.go'

--- a/cmd/govim/testdata/scenario_default/rename.txt
+++ b/cmd/govim/testdata/scenario_default/rename.txt
@@ -8,7 +8,7 @@ vim ex 'silent noautocmd wall'
 cmp main.go main.go.banana
 cmp other.go other.go.banana
 
-skip 'Pending a fix for golang.org/issues/36743'
+[golang.org/issues/36743] skip
 
 # Rename of an identifier in another package
 vim ex 'call cursor(14,16)'

--- a/cmd/govim/testdata/scenario_modfile/go_local_mod.txt
+++ b/cmd/govim/testdata/scenario_modfile/go_local_mod.txt
@@ -1,8 +1,6 @@
 # Test that calling govim#config#Set with a value for GoplsEnv of
 # GOFLAGS=-modfile=go.local.mod does the right thing
 
-# skip 'Pending fix for golang.org/issues/36789'
-
 [!go1.14] skip 'Use of -modfile requires Go 1.14'
 
 # Open file, save (which will trigger goimports) and verify that

--- a/cmd/govim/testdata/scenario_modreadonly/config_set_env_goflags_mod_readonly.txt
+++ b/cmd/govim/testdata/scenario_modreadonly/config_set_env_goflags_mod_readonly.txt
@@ -2,7 +2,7 @@
 # does the right thing. This will necessarily involve a number of checks
 # for the various build flags that can be set via GOFLAGS.
 
-skip 'Pending fix for golang.org/issues/36789'
+[golang.org/issues/36789] skip
 
 [short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'
 

--- a/testsetup/testsetup.go
+++ b/testsetup/testsetup.go
@@ -24,6 +24,12 @@ const (
 	EnvTestscriptWorkdirRoot = "GOVIM_TESTSCRIPT_WORKDIR_ROOT"
 	EnvErrLogMatchWait       = "GOVIM_ERRLOGMATCH_WAIT"
 	EnvDetectUserBusy        = "GOVIM_DETECT_USER_BUSY"
+
+	// EnvTestscriptIssues can be set to a regular expression which
+	// causes issue tracker conditions not to be satisfied. e.g.
+	// GOVIM_TESTSCRIPT_ISSUES=. will cause all issue tracker conditions
+	// (e.g. [golang.org/issues/1234]) to not be satisfied.
+	EnvTestscriptIssues = "GOVIM_TESTSCRIPT_ISSUES"
 )
 
 // user environment variables


### PR DESCRIPTION
Some of our testscript tests are skipped because they are dependent on
fixes for issues that remain open, i.e. the fixes have not landed. We
try to annotate this skips with an appropriately structured comment,
e.g.:

    skip 'Pending fix for golang.org/issues/36789'

However, this approach makes it hard to not skip the test when you are
looking to verify a fix. We end up having to suggest a sed command (or
similar) to remove/comment out the skip.

Instead we now provide a custom testscript condition that allows issue
tracker links as the condition itself, e.g.

    [golang.org/issues/36789] skip
    [github.com/govim/govim/issues/1234] skip

This means we retain the structure and linkage of the current approach.

Such a condition is always satisfied unless the the
GOVIM_TESTSCRIPT_ISSUES environment variable is a regular expression
that matches the condition in question. For example:

    GOVIM_TESTSCRIPT_ISSUES=.

will cause all issue tracker conditions not to be satsfied, i.e. we
don't skip any tests.