### PR TITLE
cmd/govim: add support for manually triggered reference highlight

### DIFF
--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -231,6 +231,10 @@ const (
 
 	// CommandSuggestedFixes
 	CommandSuggestedFixes Command = "SuggestedFixes"
+
+	// CommandHighlightReferences highlights references to the identifier under
+	// the cursor.
+	CommandHighlightReferences Command = "HighlightReferences"
 )
 
 type Function string

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -300,6 +300,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineCommand(string(config.CommandRename), g.vimstate.rename, govim.NArgsZeroOrOne)
 	g.DefineCommand(string(config.CommandStringFn), g.vimstate.stringfns, govim.RangeLine, govim.CompleteCustomList(PluginPrefix+config.FunctionStringFnComplete), govim.NArgsOneOrMore)
 	g.DefineFunction(string(config.FunctionStringFnComplete), []string{"ArgLead", "CmdLine", "CursorPos"}, g.vimstate.stringfncomplete)
+	g.DefineCommand(string(config.CommandHighlightReferences), g.vimstate.referenceHighlight)
 	g.DefineAutoCommand("", govim.Events{govim.EventCompleteDone}, govim.Patterns{"*.go"}, false, g.vimstate.completeDone, "eval(expand('<abuf>'))", "v:completed_item")
 	g.defineHighlights()
 	if err := g.vimstate.signDefine(); err != nil {

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -172,12 +172,12 @@ func (v *vimstate) setUserBusy(args ...json.RawMessage) (interface{}, error) {
 	v.Parse(args[0], &isBusy)
 	v.userBusy = isBusy != 0
 
-	if err := v.updateReferenceHighlight(!v.userBusy); err != nil {
-		return nil, err
+	if v.userBusy {
+		return nil, v.removeReferenceHighlight()
 	}
 
-	if v.userBusy {
-		return nil, nil
+	if err := v.updateReferenceHighlight(false); err != nil {
+		return nil, err
 	}
 
 	return nil, v.handleDiagnosticsChanged()


### PR DESCRIPTION
Users might not want the automatic reference highlighting, but still
be able to use it by triggering in manually.

This change adds the command GOVIMHighlightReferences that can be
used to highlight references even when automatic reference highlights
is disabled.