### PR TITLE
cmd/govim: fix embarrassingly bad bug in completion textedit handling

### DIFF
--- a/cmd/govim/complete.go
+++ b/cmd/govim/complete.go
@@ -81,6 +81,7 @@ func (v *vimstate) completeDone(args ...json.RawMessage) error {
 	for _, c := range v.lastCompleteResults.Items {
 		if c.Label == chosen.Abbr {
 			match = &c
+			break
 		}
 	}
 	if match == nil {

--- a/cmd/govim/testdata/scenario_default/complete_watched.txt
+++ b/cmd/govim/testdata/scenario_default/complete_watched.txt
@@ -35,9 +35,7 @@ const (
 -- main.go.golden --
 package main
 
-import (
-	"fmt"
-)
+import "fmt"
 
 func main() {
 	fmt.Println(Const2)


### PR DESCRIPTION
As part of the current completion code that handles applying of
additional text edits we have:

	for _, c := range v.lastCompleteResults.Items {
		if c.Label == chosen.Abbr {
			match = &c
		}
	}

In a previous change, compltion items changes from being a pointer to a
non-pointer value. Hence we flipped the setting of match from c to &c.
But we forgot the break (which arguably could/should have been there
before). Which means that a further iteration of the for loop after a
match will cause the match to find the text edits from another match.
Specifically, we will be left with the additional text edits from the
last match in the list.

Fix that by breaking out of the loop on a match.

As part of this also fix a test which was incorrectly updated as a
result of this bug (which actually makes the bug itself even worse!)