### PR TITLE
tests: add testsetup.RaceSlowndownFactor

### DIFF
--- a/_scripts/dockerRun.sh
+++ b/_scripts/dockerRun.sh
@@ -76,11 +76,11 @@ export GOVIM_RUN_INSTALL_TESTSCRIPTS=true
 export GOVIM_GOPLS_VERBOSE_OUTPUT=true
 
 go generate $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
-go test $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
+go run ./internal/cmd/dots go test $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
 
 if [[ "$runRace" == "true" ]]
 then
-	go test -race $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
+	go run ./internal/cmd/dots go test -race -timeout 0s $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
 fi
 
 go vet $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')

--- a/internal/cmd/dots/dots.go
+++ b/internal/cmd/dots/dots.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"time"
+)
+
+var (
+	fTickInternal = flag.String("tick", "1m", "How often to output a 'tick'")
+)
+
+func main() {
+	os.Exit(main1())
+}
+
+func main1() int {
+	if err := mainerr(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func mainerr() error {
+	flag.Parse()
+	tickInterval, err := time.ParseDuration(*fTickInternal)
+	if err != nil {
+		return fmt.Errorf("failed to parse tick interval %q: %v", *fTickInternal, err)
+	}
+	args := flag.Args()
+	if len(args) == 0 {
+		return fmt.Errorf("need a command")
+	}
+	done := make(chan struct{})
+	progressDone := make(chan struct{})
+	var wrote bool
+	go func() {
+		tick := time.NewTicker(tickInterval)
+	Progress:
+		for {
+			select {
+			case <-tick.C:
+				fmt.Printf(".")
+				wrote = true
+			case <-done:
+				break Progress
+			}
+		}
+		tick.Stop()
+		close(progressDone)
+	}()
+	cmd := exec.Command(args[0], args[1:]...)
+	out, err := cmd.CombinedOutput()
+	close(done)
+	<-progressDone
+	if wrote {
+		fmt.Println("")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to run %v: %v\n%s", strings.Join(cmd.Args, " "), err, out)
+	}
+	fmt.Printf("%s", out)
+	return nil
+}

--- a/testdriver/testdriver.go
+++ b/testdriver/testdriver.go
@@ -53,13 +53,14 @@ var (
 func init() {
 	v := os.Getenv(testsetup.EnvErrLogMatchWait)
 	if v == "" {
-		DefaultErrLogMatchWait = "30s"
-	} else {
-		if _, err := time.ParseDuration(v); err != nil {
-			panic(fmt.Errorf("failed to parse duration %q from %v: %v", v, testsetup.EnvErrLogMatchWait, err))
-		}
-		DefaultErrLogMatchWait = v
+		v = "30s"
 	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		panic(fmt.Errorf("failed to parse duration %q from %v: %v", v, testsetup.EnvErrLogMatchWait, err))
+	}
+	d = time.Duration(testsetup.RaceSlowndown(d))
+	DefaultErrLogMatchWait = fmt.Sprintf("%v", d)
 }
 
 // TODO - this code is a mess and needs to be fixed

--- a/testsetup/norace.go
+++ b/testsetup/norace.go
@@ -2,6 +2,12 @@
 
 package testsetup
 
+import "time"
+
 func RaceOrNot() string {
 	return ""
+}
+
+func RaceSlowndown(v time.Duration) time.Duration {
+	return v
 }

--- a/testsetup/race.go
+++ b/testsetup/race.go
@@ -2,6 +2,25 @@
 
 package testsetup
 
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+)
+
 func RaceOrNot() string {
 	return "-race"
+}
+
+func RaceSlowndown(v time.Duration) time.Duration {
+	r := big.NewRat(1, 1)
+	if v := os.Getenv(EnvTestRaceSlowdown); v != "" {
+		if _, ok := r.SetString(v); !ok {
+			// Because r is undefined if SetString fails
+			panic(fmt.Errorf("%v=%q is not a valid floating point value", EnvTestRaceSlowdown, v))
+		}
+	}
+	r.Mul(r, big.NewRat(int64(v), 1))
+	return time.Duration(r.Num().Int64() / r.Denom().Int64())
 }

--- a/testsetup/testsetup.go
+++ b/testsetup/testsetup.go
@@ -30,6 +30,10 @@ const (
 	// GOVIM_TESTSCRIPT_ISSUES=. will cause all issue tracker conditions
 	// (e.g. [golang.org/issues/1234]) to not be satisfied.
 	EnvTestscriptIssues = "GOVIM_TESTSCRIPT_ISSUES"
+
+	// EnvTestRaceSlowdown is a floating point factor by which to adjust
+	// EnvErrLogMatchWait for race tests
+	EnvTestRaceSlowdown = "GOVIM_TEST_RACE_SLOWDOWN"
 )
 
 // user environment variables


### PR DESCRIPTION
When we run tests under race mode, all timings are slowed by some
factor. This means that tests which sleep in order to ensure, for
example, that no diagnostics are received, potentially have a higher
chance of passing with false negatives, i.e. they stop looking for
diagnostics too early.

Fix this by introducing a race slowdown factor which we set initially as
2.