### PR TITLE
ci: add go1.13.x to darwin test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        go_version: ['1.14.x']
+        go_version: ['1.13.x', '1.14.x']
         vim_version: ["master"]
     runs-on: ${{ matrix.os }}
     env:

--- a/internal/cmd/genconfig/genconfig.go
+++ b/internal/cmd/genconfig/genconfig.go
@@ -309,7 +309,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        go_version: ['1.14.x']
+        go_version: ['1.13.x', '1.14.x']
         vim_version: ["master"]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Add go 1.13.x to the darwin test suite as a part of investigating why
macOS build sometimes hangs for several minutes. This makes sure it
isn't a go1.14rc1 bug.

Updates #781