### PR TITLE
deps: upgrade x/tools and gopls to fe90550f

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.5.2
 	golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7
-	golang.org/x/tools/gopls v0.1.8-0.20200130002326-2f3ba24bd6e7
+	golang.org/x/tools v0.0.0-20200130224504-fe90550fed74
+	golang.org/x/tools/gopls v0.1.8-0.20200130224504-fe90550fed74
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191017151554-a3bc800455d5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 h1:EBZoQjiKKPaLbPrbpssUfuHtwM6KV/vb4U85g/cigFY=
-golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools/gopls v0.1.8-0.20200130002326-2f3ba24bd6e7 h1:xgunrWcYH8cy9t1I7Phk8YsN3aALl4mOjNK2Q4SOu9U=
-golang.org/x/tools/gopls v0.1.8-0.20200130002326-2f3ba24bd6e7/go.mod h1:gl6R36ojRXGBQy36p7BYYZBu495D+W3pYAX3UYwDTpM=
+golang.org/x/tools v0.0.0-20200130224504-fe90550fed74 h1:YddJHrkQi5NW0zwlPK0Y6gOK/dX7iGOxWznYoLzRYi8=
+golang.org/x/tools v0.0.0-20200130224504-fe90550fed74/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools/gopls v0.1.8-0.20200130224504-fe90550fed74 h1:8GvZhTomkv6+10NM18u1HbJKaSc4BeuJBMwnufJR1nc=
+golang.org/x/tools/gopls v0.1.8-0.20200130224504-fe90550fed74/go.mod h1:gl6R36ojRXGBQy36p7BYYZBu495D+W3pYAX3UYwDTpM=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* go/packages: fix non-determinism on package list order fe90550f
* internal/span: always uppercase the drive letter for Windows 07253810
* go/packages: make TestOverlayDeps deterministic 90908045
* go/packages: work around pkg-config errors in go list 449c356b
* go/packages: add a workaround for golang/go#36188 71629799