### PR TITLE
cmd/govim: define GOVIMWorkspaceSymbol to expose gopls' workspace/symbol

### DIFF
--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -291,6 +291,10 @@ const (
 
 	// FunctionMotion moves the cursor according to the arguments provided.
 	FunctionMotion Function = "Motion"
+
+	// FunctionWorkspaceSymbol exposes the LSP workspace/symbol method. Its
+	// signature is identical to the LSP method.
+	FunctionWorkspaceSymbol = "WorkspaceSymbol"
 )
 
 // FormatOnSave typed constants define the set of valid values that

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -303,6 +303,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineFunction(string(config.FunctionStringFnComplete), []string{"ArgLead", "CmdLine", "CursorPos"}, g.vimstate.stringfncomplete)
 	g.DefineCommand(string(config.CommandHighlightReferences), g.vimstate.referenceHighlight)
 	g.DefineAutoCommand("", govim.Events{govim.EventCompleteDone}, govim.Patterns{"*.go"}, false, g.vimstate.completeDone, "eval(expand('<abuf>'))", "v:completed_item")
+	g.DefineFunction(string(config.FunctionWorkspaceSymbol), []string{"params"}, g.vimstate.workspaceSymbol)
 	g.defineHighlights()
 	if err := g.vimstate.signDefine(); err != nil {
 		return fmt.Errorf("failed to define signs: %v", err)

--- a/cmd/govim/testdata/scenario_default/workspace_symbol.txt
+++ b/cmd/govim/testdata/scenario_default/workspace_symbol.txt
@@ -1,0 +1,39 @@
+# Test that GOVIMWorkspaceSymbol works as expected
+
+vim -indent expr 'GOVIMWorkspaceSymbol({\"query\": \"main\"})'
+cmpenv stdout symbols.golden
+! stderr .+
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+func main() {
+}
+-- symbols.golden --
+[
+  {
+    "kind": 12,
+    "location": {
+      "range": {
+        "end": {
+          "character": 9,
+          "line": 2
+        },
+        "start": {
+          "character": 5,
+          "line": 2
+        }
+      },
+      "uri": "file://$WORK/main.go"
+    },
+    "name": "main"
+  }
+]

--- a/cmd/govim/workspace.go
+++ b/cmd/govim/workspace.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+)
+
+func (v *vimstate) workspaceSymbol(args ...json.RawMessage) (interface{}, error) {
+	var params protocol.WorkspaceSymbolParams
+	v.Parse(args[0], &params)
+	return v.server.Symbol(context.Background(), &params)
+}


### PR DESCRIPTION
This allows calls like:

    call GOVIMWorkspaceSymbol({'query': 'main'})