### PR TITLE
cmd/govim: add support for loading an initial file in testscript tests

### DIFF
--- a/cmd/govim/testdata/scenario_default/load_initial_file.txt
+++ b/cmd/govim/testdata/scenario_default/load_initial_file.txt
@@ -1,0 +1,35 @@
+# Test to ensure that we can load an initial file where there is a
+# vim_config.json file in the archive
+
+vim expr 'bufname(\"\")'
+stdout '^"main.go"$'
+! stderr .+
+vimexprwait errors.golden GOVIMTest_getqflist()
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- main.go --
+package main
+
+asdf
+-- errors.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found asdf",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- vim_config.json --
+{
+	"InitialFile": "main.go"
+}

--- a/testdriver/testdriver.go
+++ b/testdriver/testdriver.go
@@ -95,12 +95,20 @@ type TestDriver struct {
 }
 
 type Config struct {
-	Name, GovimPath, TestHomePath, TestPluginPath string
+	Name           string
+	GovimPath      string
+	TestHomePath   string
+	TestPluginPath string
+	Vim            *VimConfig
 	Debug
 	ReadLog *LockingBuffer
 	Log     io.Writer
 	*testscript.Env
 	Plugin govim.Plugin
+}
+
+type VimConfig struct {
+	InitialFile string
 }
 
 type Debug struct {
@@ -196,6 +204,12 @@ func NewTestDriver(c *Config) (*TestDriver, error) {
 	if c.Debug.Enabled {
 		res.debug = c.Debug
 		vimCmd = append(vimCmd, fmt.Sprintf("-V%d%s", c.Debug.VimLogLevel, c.VimLogPath))
+	}
+
+	if c.Vim != nil {
+		if c.Vim.InitialFile != "" {
+			vimCmd = append(vimCmd, c.Vim.InitialFile)
+		}
 	}
 
 	res.cmd = exec.Command(vimCmd[0], vimCmd[1:]...)


### PR DESCRIPTION
PR #784 has uncovered a need to be able to load an initial file as part
of a testscript test. Support this by allowing a vim_config.json file to
be present in a test's archive, a JSON file that is parsed and passed to
the testdriver as Vim-specific config.

Add a test to verify that things work as expected.