### PR TITLE
cmd/govim/config: promote ExperimentalTempModfile to TempModfile

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -100,7 +100,7 @@ function! s:validCompletionBudget(v)
   return s:validString(a:v)
 endfunction
 
-function! s:validExperimentalTempModfile(v)
+function! s:validTempModfile(v)
   return s:validBool(a:v)
 endfunction
 
@@ -146,7 +146,7 @@ let s:validators = {
       \ "CompleteUnimported": function("s:validCompleteUnimported"),
       \ "GoImportsLocalPrefix": function("s:validGoImportsLocalPrefix"),
       \ "CompletionBudget": function("s:validCompletionBudget"),
-      \ "ExperimentalTempModfile": function("s:validExperimentalTempModfile"),
+      \ "TempModfile": function("s:validTempModfile"),
       \ "GoplsEnv": function("s:validGoplsEnv"),
       \ "ExperimentalMouseTriggeredHoverPopupOptions": function("s:validExperimentalMouseTriggeredHoverPopupOptions"),
       \ "ExperimentalCursorTriggeredHoverPopupOptions": function("s:validExperimentalCursorTriggeredHoverPopupOptions"),

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -107,7 +107,7 @@ type Config struct {
 	// results. Zero seconds means unlimited. Examples values: "0s", "100ms"
 	CompletionBudget *string `json:",omitempty"`
 
-	// ExperimentalTempModfile corresponds to the gopls config setting
+	// TempModfile corresponds to the gopls config setting
 	// "tempModfile" which controls whether a temporary modfile is used in place
 	// of the main module's original go.mod file. When enabled, any
 	// user-initiated changes (to .go files) that would otherwise have resulted
@@ -118,7 +118,7 @@ type Config struct {
 	// https://go-review.googlesource.com/c/tools/+/216277.
 	//
 	// Default: false
-	ExperimentalTempModfile *bool `json:",omitempty"`
+	TempModfile *bool `json:",omitempty"`
 
 	// GoplsEnv configures the set of environment variables gopls is using in
 	// calls to go/packages. This is most easily understood in the context of

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -34,8 +34,8 @@ func (r *Config) Apply(v *Config) {
 	if v.CompletionBudget != nil {
 		r.CompletionBudget = v.CompletionBudget
 	}
-	if v.ExperimentalTempModfile != nil {
-		r.ExperimentalTempModfile = v.ExperimentalTempModfile
+	if v.TempModfile != nil {
+		r.TempModfile = v.TempModfile
 	}
 	if v.GoplsEnv != nil {
 		r.GoplsEnv = v.GoplsEnv

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -150,8 +150,8 @@ func (g *govimplugin) Configuration(ctxt context.Context, params *protocol.Param
 	if conf.CompletionBudget != nil {
 		goplsConfig[goplsCompletionBudget] = *conf.CompletionBudget
 	}
-	if g.vimstate.config.ExperimentalTempModfile != nil {
-		goplsConfig[goplsTempModfile] = *conf.ExperimentalTempModfile
+	if g.vimstate.config.TempModfile != nil {
+		goplsConfig[goplsTempModfile] = *conf.TempModfile
 	}
 	if os.Getenv(string(config.EnvVarGoplsVerbose)) == "true" {
 		goplsConfig[goplsVerboseOutput] = true

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -18,7 +18,7 @@ type VimConfig struct {
 	CompleteUnimported                           *int
 	GoImportsLocalPrefix                         *string
 	CompletionBudget                             *string
-	ExperimentalTempModfile                      *int
+	TempModfile                                  *int
 	GoplsEnv                                     *map[string]string
 	ExperimentalMouseTriggeredHoverPopupOptions  *map[string]interface{}
 	ExperimentalCursorTriggeredHoverPopupOptions *map[string]interface{}
@@ -37,7 +37,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		CompleteUnimported:        boolVal(c.CompleteUnimported, d.CompleteUnimported),
 		GoImportsLocalPrefix:      stringVal(c.GoImportsLocalPrefix, d.GoImportsLocalPrefix),
 		CompletionBudget:          stringVal(c.CompletionBudget, d.CompletionBudget),
-		ExperimentalTempModfile:   boolVal(c.ExperimentalTempModfile, d.ExperimentalTempModfile),
+		TempModfile:               boolVal(c.TempModfile, d.TempModfile),
 		GoplsEnv:                  copyStringValMap(c.GoplsEnv, d.GoplsEnv),
 		ExperimentalMouseTriggeredHoverPopupOptions:  copyMap(c.ExperimentalMouseTriggeredHoverPopupOptions, d.ExperimentalMouseTriggeredHoverPopupOptions),
 		ExperimentalCursorTriggeredHoverPopupOptions: copyMap(c.ExperimentalCursorTriggeredHoverPopupOptions, d.ExperimentalCursorTriggeredHoverPopupOptions),

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -230,6 +230,7 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 			Staticcheck:             vimconfig.BoolVal(false),
 			HighlightDiagnostics:    vimconfig.BoolVal(true),
 			HoverDiagnostics:        vimconfig.BoolVal(true),
+			TempModfile:             vimconfig.BoolVal(false),
 		}
 	}
 	// Overlay the initial user values on the defaults

--- a/cmd/govim/testdata/scenario_tempmodfile/user_config.json
+++ b/cmd/govim/testdata/scenario_tempmodfile/user_config.json
@@ -1,3 +1,3 @@
 {
-	"ExperimentalTempModfile": true
+	"TempModfile": true
 }


### PR DESCRIPTION
The equivalent gopls setting has already been promoted to a "production"
config setting.

We also set a govim-level default of false for now.