### PR TITLE
cmd/govim: switch to the didChangeWatchedFiles API

### DIFF
--- a/cmd/govim/buffer_events.go
+++ b/cmd/govim/buffer_events.go
@@ -45,16 +45,7 @@ func (v *vimstate) bufReadPost(args ...json.RawMessage) error {
 	}
 
 	v.buffers[nb.Num] = nb
-	if wf, ok := v.watchedFiles[nb.Name]; ok {
-		// We are now picking up from a file that was previously watched. If we subsequently
-		// close this buffer then we will handle that event and delete the entry in v.buffers
-		// at which point the file watching will take back over again.
-		delete(v.watchedFiles, nb.Name)
-		nb.Version = wf.Version + 1
-	} else {
-		// first time we have seen the buffer
-		nb.Version = 1
-	}
+	nb.Version = 1
 	nb.Listener = v.ParseInt(v.ChannelCall("listener_add", v.Prefix()+string(config.FunctionEnrichDelta), nb.Num))
 
 	if err := v.updateSigns(v.diagnostics(), true); err != nil {

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -18,8 +18,8 @@ const (
 	// govim.
 	EnvVarUseGoplsFromPath EnvVar = "GOVIM_USE_GOPLS_FROM_PATH"
 
-	// EnvVarGoplsDebug is an environment variable which, when set, will be
-	// used to pass the value as flags to gopls.
+	// EnvVarGoplsFlags is an environment variable which, when set, will be used
+	// to pass the value as flags to gopls.
 	EnvVarGoplsFlags EnvVar = "GOVIM_GOPLS_FLAGS"
 
 	// EnvVarGoplsVerbose is an environment variable which, when set to the

--- a/cmd/govim/internal/fswatcher/fswatcher.go
+++ b/cmd/govim/internal/fswatcher/fswatcher.go
@@ -14,4 +14,5 @@ type Op string
 const (
 	OpChanged Op = "changed"
 	OpRemoved Op = "removed"
+	OpCreated Op = "created"
 )

--- a/cmd/govim/internal/fswatcher/os_darwin.go
+++ b/cmd/govim/internal/fswatcher/os_darwin.go
@@ -14,7 +14,8 @@ import (
 )
 
 const fRemoved = fsevents.ItemRemoved | fsevents.ItemRenamed
-const fChanged = fsevents.ItemCreated | fsevents.ItemModified | fsevents.ItemChangeOwner
+const fChanged = fsevents.ItemModified | fsevents.ItemChangeOwner
+const fCreated = fsevents.ItemCreated
 
 type fswatcher struct {
 	eventCh chan Event
@@ -71,6 +72,8 @@ func New(gomodpath string, tomb *tomb.Tomb) (*FSWatcher, error) {
 					eventCh <- Event{path, OpRemoved}
 				case event.Flags&fChanged > 0:
 					eventCh <- Event{path, OpChanged}
+				case event.Flags&fCreated > 0:
+					eventCh <- Event{path, OpCreated}
 				}
 			}
 		}

--- a/cmd/govim/internal/fswatcher/os_others.go
+++ b/cmd/govim/internal/fswatcher/os_others.go
@@ -30,9 +30,13 @@ func New(gomodpath string, tomb *tomb.Tomb) (*FSWatcher, error) {
 			}
 			switch e.Op {
 			case fsnotify.Rename, fsnotify.Remove:
+				// fsnotify processes file renaming as a Rename event followed by a
+				// Create event, so we can effectively treat renaming as removal.
 				eventCh <- Event{e.Name, OpRemoved}
-			case fsnotify.Create, fsnotify.Chmod, fsnotify.Write:
+			case fsnotify.Chmod, fsnotify.Write:
 				eventCh <- Event{e.Name, OpChanged}
+			case fsnotify.Create:
+				eventCh <- Event{e.Name, OpCreated}
 			}
 		}
 		close(eventCh)

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -250,7 +250,6 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 			buffers:               make(map[int]*types.Buffer),
 			defaultConfig:         *defaults,
 			config:                *defaults,
-			watchedFiles:          make(map[string]*types.WatchedFile),
 			quickfixIsDiagnostics: true,
 			suggestedFixesPopups:  make(map[int][]protocol.WorkspaceEdit),
 		},
@@ -385,7 +384,10 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 		ContentFormat: []protocol.MarkupKind{protocol.PlainText},
 	}
 	initParams.Capabilities.Workspace.Configuration = true
+	// TODO: actually handle these registrations dynamically, if we ever want to
+	// target language servers other than gopls.
 	initParams.Capabilities.Workspace.DidChangeConfiguration.DynamicRegistration = true
+	initParams.Capabilities.Workspace.DidChangeWatchedFiles.DynamicRegistration = true
 	initOpts := make(map[string]interface{})
 	initOpts[goplsInitOptIncrementalSync] = true
 	initOpts["noDocsOnHover"] = true

