### PR TITLE
deps: upgrade x/tools and gopls to 2f3ba24b

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/packages"
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/telemetry"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/packagesinternal"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
@@ -40,6 +39,7 @@ type metadata struct {
 
 func (s *snapshot) load(ctx context.Context, scopes ...interface{}) ([]*metadata, error) {
 	var query []string
+	var containsDir bool // for logging
 	for _, scope := range scopes {
 		switch scope := scope.(type) {
 		case packagePath:
@@ -70,6 +70,10 @@ func (s *snapshot) load(ctx context.Context, scopes ...interface{}) ([]*metadata
 		default:
 			panic(fmt.Sprintf("unknown scope type %T", scope))
 		}
+		switch scope.(type) {
+		case directoryURI, viewLoadScope:
+			containsDir = true
+		}
 	}
 	sort.Strings(query) // for determinism
 
@@ -90,64 +94,8 @@ func (s *snapshot) load(ctx context.Context, scopes ...interface{}) ([]*metadata
 	if len(pkgs) == 0 {
 		return nil, err
 	}
-	return s.updateMetadata(ctx, scopes, pkgs, cfg)
-}
-
-// shouldLoad reparses a file's package and import declarations to
-// determine if the file requires a metadata reload.
-func (c *cache) shouldLoad(ctx context.Context, s *snapshot, originalFH, currentFH source.FileHandle) bool {
-	if originalFH == nil {
-		return currentFH.Identity().Kind == source.Go
-	}
-	// If the file hasn't changed, there's no need to reload.
-	if originalFH.Identity().String() == currentFH.Identity().String() {
-		return false
-	}
-	// If a go.mod file's contents have changed, always invalidate metadata.
-	if kind := originalFH.Identity().Kind; kind == source.Mod {
-		return true
-	}
-	// Get the original and current parsed files in order to check package name and imports.
-	original, _, _, originalErr := c.ParseGoHandle(originalFH, source.ParseHeader).Parse(ctx)
-	current, _, _, currentErr := c.ParseGoHandle(currentFH, source.ParseHeader).Parse(ctx)
-	if originalErr != nil || currentErr != nil {
-		return (originalErr == nil) != (currentErr == nil)
-	}
-
-	// Check if the package's metadata has changed. The cases handled are:
-	//    1. A package's name has changed
-	//    2. A file's imports have changed
-	if original.Name.Name != current.Name.Name {
-		return true
-	}
-	// If the package's imports have increased, definitely re-run `go list`.
-	if len(original.Imports) < len(current.Imports) {
-		return true
-	}
-	importSet := make(map[string]struct{})
-	for _, importSpec := range original.Imports {
-		importSet[importSpec.Path.Value] = struct{}{}
-	}
-	// If any of the current imports were not in the original imports.
-	for _, importSpec := range current.Imports {
-		if _, ok := importSet[importSpec.Path.Value]; !ok {
-			return true
-		}
-	}
-	return false
-}
-
-func (s *snapshot) updateMetadata(ctx context.Context, scopes []interface{}, pkgs []*packages.Package, cfg *packages.Config) ([]*metadata, error) {
 	var results []*metadata
 	for _, pkg := range pkgs {
-		// Don't log output for full workspace packages.Loads.
-		var containsDir bool
-		for _, scope := range scopes {
-			switch scope.(type) {
-			case directoryURI, viewLoadScope:
-				containsDir = true
-			}
-		}
 		if !containsDir || s.view.Options().VerboseOutput {
 			log.Print(ctx, "go/packages.Load", tag.Of("snapshot", s.ID()), tag.Of("package", pkg.PkgPath), tag.Of("files", pkg.CompiledGoFiles))
 		}
@@ -161,12 +109,17 @@ func (s *snapshot) updateMetadata(ctx context.Context, scopes []interface{}, pkg
 			continue
 		}
 		// Set the metadata for this package.
-		if err := s.updateImports(ctx, packagePath(pkg.PkgPath), pkg, cfg, map[packageID]struct{}{}); err != nil {
+		m, err := s.setMetadata(ctx, packagePath(pkg.PkgPath), pkg, cfg, map[packageID]struct{}{})
+		if err != nil {
 			return nil, err
 		}
-		if m := s.getMetadata(packageID(pkg.ID)); m != nil {
-			results = append(results, m)
+		// All packages returned by packages.Load will be top-level packages,
+		// with dependencies in the Imports field. Therefore, we can assume that
+		// they are all workspace packages and mark them as such.
+		if err := s.setWorkspacePackage(ctx, m); err != nil {
+			return nil, err
 		}
+		results = append(results, m)
 	}
 
 	// Rebuild the import graph when the metadata is updated.
@@ -178,10 +131,30 @@ func (s *snapshot) updateMetadata(ctx context.Context, scopes []interface{}, pkg
 	return results, nil
 }
 
-func (s *snapshot) updateImports(ctx context.Context, pkgPath packagePath, pkg *packages.Package, cfg *packages.Config, seen map[packageID]struct{}) error {
+func (s *snapshot) setWorkspacePackage(ctx context.Context, m *metadata) error {
+	// Make sure that the builtin package doesn't get marked a workspace package.
+	if m.pkgPath == "builtin" {
+		return nil
+	}
+	// A test variant of a package can only be loaded directly by loading
+	// the non-test variant with -test. Track the import path of the non-test variant.
+	pkgPath := m.pkgPath
+	if m.forTest != "" {
+		pkgPath = m.forTest
+	}
+
+	s.mu.Lock()
+	s.workspacePackages[m.id] = pkgPath
+	s.mu.Unlock()
+
+	_, err := s.packageHandle(ctx, m.id)
+	return err
+}
+
+func (s *snapshot) setMetadata(ctx context.Context, pkgPath packagePath, pkg *packages.Package, cfg *packages.Config, seen map[packageID]struct{}) (*metadata, error) {
 	id := packageID(pkg.ID)
 	if _, ok := seen[id]; ok {
-		return errors.Errorf("import cycle detected: %q", id)
+		return nil, errors.Errorf("import cycle detected: %q", id)
 	}
 	// Recreate the metadata rather than reusing it to avoid locking.
 	m := &metadata{
@@ -205,8 +178,9 @@ func (s *snapshot) updateImports(ctx context.Context, pkgPath packagePath, pkg *
 		s.addID(uri, m.id)
 	}
 
-	seen[id] = struct{}{}
-	copied := make(map[packageID]struct{})
+	copied := map[packageID]struct{}{
+		id: struct{}{},
+	}
 	for k, v := range seen {
 		copied[k] = v
 	}
@@ -225,14 +199,24 @@ func (s *snapshot) updateImports(ctx context.Context, pkgPath packagePath, pkg *
 			continue
 		}
 		if s.getMetadata(importID) == nil {
-			if err := s.updateImports(ctx, importPkgPath, importPkg, cfg, copied); err != nil {
+			if _, err := s.setMetadata(ctx, importPkgPath, importPkg, cfg, copied); err != nil {
 				log.Error(ctx, "error in dependency", err)
 			}
 		}
 	}
 	// Add the metadata to the cache.
-	s.setMetadata(m)
-	return nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// TODO: We should make sure not to set duplicate metadata,
+	// and instead panic here. This can be done by making sure not to
+	// reset metadata information for packages we've already seen.
+	if orig, ok := s.metadata[m.id]; ok {
+		return orig, nil
+	} else {
+		s.metadata[m.id] = m
+		return m, nil
+	}
 }
 
 func isTestMain(ctx context.Context, pkg *packages.Package, gocache string) bool {

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.5.2
 	golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/tools v0.0.0-20200129045341-207d3de1faaf
-	golang.org/x/tools/gopls v0.1.8-0.20200129045341-207d3de1faaf
+	golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7
+	golang.org/x/tools/gopls v0.1.8-0.20200130002326-2f3ba24bd6e7
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191017151554-a3bc800455d5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200129045341-207d3de1faaf h1:mFgR10kFfr83r2+nXf0GZC2FKrFhMSs9NdJ0YdEaGiY=
-golang.org/x/tools v0.0.0-20200129045341-207d3de1faaf/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools/gopls v0.1.8-0.20200129045341-207d3de1faaf h1:qqPQ+FLdgR9CuLW/tNpKRWdM4Dr7F2Wqg6QGspkVLVk=
-golang.org/x/tools/gopls v0.1.8-0.20200129045341-207d3de1faaf/go.mod h1:gl6R36ojRXGBQy36p7BYYZBu495D+W3pYAX3UYwDTpM=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 h1:EBZoQjiKKPaLbPrbpssUfuHtwM6KV/vb4U85g/cigFY=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools/gopls v0.1.8-0.20200130002326-2f3ba24bd6e7 h1:xgunrWcYH8cy9t1I7Phk8YsN3aALl4mOjNK2Q4SOu9U=
+golang.org/x/tools/gopls v0.1.8-0.20200130002326-2f3ba24bd6e7/go.mod h1:gl6R36ojRXGBQy36p7BYYZBu495D+W3pYAX3UYwDTpM=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* all: revert uses of types.NewInterfaceType 2f3ba24b
* internal/lsp: set workspace packages during (*snapshot).load 4e655657
* internal/lsp/mod: fix test that checks for unchanged go.mod c8253cff
* internal/lsp/cache: move shouldLoad function to snapshot.go 8a05c59e
* internal/lsp/cache: use telemetry logging for imports refresh 71655563
* internal/lsp/source: check cancellation before analysis ec2e11d2
* internal/lsp/cache: delete a few unused functions 11f6c2ac