### PR TITLE
govim: synchronise access to out *json.Encoder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ env:
   GH_USER: "x-access-token"
   GH_TOKEN: ${{ github.token }}
   GOVIM_TEST_RACE_SLOWDOWN: "1.5"
+  RACE_BUILD: 786
 
 name: Go
 jobs:

--- a/internal/cmd/genconfig/genconfig.go
+++ b/internal/cmd/genconfig/genconfig.go
@@ -270,6 +270,7 @@ env:
   GH_USER: "x-access-token"
   GH_TOKEN: ${{ github.token }}
   GOVIM_TEST_RACE_SLOWDOWN: "1.5"
+  RACE_BUILD: 786
 
 name: Go
 jobs:


### PR DESCRIPTION
The refactor in #784 uncovered a bug which showed, in race tests, that
we were not synchronising writes to the *json.Encoder when sending
messages to Vim.

Fix that by using a mutex to guard access.