### PR TITLE
ci: use specific commits of actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       VIM_VERSION: ${{ matrix.vim_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
     - name: Build docker image
       run: ./_scripts/buildGovimImage.sh
     - name: Run Docker, run!

--- a/internal/cmd/genconfig/genconfig.go
+++ b/internal/cmd/genconfig/genconfig.go
@@ -281,7 +281,7 @@ jobs:
       VIM_VERSION: ${{ matrix.vim_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
     - name: Build docker image
       run: ./_scripts/buildGovimImage.sh
     - name: Run Docker, run!


### PR DESCRIPTION
Per this thread:

    https://twitter.com/_myitcv/status/1223329679442173953

using short-hand major versions for actions, e.g.:

   actions/checkout@v1

is brittle. Per the rest of the thread, using even full semver versions
is brittle because it's so easy to move tags on GitHub.

Therefore using commit hashes is the best of a bad bunch right now.

Given:

    https://twitter.com/_rsc/status/1088109141409837063

we are still not, however, out of the woods because we are not
guaranteed to run exactly the transitive dependencies tomorrow that we
ran today.

This is all somewhat moot because we are running CI on GitHub
infrastructure, but let's try to make this as safe as possible given the
tools we have.