--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -94,7 +94,9 @@ func TestScripts(t *testing.T) {
 		workdir := workdir
 		if workdir != "" {
 			workdir = filepath.Join(workdir, entry.Name())
-			os.MkdirAll(workdir, 0777)
+			if err := os.MkdirAll(workdir, 0777); err != nil {
+				t.Fatal("failed to make work dir")
+			}
 		}
 		t.Run(entry.Name(), func(t *testing.T) {
 			t.Parallel()

--- a/cmd/govim/testdata/scenario_default/complete_watched.txt
+++ b/cmd/govim/testdata/scenario_default/complete_watched.txt
@@ -1,12 +1,9 @@
 # Test that ominfunc complete works where the completion is made
 # available in a file that is not loaded via the editor.
-#
-# We add in a generous sleep to ensure the watch event has been
-# handled.
 
 vim ex 'e main.go'
 cp const.go.orig const.go
-errlogmatch '&protocol\.DidOpenTextDocumentParams\{\n\S+:\s+TextDocument: protocol.TextDocumentItem{URI:"file://'$WORK/const.go
+errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const.go'", Type:1\}'
 vim ex 'call cursor(6,16)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<C-N>\\<ESC>\", \"x\")'
 vim ex 'w'

--- a/cmd/govim/testdata/scenario_default/watcher.txt
+++ b/cmd/govim/testdata/scenario_default/watcher.txt
@@ -1,16 +1,29 @@
 # Test that the file watcher picks up file changes that occurs outside the editor
 
-[short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'
-
 # New file in the same package
 vim ex 'e main.go'
 cp const.go.orig const.go
-errlogmatch '&protocol\.DidOpenTextDocumentParams\{\n\S+:\s+TextDocument: protocol.TextDocumentItem{URI:"file://'$WORK/const.go
+errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const.go'", Type:1\}'
 vim ex 'call cursor(6,16)'
 vim ex 'call feedkeys(\"iConst2\\<ESC>\", \"x\")'
 vim ex 'w'
 vimexprwait errors.empty GOVIMTest_getqflist()
 cmp main.go main.go.golden
+
+# Update const.go with an error
+cp const.go.updated const.go
+errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const.go'", Type:2\}'
+vimexprwait errors.undeclared GOVIMTest_getqflist()
+
+# Add a const2.go that conflicts with const.go
+cp const2.go.orig const2.go
+errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const2.go'", Type:1\}'
+vimexprwait errors.otherdeclaration GOVIMTest_getqflist()
+
+# Remove const.go to resolve the conflict
+rm const.go
+errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const.go'", Type:3\}'
+vimexprwait errors.empty GOVIMTest_getqflist()
 
 skip 'Temporary disabled due to https://github.com/govim/govim/issues/492'
 
@@ -20,11 +33,11 @@ vim ex 'call feedkeys(\"ifmt.Println(foo.Bar)\n\\<ESC>\",\"x\")'
 errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
 mkdir foo
 cp foo_foo.go.orig foo/foo.go
-errlogmatch '&protocol.DidOpenTextDocumentParams{\n\S+:\s+TextDocument: protocol.TextDocumentItem{URI:"file://'$WORK/foo/foo.go
+errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/foo/foo.go'", Type:1\}'
 errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/foo/foo.go
 vim ex 'w'
 errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
-vimexprwait errors.empty GOVIMTest_getqflist()
+vimexprwait errors.updated GOVIMTest_getqflist()
 
 # No warnings or errors during the test
 
@@ -51,6 +64,19 @@ const (
 	Const1 = 1
 	Const2 = 2
 )
+-- const.go.updated --
+package main
+
+const (
+	Const1 = 1
+)
+-- const2.go.orig --
+package main
+
+const (
+	Const1 = 1
+	Const2 = 2
+)
 -- main.go.golden --
 package main
 
@@ -65,3 +91,45 @@ package foo
 const Bar = 1
 -- errors.empty --
 []
+-- errors.undeclared --
+[
+  {
+    "bufname": "main.go",
+    "col": 14,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: Const2",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.otherdeclaration --
+[
+  {
+    "bufname": "const.go",
+    "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "other declaration of Const1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "const2.go",
+    "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Const1 redeclared in this block",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -22,10 +22,6 @@ type vimstate struct {
 	// or autocommand.
 	buffers map[int]*types.Buffer
 
-	// watchedFiles is a map of files that we are handling via file watching
-	// events, rather than via open Buffers in Vim
-	watchedFiles map[string]*types.WatchedFile
-
 	// jumpStack is akin to the Vim concept of a tagstack
 	jumpStack    []protocol.Location
 	jumpStackPos int


### PR DESCRIPTION
Now that gopls supports the didChangeWatchedFiles notification, govim no
longer needs to synthetically open files on external file changes.

This change updates the fswatcher package, along with watcher.go, to use
didChangeWatchedFiles. Notably, this change requires tracking file
creation separately from modification or removal.

Tests are updated to exercise some of this new behavior.

Fixes #187