### PR TITLE
cmd/govim: add reference highlighting when user goes idle

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -68,6 +68,10 @@ function! s:validHighlightDiagnostics(v)
     return s:validBool(a:v)
 endfunction
 
+function! s:validHighlightReferences(v)
+    return s:validBool(a:v)
+endfunction
+
 function! s:validHoverDiagnostics(v)
     return s:validBool(a:v)
 endfunction
@@ -141,6 +145,7 @@ let s:validators = {
       \ "CompletionMatcher": function("s:validCompletionMatcher"),
       \ "QuickfixSigns": function("s:validQuickfixSigns"),
       \ "HighlightDiagnostics": function("s:validHighlightDiagnostics"),
+      \ "HighlightReferences": function("s:validHighlightReferences"),
       \ "HoverDiagnostics": function("s:validHoverDiagnostics"),
       \ "Staticcheck": function("s:validStaticcheck"),
       \ "CompleteUnimported": function("s:validCompleteUnimported"),

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -62,6 +62,17 @@ type Config struct {
 	// Default: true
 	HighlightDiagnostics *bool `json:",omitempty"`
 
+	// HighlightReferences is a boolean (0 or 1 in VimScript) that controls
+	// whether references to what is currently under the cursor should be
+	// highlighted. When enabled, govim waits for updatetime (help updatetime)
+	// before adding text properties covering each reference.
+	//
+	// Override the vim highlight group GOVIMReferences to alter the text
+	// property style.
+	//
+	// Default: true
+	HighlightReferences *bool `json:",omitempty"`
+
 	// HoverDiagnostics is a boolean (0 or 1 in VimScript) that controls
 	// whether diagnostics should be shown in the hover popup. When enabled
 	// each diagnostic that covers the cursor/mouse position will be added
@@ -341,4 +352,7 @@ const (
 
 	// HighlightHoverDiagSrc is the group used to format the source part of a hover diagnostic
 	HighlightHoverDiagSrc Highlight = "GOVIMHoverDiagSrc"
+
+	// HighlightReferences is the group used to add text properties to references
+	HighlightReferences Highlight = "GOVIMReferences"
 )

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -13,6 +13,9 @@ func (r *Config) Apply(v *Config) {
 	if v.HighlightDiagnostics != nil {
 		r.HighlightDiagnostics = v.HighlightDiagnostics
 	}
+	if v.HighlightReferences != nil {
+		r.HighlightReferences = v.HighlightReferences
+	}
 	if v.HoverDiagnostics != nil {
 		r.HoverDiagnostics = v.HoverDiagnostics
 	}

--- a/cmd/govim/highlight.go
+++ b/cmd/govim/highlight.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/govim/govim"
 	"github.com/govim/govim/cmd/govim/config"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/types"
 )
 
+// propDict is the representation of arguments used in vim's prop_type_add()
 type propDict struct {
 	Highlight string `json:"highlight"`
 	Combine   bool   `json:"combine,omitempty"`
@@ -14,6 +18,22 @@ type propDict struct {
 	StartIncl bool   `json:"start_incl,omitempty"`
 	EndIncl   bool   `json:"end_incl,omitempty"`
 }
+
+// propAddDict is the representation of arguments used in vim's prop_add()
+type propAddDict struct {
+	Type    string `json:"type"`
+	ID      int    `json:"id"`
+	EndLine int    `json:"end_lnum"`
+	EndCol  int    `json:"end_col"` // Column just after the text
+	BufNr   int    `json:"bufnr"`
+}
+
+// assertPropAdd is used when we add text properties that might fail due to the fact
+// that the buffer might have changed since the text properties was calculated.
+// There are two vim errors that we like to suppress, invalid line and invalid column.
+var assertPropAdd AssertExpr = AssertIsErrorOrNil(
+	"^Vim(let):E964:", // Invalid column (col) passed to vim prop_add()
+	"^Vim(let):E966:") // Invalid line (lnum) passed to vim prop_add()
 
 func (v *vimstate) textpropDefine() error {
 	v.BatchStart()
@@ -38,6 +58,12 @@ func (v *vimstate) textpropDefine() error {
 	v.BatchChannelCall("prop_type_add", config.HighlightHoverDiagSrc, propDict{
 		Highlight: string(config.HighlightHoverDiagSrc),
 		Combine:   true, // Combine with syntax highlight
+		Priority:  types.SeverityPriority[types.SeverityErr] + 1,
+	})
+
+	v.BatchChannelCall("prop_type_add", config.HighlightReferences, propDict{
+		Highlight: string(config.HighlightReferences),
+		Combine:   true,
 		Priority:  types.SeverityPriority[types.SeverityErr] + 1,
 	})
 
@@ -83,21 +109,137 @@ func (v *vimstate) redefineHighlights(diags []types.Diagnostic, force bool) erro
 			return fmt.Errorf("failed to find highlight for severity %v", d.Severity)
 		}
 
-		v.BatchChannelCall("prop_add",
+		v.BatchAssertChannelCall(assertPropAdd, "prop_add",
 			d.Range.Start.Line(),
 			d.Range.Start.Col(),
-			struct {
-				Type    string `json:"type"`
-				EndLine int    `json:"end_lnum"`
-				EndCol  int    `json:"end_col"` // column just after the text
-				BufNr   int    `json:"bufnr"`
-			}{string(hi), d.Range.End.Line(), d.Range.End.Col(), d.Buf})
+			propAddDict{string(hi), types.DiagnosticTextPropID, d.Range.End.Line(), d.Range.End.Col(), d.Buf},
+		)
 	}
 
 	v.MustBatchEnd()
 	return nil
 }
 
+func (v *vimstate) updateReferenceHighlight(refresh bool) error {
+	if v.config.HighlightReferences == nil || !*v.config.HighlightReferences {
+		return nil
+	}
+	b, pos, err := v.cursorPos()
+	if err != nil {
+		return fmt.Errorf("failed to get current position: %v", err)
+	}
+
+	// refresh indicates if govim should call DocumentHighlight to refresh
+	// ranges from gopls since we want to refresh when the user goes idle,
+	// and remove highlights as soon as the user is busy. To prevent
+	// flickering we keep track of the current highlight ranges and avoid
+	// removing text properties if the cursor is still within all ranges.
+	if !refresh {
+		for i := range v.currentReferences {
+			if !pos.IsWithin(*v.currentReferences[i]) {
+				v.removeTextProps(types.ReferencesTextPropID)
+				return nil
+			}
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel any ongoing requests to make sure that we only process the
+	// latest response.
+	v.cancelDocHighlightLock.Lock()
+	if v.cancelDocHighlight != nil {
+		v.cancelDocHighlight()
+		v.cancelDocHighlight = nil
+	}
+	v.cancelDocHighlight = cancel
+	v.cancelDocHighlightLock.Unlock()
+
+	v.tomb.Go(func() error {
+		v.redefineReferenceHighlight(ctx, b, pos)
+		return nil
+	})
+
+	return nil
+}
+
+func (g *govimplugin) redefineReferenceHighlight(ctx context.Context, b *types.Buffer, cursorPos types.Point) {
+	res, err := g.server.DocumentHighlight(ctx,
+		&protocol.DocumentHighlightParams{
+			TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+				TextDocument: protocol.TextDocumentIdentifier{
+					URI: protocol.DocumentURI(b.URI()),
+				},
+				Position: cursorPos.ToPosition(),
+			},
+		},
+	)
+
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+	if err != nil {
+		g.Logf("documentHighlight call failed: %v", err)
+		return
+	}
+
+	g.Schedule(func(govim.Govim) error {
+		// If the context is cancelled, a new DocumentHighlight request has or will soon be sent and
+		// this one is no longer relevant so we just return here.
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		// Same thing about user busy. If the user start moving the cursor (typing or removing text
+		// for example), the results here are no longer relevant.
+		if g.vimstate.userBusy {
+			return nil
+		}
+
+		return g.vimstate.handleDocumentHighlight(b, cursorPos, res)
+	})
+}
+
+func (v *vimstate) handleDocumentHighlight(b *types.Buffer, cursorPos types.Point, res []protocol.DocumentHighlight) error {
+	if len(v.currentReferences) > 0 {
+		v.currentReferences = make([]*types.Range, 0)
+		v.removeTextProps(types.ReferencesTextPropID)
+	}
+
+	v.BatchStart()
+	defer v.BatchCancelIfNotEnded()
+	for i := range res {
+		start, err := types.PointFromPosition(b, res[i].Range.Start)
+		if err != nil {
+			v.Logf("failed to convert start position %v to point: %v", res[i].Range.Start, err)
+			return nil
+		}
+		end, err := types.PointFromPosition(b, res[i].Range.End)
+		if err != nil {
+			v.Logf("failed to convert end position %v to point: %v", res[i].Range.End, err)
+			return nil
+		}
+		r := types.Range{Start: start, End: end}
+		if cursorPos.IsWithin(r) {
+			v.currentReferences = append(v.currentReferences, &r)
+			continue // We don't want to highlight what is currently under the cursor
+		}
+		v.BatchAssertChannelCall(assertPropAdd, "prop_add",
+			start.Line(),
+			start.Col(),
+			propAddDict{string(config.HighlightReferences), types.ReferencesTextPropID, end.Line(), end.Col(), b.Num},
+		)
+	}
+	v.MustBatchEnd()
+	return nil
+}
+
+// removeTextProps is used to remove all added text properties with a specific ID, regardless
+// of configuration setting.
 func (v *vimstate) removeTextProps(id types.TextPropID) {
 	var didStart bool
 	if didStart = v.BatchStartIfNeeded(); didStart {

--- a/cmd/govim/internal/types/types.go
+++ b/cmd/govim/internal/types/types.go
@@ -296,4 +296,5 @@ type TextPropID int
 
 const (
 	DiagnosticTextPropID = 0
+	ReferencesTextPropID = 1
 )

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -11,6 +11,7 @@ type VimConfig struct {
 	QuickfixAutoDiagnostics                      *int
 	QuickfixSigns                                *int
 	HighlightDiagnostics                         *int
+	HighlightReferences                          *int
 	HoverDiagnostics                             *int
 	CompletionDeepCompletions                    *int
 	CompletionMatcher                            *config.CompletionMatcher
@@ -30,6 +31,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		QuickfixSigns:             boolVal(c.QuickfixSigns, d.QuickfixSigns),
 		QuickfixAutoDiagnostics:   boolVal(c.QuickfixAutoDiagnostics, d.QuickfixAutoDiagnostics),
 		HighlightDiagnostics:      boolVal(c.HighlightDiagnostics, d.HighlightDiagnostics),
+		HighlightReferences:       boolVal(c.HighlightReferences, d.HighlightReferences),
 		HoverDiagnostics:          boolVal(c.HoverDiagnostics, d.HoverDiagnostics),
 		CompletionDeepCompletions: boolVal(c.CompletionDeepCompletions, d.CompletionDeepCompletions),
 		CompletionMatcher:         c.CompletionMatcher,

--- a/cmd/govim/testdata/scenario_default/reference_highlight.txt
+++ b/cmd/govim/testdata/scenario_default/reference_highlight.txt
@@ -1,0 +1,127 @@
+# Tests that references to the identifier at the cursor is being highlighted when the user
+# goes idle. Since user idle detection is disabled in tests, GOVIM_internal_SetUserBusy()
+# is invoked directly.
+
+vim ex 'e main.go'
+
+# Placing the cursor on "foo" should highlight all other occations of foo
+vim ex 'call cursor(5,5)'
+vim ex 'call GOVIM_internal_SetUserBusy(1)'
+vim ex 'call GOVIM_internal_SetUserBusy(0)'
+vimexprwait foo_references.golden 'map(range(1,line(\"$\")), \"prop_list(v:val)\")'
+
+
+# Placing the cursor on "fmt" should highlight all other occations of fmt
+vim ex 'call cursor(9,2)'
+vim ex 'call GOVIM_internal_SetUserBusy(1)'
+vim ex 'call GOVIM_internal_SetUserBusy(0)'
+vim ex 'w'
+vimexprwait fmt_references.golden 'map(range(1,line(\"$\")), \"prop_list(v:val)\")'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+import "fmt"
+
+var foo = 1
+var bar = 2
+
+func main() {
+	fmt.Printf("This is a test %v\n", foo)
+	fmt.Printf("This is another test %v\n", foo)
+	fmt.Printf("This is also a test %v\n", foo)
+}
+
+-- foo_references.golden --
+[
+  [],
+  [],
+  [],
+  [],
+  [],
+  [],
+  [],
+  [],
+  [
+    {
+      "col": 36,
+      "end": 1,
+      "id": 1,
+      "length": 3,
+      "start": 1,
+      "type": "GOVIMReferences"
+    }
+  ],
+  [
+    {
+      "col": 42,
+      "end": 1,
+      "id": 1,
+      "length": 3,
+      "start": 1,
+      "type": "GOVIMReferences"
+    }
+  ],
+  [
+    {
+      "col": 41,
+      "end": 1,
+      "id": 1,
+      "length": 3,
+      "start": 1,
+      "type": "GOVIMReferences"
+    }
+  ],
+  [],
+  []
+]
+-- fmt_references.golden --
+[
+  [],
+  [],
+  [
+    {
+      "col": 8,
+      "end": 1,
+      "id": 1,
+      "length": 5,
+      "start": 1,
+      "type": "GOVIMReferences"
+    }
+  ],
+  [],
+  [],
+  [],
+  [],
+  [],
+  [],
+  [
+    {
+      "col": 2,
+      "end": 1,
+      "id": 1,
+      "length": 3,
+      "start": 1,
+      "type": "GOVIMReferences"
+    }
+  ],
+  [
+    {
+      "col": 2,
+      "end": 1,
+      "id": 1,
+      "length": 3,
+      "start": 1,
+      "type": "GOVIMReferences"
+    }
+  ],
+  []
+]


### PR DESCRIPTION
This change adds reference highlighting of the thing under the cursor,
when the user goes idle. As soon as the user goes idle, it will send a
documentHighlight request to gopls, and add a text property according to
the response.

To alter style/format, override the highlight group GOVIMReferences with
your prefered highlight setting.