### PR TITLE
ci: add branchCheck to postRun script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Tidy up
       run: ./_scripts/postRun.sh
     - name: Upload artefacts
-      if: success()
+      if: success() && env.CI_SKIP_JOB != 'true'
       uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5
       with:
         path: /home/runner/.artefacts

--- a/_scripts/common.bash
+++ b/_scripts/common.bash
@@ -39,5 +39,6 @@ function doBranchCheck {
 		return
 	fi
 	echo "Skipping build for ${VIM_FLAVOR}_${VIM_VERSION}_${GO_VERSION}"
+	echo "::set-env name=CI_SKIP_JOB::true"
 	exit 0
 }

--- a/_scripts/postRun.sh
+++ b/_scripts/postRun.sh
@@ -8,4 +8,6 @@ then
 	exit
 fi
 
+doBranchCheck
+
 tidyUp $ARTEFACTS

--- a/internal/cmd/genconfig/genconfig.go
+++ b/internal/cmd/genconfig/genconfig.go
@@ -297,7 +297,7 @@ jobs:
     - name: Tidy up
       run: ./_scripts/postRun.sh
     - name: Upload artefacts
-      if: success()
+      if: success() && env.CI_SKIP_JOB != 'true'
       uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5
       with:
         path: /home/runner/.artefacts


### PR DESCRIPTION
Jobs that are skipped in WIP branches have no $ARTEFACTS directory
so those will fail during post run.

This change adds a branchCheck to exit gracefully.