### PR TITLE
deps: upgrade x/tools and gopls to 2086a0a6

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/jsonrpc2/servertest/servertest.go
+++ b/cmd/govim/internal/golang_org_x_tools/jsonrpc2/servertest/servertest.go
@@ -9,46 +9,118 @@ package servertest
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
+	"sync"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/jsonrpc2"
 )
 
-// Server is a helper for executing tests against a remote jsonrpc2 connection.
-// Once initialized, its Addr field may be used to connect a jsonrpc2 client.
-type Server struct {
-	Addr string
-
-	ln net.Listener
+// Connector is the interface used to connect to a server.
+type Connector interface {
+	Connect(context.Context) *jsonrpc2.Conn
 }
 
-// NewServer returns a new test server listening on local tcp port and serving
-// incoming jsonrpc2 streams using the provided stream server. It panics on any
-// error.
-func NewServer(ctx context.Context, server jsonrpc2.StreamServer) *Server {
+// TCPServer is a helper for executing tests against a remote jsonrpc2
+// connection. Once initialized, its Addr field may be used to connect a
+// jsonrpc2 client.
+type TCPServer struct {
+	Addr string
+
+	ln  net.Listener
+	cls *closerList
+}
+
+// NewTCPServer returns a new test server listening on local tcp port and
+// serving incoming jsonrpc2 streams using the provided stream server. It
+// panics on any error.
+func NewTCPServer(ctx context.Context, server jsonrpc2.StreamServer) *TCPServer {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(fmt.Sprintf("servertest: failed to listen: %v", err))
 	}
 	go jsonrpc2.Serve(ctx, ln, server)
-	return &Server{Addr: ln.Addr().String(), ln: ln}
+	return &TCPServer{Addr: ln.Addr().String(), ln: ln, cls: &closerList{}}
 }
 
 // Connect dials the test server and returns a jsonrpc2 Connection that is
 // ready for use.
-func (s *Server) Connect(ctx context.Context) *jsonrpc2.Conn {
+func (s *TCPServer) Connect(ctx context.Context) *jsonrpc2.Conn {
 	netConn, err := net.Dial("tcp", s.Addr)
 	if err != nil {
 		panic(fmt.Sprintf("servertest: failed to connect to test instance: %v", err))
 	}
+	s.cls.add(func() {
+		netConn.Close()
+	})
 	conn := jsonrpc2.NewConn(jsonrpc2.NewHeaderStream(netConn, netConn))
 	go conn.Run(ctx)
 	return conn
 }
 
-// Close is a placeholder for proper test server shutdown.
-// TODO: implement proper shutdown, which gracefully closes existing
-// connections to the test server.
-func (s *Server) Close() error {
+// Close closes all connected pipes.
+func (s *TCPServer) Close() error {
+	s.cls.closeAll()
 	return nil
+}
+
+// PipeServer is a test server that handles connections over io.Pipes.
+type PipeServer struct {
+	server jsonrpc2.StreamServer
+	cls    *closerList
+}
+
+// NewPipeServer returns a test server that can be connected to via io.Pipes.
+func NewPipeServer(ctx context.Context, server jsonrpc2.StreamServer) *PipeServer {
+	return &PipeServer{server: server, cls: &closerList{}}
+}
+
+// Connect creates new io.Pipes and binds them to the underlying StreamServer.
+func (s *PipeServer) Connect(ctx context.Context) *jsonrpc2.Conn {
+	// Pipes connect like this:
+	// Client🡒(sWriter)🡒(sReader)🡒Server
+	//       🡔(cReader)🡐(cWriter)🡗
+	sReader, sWriter := io.Pipe()
+	cReader, cWriter := io.Pipe()
+	s.cls.add(func() {
+		sReader.Close()
+		sWriter.Close()
+		cReader.Close()
+		cWriter.Close()
+	})
+	serverStream := jsonrpc2.NewStream(sReader, cWriter)
+	go s.server.ServeStream(ctx, serverStream)
+
+	clientStream := jsonrpc2.NewStream(cReader, sWriter)
+	clientConn := jsonrpc2.NewConn(clientStream)
+	go clientConn.Run(ctx)
+	return clientConn
+}
+
+// Close closes all connected pipes.
+func (s *PipeServer) Close() error {
+	s.cls.closeAll()
+	return nil
+}
+
+// closerList tracks closers to run when a testserver is closed.  This is a
+// convenience, so that callers don't have to worry about closing each
+// connection.
+type closerList struct {
+	mu      sync.Mutex
+	closers []func()
+}
+
+func (l *closerList) add(closer func()) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.closers = append(l.closers, closer)
+}
+
+func (l *closerList) closeAll() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, closer := range l.closers {
+		closer()
+	}
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/cache.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/cache.go
@@ -19,9 +19,9 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 )
 
-func New(options func(*source.Options)) source.Cache {
+func New(options func(*source.Options)) *Cache {
 	index := atomic.AddInt64(&cacheIndex, 1)
-	c := &cache{
+	c := &Cache{
 		fs:      &nativeFileSystem{},
 		id:      strconv.FormatInt(index, 10),
 		fset:    token.NewFileSet(),
@@ -31,7 +31,7 @@ func New(options func(*source.Options)) source.Cache {
 	return c
 }
 
-type cache struct {
+type Cache struct {
 	fs      source.FileSystem
 	id      string
 	fset    *token.FileSet
@@ -45,7 +45,7 @@ type fileKey struct {
 }
 
 type fileHandle struct {
-	cache      *cache
+	cache      *Cache
 	underlying source.FileHandle
 	handle     *memoize.Handle
 }
@@ -57,7 +57,7 @@ type fileData struct {
 	err   error
 }
 
-func (c *cache) GetFile(uri span.URI) source.FileHandle {
+func (c *Cache) GetFile(uri span.URI) source.FileHandle {
 	underlying := c.fs.GetFile(uri)
 	key := fileKey{
 		identity: underlying.Identity(),
@@ -74,9 +74,9 @@ func (c *cache) GetFile(uri span.URI) source.FileHandle {
 	}
 }
 
-func (c *cache) NewSession() source.Session {
+func (c *Cache) NewSession() *Session {
 	index := atomic.AddInt64(&sessionIndex, 1)
-	s := &session{
+	s := &Session{
 		cache:    c,
 		id:       strconv.FormatInt(index, 10),
 		options:  source.DefaultOptions(),
@@ -86,7 +86,7 @@ func (c *cache) NewSession() source.Session {
 	return s
 }
 
-func (c *cache) FileSet() *token.FileSet {
+func (c *Cache) FileSet() *token.FileSet {
 	return c.fset
 }
 
@@ -115,8 +115,8 @@ func hashContents(contents []byte) string {
 
 var cacheIndex, sessionIndex, viewIndex int64
 
-type debugCache struct{ *cache }
+type debugCache struct{ *Cache }
 
-func (c *cache) ID() string                         { return c.id }
+func (c *Cache) ID() string                         { return c.id }
 func (c debugCache) FileSet() *token.FileSet        { return c.fset }
 func (c debugCache) MemStats() map[reflect.Type]int { return c.store.Stats() }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
@@ -54,6 +54,19 @@ func (ph *packageHandle) packageKey() packageKey {
 	}
 }
 
+func (ph *packageHandle) isValidImportFor(parentPkgPath string) bool {
+	importPath := string(ph.m.pkgPath)
+
+	pkgRootIndex := strings.Index(importPath, "/internal/")
+	if pkgRootIndex != -1 && parentPkgPath != "command-line-arguments" {
+		if !strings.HasPrefix(parentPkgPath, importPath[0:pkgRootIndex]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // packageData contains the data produced by type-checking a package.
 type packageData struct {
 	memoize.NoCopy
@@ -274,6 +287,7 @@ func typeCheck(ctx context.Context, fset *token.FileSet, m *metadata, mode sourc
 		mode:            mode,
 		goFiles:         goFiles,
 		compiledGoFiles: compiledGoFiles,
+		module:          m.module,
 		imports:         make(map[packagePath]*pkg),
 		typesSizes:      m.typesSizes,
 		typesInfo: &types.Info{
@@ -366,6 +380,9 @@ func typeCheck(ctx context.Context, fset *token.FileSet, m *metadata, mode sourc
 			}
 			if dep == nil {
 				return nil, errors.Errorf("no package for import %s", pkgPath)
+			}
+			if !dep.isValidImportFor(pkg.PkgPath()) {
+				return nil, errors.Errorf("invalid use of internal package %s", pkgPath)
 			}
 			depPkg, err := dep.check(ctx)
 			if err != nil {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/debug.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/debug.go
@@ -17,7 +17,7 @@ func (v debugView) ID() string             { return v.id }
 func (v debugView) Session() debug.Session { return debugSession{v.session} }
 func (v debugView) Env() []string          { return v.Options().Env }
 
-type debugSession struct{ *session }
+type debugSession struct{ *Session }
 
 func (s debugSession) ID() string         { return s.id }
 func (s debugSession) Cache() debug.Cache { return debugCache{s.cache} }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
@@ -33,6 +33,7 @@ type metadata struct {
 	errors          []packages.Error
 	deps            []packageID
 	missingDeps     map[packagePath]struct{}
+	module          *packagesinternal.Module
 
 	// config is the *packages.Config associated with the loaded package.
 	config *packages.Config
@@ -144,6 +145,7 @@ func (s *snapshot) setMetadata(ctx context.Context, pkgPath packagePath, pkg *pa
 		typesSizes: pkg.TypesSizes,
 		errors:     pkg.Errors,
 		config:     cfg,
+		module:     packagesinternal.GetModule(pkg),
 	}
 
 	for _, filename := range pkg.CompiledGoFiles {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/packagesinternal"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	errors "golang.org/x/xerrors"
 )
@@ -26,6 +27,7 @@ type pkg struct {
 	compiledGoFiles []source.ParseGoHandle
 	errors          []*source.Error
 	imports         map[packagePath]*pkg
+	module          *packagesinternal.Module
 	types           *types.Package
 	typesInfo       *types.Info
 	typesSizes      types.Sizes
@@ -117,6 +119,10 @@ func (p *pkg) Imports() []source.Package {
 		result = append(result, imp)
 	}
 	return result
+}
+
+func (p *pkg) Module() *packagesinternal.Module {
+	return p.module
 }
 
 func (s *snapshot) FindAnalysisError(ctx context.Context, pkgID, analyzerName, msg string, rng protocol.Range) (*source.Error, error) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
@@ -34,7 +34,7 @@ import (
 )
 
 type view struct {
-	session *session
+	session *Session
 	id      string
 
 	options source.Options

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/cmd.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/cmd.go
@@ -58,7 +58,7 @@ type Application struct {
 	env []string
 
 	// Support for remote lsp server
-	Remote string `flag:"remote" help:"*EXPERIMENTAL* - forward all commands to a remote lsp"`
+	Remote string `flag:"remote" help:"*EXPERIMENTAL* - forward all commands to a remote lsp specified by this flag. If prefixed by 'unix;', the subsequent address is assumed to be a unix domain socket. Otherwise, TCP is used."`
 
 	// Enable verbose logging
 	Verbose bool `flag:"v" help:"verbose output"`

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/serve.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/serve.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/jsonrpc2"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/cache"
@@ -23,7 +24,7 @@ type Serve struct {
 	Logfile string `flag:"logfile" help:"filename to log to. if value is \"auto\", then logging to a default output file is enabled"`
 	Mode    string `flag:"mode" help:"no effect"`
 	Port    int    `flag:"port" help:"port on which to run gopls for debugging purposes"`
-	Address string `flag:"listen" help:"address on which to listen for remote connections"`
+	Address string `flag:"listen" help:"address on which to listen for remote connections. If prefixed by 'unix;', the subsequent address is assumed to be a unix domain socket. Otherwise, TCP is used."`
 	Trace   bool   `flag:"rpc.trace" help:"print the full rpc trace in lsp inspector format"`
 	Debug   string `flag:"debug" help:"serve debug information on the supplied address"`
 
@@ -52,7 +53,7 @@ func (s *Serve) Run(ctx context.Context, args ...string) error {
 		return tool.CommandLineErrorf("server does not take arguments, got %v", args)
 	}
 
-	err, closeLog := s.app.debug.SetLogFile(s.Logfile)
+	closeLog, err := s.app.debug.SetLogFile(s.Logfile)
 	if err != nil {
 		return err
 	}
@@ -64,21 +65,31 @@ func (s *Serve) Run(ctx context.Context, args ...string) error {
 
 	var ss jsonrpc2.StreamServer
 	if s.app.Remote != "" {
-		ss = lsprpc.NewForwarder(s.app.Remote, true)
+		network, addr := parseAddr(s.app.Remote)
+		ss = lsprpc.NewForwarder(network, addr, true)
 	} else {
 		ss = lsprpc.NewStreamServer(cache.New(s.app.options), true)
 	}
 
 	if s.Address != "" {
-		return jsonrpc2.ListenAndServe(ctx, s.Address, ss)
+		network, addr := parseAddr(s.Address)
+		return jsonrpc2.ListenAndServe(ctx, network, addr, ss)
 	}
 	if s.Port != 0 {
 		addr := fmt.Sprintf(":%v", s.Port)
-		return jsonrpc2.ListenAndServe(ctx, addr, ss)
+		return jsonrpc2.ListenAndServe(ctx, "tcp", addr, ss)
 	}
 	stream := jsonrpc2.NewHeaderStream(os.Stdin, os.Stdout)
 	if s.Trace {
 		stream = protocol.LoggingStream(stream, s.app.debug.LogWriter)
 	}
 	return ss.ServeStream(ctx, stream)
+}
+
+// parseAddr parses the -listen flag in to a network, and address.
+func parseAddr(listen string) (network string, address string) {
+	if parts := strings.SplitN(listen, ";", 2); len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "tcp", listen
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/cmdtest.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/cmdtest.go
@@ -9,11 +9,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"golang.org/x/tools/go/packages/packagestest"
@@ -125,16 +126,18 @@ func (r *runner) runGoplsCmd(t testing.TB, args ...string) (string, string) {
 		t.Fatal(err)
 	}
 	oldStderr := os.Stderr
-	defer func() {
-		os.Stdout = oldStdout
-		os.Stderr = oldStderr
-		wStdout.Close()
-		rStdout.Close()
-		wStderr.Close()
-		rStderr.Close()
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		io.Copy(stdout, rStdout)
+		wg.Done()
 	}()
-	os.Stdout = wStdout
-	os.Stderr = wStderr
+	go func() {
+		io.Copy(stderr, rStderr)
+		wg.Done()
+	}()
+	os.Stdout, os.Stderr = wStdout, wStderr
 	app := cmd.New("gopls-test", r.data.Config.Dir, r.data.Exported.Config.Env, r.options)
 	remote := r.remote
 	err = tool.Run(tests.Context(t),
@@ -145,15 +148,11 @@ func (r *runner) runGoplsCmd(t testing.TB, args ...string) (string, string) {
 	}
 	wStdout.Close()
 	wStderr.Close()
-	stdout, err := ioutil.ReadAll(rStdout)
-	if err != nil {
-		t.Fatal(err)
-	}
-	stderr, err := ioutil.ReadAll(rStderr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(stdout), string(stderr)
+	wg.Wait()
+	os.Stdout, os.Stderr = oldStdout, oldStderr
+	rStdout.Close()
+	rStderr.Close()
+	return stdout.String(), stderr.String()
 }
 
 // NormalizeGoplsCmd runs the gopls command and normalizes its output.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/debug/serve.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/debug/serve.go
@@ -258,7 +258,7 @@ func (i *Instance) Prepare(ctx context.Context) {
 	export.AddExporters(i.ocagent, i.prometheus, i.rpcs, i.traces)
 }
 
-func (i *Instance) SetLogFile(logfile string) (error, func()) {
+func (i *Instance) SetLogFile(logfile string) (func(), error) {
 	// TODO: probably a better solution for deferring closure to the caller would
 	// be for the debug instance to itself be closed, but this fixes the
 	// immediate bug of logs not being captured.
@@ -269,7 +269,7 @@ func (i *Instance) SetLogFile(logfile string) (error, func()) {
 		}
 		f, err := os.Create(logfile)
 		if err != nil {
-			return fmt.Errorf("Unable to create log file: %v", err), nil
+			return nil, fmt.Errorf("unable to create log file: %v", err)
 		}
 		closeLog = func() {
 			defer f.Close()
@@ -278,7 +278,7 @@ func (i *Instance) SetLogFile(logfile string) (error, func()) {
 		i.LogWriter = f
 	}
 	i.Logfile = logfile
-	return nil, closeLog
+	return closeLog, nil
 }
 
 // Serve starts and runs a debug server in the background.
@@ -335,7 +335,7 @@ func (i *Instance) Serve(ctx context.Context) error {
 
 func (i *Instance) MonitorMemory(ctx context.Context) {
 	tick := time.NewTicker(time.Second)
-	nextThresholdGiB := uint64(5)
+	nextThresholdGiB := uint64(1)
 	go func() {
 		for {
 			<-tick.C

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
@@ -70,12 +70,19 @@ func NewEditor(ws *Workspace) *Editor {
 	}
 }
 
-// ShutdownAndExit shuts down the client and issues the editor exit.
-func (e *Editor) ShutdownAndExit(ctx context.Context) error {
+// Shutdown issues the 'shutdown' LSP notification.
+func (e *Editor) Shutdown(ctx context.Context) error {
 	if e.server != nil {
 		if err := e.server.Shutdown(ctx); err != nil {
 			return fmt.Errorf("Shutdown: %v", err)
 		}
+	}
+	return nil
+}
+
+// Exit issues the 'exit' LSP notification.
+func (e *Editor) Exit(ctx context.Context) error {
+	if e.server != nil {
 		// Not all LSP clients issue the exit RPC, but we do so here to ensure that
 		// we gracefully handle it on multi-session servers.
 		if err := e.server.Exit(ctx); err != nil {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/general.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/general.go
@@ -272,13 +272,17 @@ func (s *Server) shutdown(ctx context.Context) error {
 	return nil
 }
 
+// ServerExitFunc is used to exit when requested by the client. It is mutable
+// for testing purposes.
+var ServerExitFunc = os.Exit
+
 func (s *Server) exit(ctx context.Context) error {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 	if s.state != serverShutDown {
-		os.Exit(1)
+		ServerExitFunc(1)
 	}
-	os.Exit(0)
+	ServerExitFunc(0)
 	return nil
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/link.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/link.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
@@ -27,6 +28,14 @@ func (s *Server) documentLink(ctx context.Context, params *protocol.DocumentLink
 		return nil, err
 	}
 	view := snapshot.View()
+	phs, err := view.Snapshot().PackageHandles(ctx, fh)
+	if err != nil {
+		return nil, err
+	}
+	ph, err := source.WidestPackageHandle(phs)
+	if err != nil {
+		return nil, err
+	}
 	file, _, m, _, err := view.Session().Cache().ParseGoHandle(fh, source.ParseFull).Parse(ctx)
 	if err != nil {
 		return nil, err
@@ -37,8 +46,10 @@ func (s *Server) documentLink(ctx context.Context, params *protocol.DocumentLink
 		case *ast.ImportSpec:
 			// For import specs, provide a link to a documentation website, like https://pkg.go.dev.
 			if target, err := strconv.Unquote(n.Path.Value); err == nil {
+				if mod, version, ok := moduleAtVersion(ctx, target, ph); ok && strings.ToLower(view.Options().LinkTarget) == "pkg.go.dev" {
+					target = strings.Replace(target, mod, mod+"@"+version, 1)
+				}
 				target = fmt.Sprintf("https://%s/%s", view.Options().LinkTarget, target)
-
 				// Account for the quotation marks in the positions.
 				start, end := n.Path.Pos()+1, n.Path.End()-1
 				if l, err := toProtocolLink(view, m, target, start, end); err == nil {
@@ -64,6 +75,25 @@ func (s *Server) documentLink(ctx context.Context, params *protocol.DocumentLink
 		}
 	}
 	return links, nil
+}
+
+func moduleAtVersion(ctx context.Context, target string, ph source.PackageHandle) (string, string, bool) {
+	pkg, err := ph.Check(ctx)
+	if err != nil {
+		return "", "", false
+	}
+	impPkg, err := pkg.GetImport(target)
+	if err != nil {
+		return "", "", false
+	}
+	if impPkg.Module() == nil {
+		return "", "", false
+	}
+	version, modpath := impPkg.Module().Version, impPkg.Module().Path
+	if modpath == "" || version == "" {
+		return "", "", false
+	}
+	return modpath, version, true
 }
 
 func findLinksInString(ctx context.Context, view source.View, src string, pos token.Pos, m *protocol.ColumnMapper) []protocol.DocumentLink {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/tools/go/packages"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/imports"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/packagesinternal"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 )
 
@@ -228,9 +229,6 @@ type Cache interface {
 	// A FileSystem that reads file contents from external storage.
 	FileSystem
 
-	// NewSession creates a new Session manager and returns it.
-	NewSession() Session
-
 	// FileSet returns the shared fileset used by all files in the system.
 	FileSet() *token.FileSet
 
@@ -362,6 +360,7 @@ type Package interface {
 	ForTest() string
 	GetImport(pkgPath string) (Package, error)
 	Imports() []Package
+	Module() *packagesinternal.Module
 }
 
 type Error struct {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/cgoimport/usegco.go.golden
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/cgoimport/usegco.go.golden
@@ -1,2 +1,0 @@
--- funcexample-hover --
-func cgo.Example()

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/godef/b/b.go.golden
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/godef/b/b.go.golden
@@ -90,29 +90,6 @@ func a.AStuff()
 ```go
 func a.AStuff()
 ```
--- PackageFoo-definition --
-foo/foo.go:1:1-30:16: defined here as myFoo "golang.org/x/tools/internal/lsp/foo" //@mark(myFoo, "myFoo"),godef("foo", PackageFoo),godef("myFoo", myFoo)
--- PackageFoo-definition-json --
-{
-	"span": {
-		"uri": "file://foo/foo.go",
-		"start": {
-			"line": 1,
-			"column": 1,
-			"offset": 0
-		},
-		"end": {
-			"line": 30,
-			"column": 16,
-			"offset": 922
-		}
-	},
-	"description": "myFoo \"golang.org/x/tools/internal/lsp/foo\" //@mark(myFoo, \"myFoo\"),godef(\"foo\", PackageFoo),godef(\"myFoo\", myFoo)"
-}
-
--- PackageFoo-hover --
-myFoo "golang.org/x/tools/internal/lsp/foo" //@mark(myFoo, "myFoo"),godef("foo", PackageFoo),godef("myFoo", myFoo)
-
 -- S1-definition --
 godef/b/b.go:8:6-8: defined here as ```go
 S1 struct {
@@ -325,28 +302,6 @@ field F2 int
 ```go
 field F2 int
 ```
--- Stuff-definition --
-godef/a/a.go:9:6-11: defined here as func a.Stuff()
--- Stuff-definition-json --
-{
-	"span": {
-		"uri": "file://godef/a/a.go",
-		"start": {
-			"line": 9,
-			"column": 6,
-			"offset": 95
-		},
-		"end": {
-			"line": 9,
-			"column": 11,
-			"offset": 100
-		}
-	},
-	"description": "func a.Stuff()"
-}
-
--- Stuff-hover --
-func a.Stuff()
 -- bX-definition --
 godef/b/b.go:37:7-8: defined here as ```go
 const X untyped int = 0

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/links/links.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/links/links.go
@@ -7,7 +7,7 @@ import (
 
 	_ "database/sql" //@link(`database/sql`, `https://pkg.go.dev/database/sql`)
 
-	errors "golang.org/x/xerrors" //@link(`golang.org/x/xerrors`, `https://pkg.go.dev/golang.org/x/xerrors`)
+	_ "example.com/extramodule/pkg" //@link(`example.com/extramodule/pkg`,`https://pkg.go.dev/example.com/extramodule@v1.0.0/pkg`)
 )
 
 var (

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/signature/signature.go.golden
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/signature/signature.go.golden
@@ -1,5 +1,3 @@
--- -signature --
-
 -- Bar(float64, ...byte)-signature --
 Bar(float64, ...byte)
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/snippets/snippets.go.golden
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/snippets/snippets.go.golden
@@ -1,5 +1,3 @@
--- -signature --
-
 -- baz(at AliasType, b bool)-signature --
 baz(at AliasType, b bool)
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/tests/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/tests/util.go
@@ -49,7 +49,7 @@ func DiffLinks(mapper *protocol.ColumnMapper, wantLinks []Link, gotLinks []proto
 		if target, ok := links[spn]; ok {
 			delete(links, spn)
 			if target != link.Target {
-				return fmt.Sprintf("for %v want %v, got %v\n", spn, link.Target, target)
+				return fmt.Sprintf("for %v want %v, got %v\n", spn, target, link.Target)
 			}
 		} else {
 			return fmt.Sprintf("unexpected link %v:%v\n", spn, link.Target)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/text_synchronization.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/text_synchronization.go
@@ -73,19 +73,47 @@ func (s *Server) didChange(ctx context.Context, params *protocol.DidChangeTextDo
 
 func (s *Server) didChangeWatchedFiles(ctx context.Context, params *protocol.DidChangeWatchedFilesParams) error {
 	var modifications []source.FileModification
+	deletions := make(map[span.URI]struct{})
 	for _, change := range params.Changes {
 		uri := change.URI.SpanURI()
 		if !uri.IsFile() {
 			continue
 		}
+		action := changeTypeToFileAction(change.Type)
 		modifications = append(modifications, source.FileModification{
 			URI:    uri,
-			Action: changeTypeToFileAction(change.Type),
+			Action: action,
 			OnDisk: true,
 		})
+		// Keep track of deleted files so that we can clear their diagnostics.
+		// A file might be re-created after deletion, so only mark files that
+		// have truly been deleted.
+		switch action {
+		case source.Delete:
+			deletions[uri] = struct{}{}
+		case source.Close:
+		default:
+			delete(deletions, uri)
+		}
 	}
-	_, err := s.didModifyFiles(ctx, modifications)
-	return err
+	snapshots, err := s.didModifyFiles(ctx, modifications)
+	if err != nil {
+		return err
+	}
+	// Clear the diagnostics for any deleted files.
+	for uri := range deletions {
+		if snapshot := snapshots[uri]; snapshot == nil || snapshot.IsOpen(uri) {
+			continue
+		}
+		if err := s.client.PublishDiagnostics(ctx, &protocol.PublishDiagnosticsParams{
+			URI:         protocol.URIFromSpanURI(uri),
+			Diagnostics: []protocol.Diagnostic{},
+			Version:     0,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Server) didSave(ctx context.Context, params *protocol.DidSaveTextDocumentParams) error {
@@ -93,7 +121,6 @@ func (s *Server) didSave(ctx context.Context, params *protocol.DidSaveTextDocume
 	if !uri.IsFile() {
 		return nil
 	}
-
 	c := source.FileModification{
 		URI:     uri,
 		Action:  source.Save,
@@ -111,8 +138,7 @@ func (s *Server) didClose(ctx context.Context, params *protocol.DidCloseTextDocu
 	if !uri.IsFile() {
 		return nil
 	}
-
-	_, err := s.didModifyFiles(ctx, []source.FileModification{
+	snapshots, err := s.didModifyFiles(ctx, []source.FileModification{
 		{
 			URI:     uri,
 			Action:  source.Close,
@@ -120,7 +146,26 @@ func (s *Server) didClose(ctx context.Context, params *protocol.DidCloseTextDocu
 			Text:    nil,
 		},
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	snapshot := snapshots[uri]
+	if snapshot == nil {
+		return errors.Errorf("no snapshot for %s", uri)
+	}
+	fh, err := snapshot.GetFile(uri)
+	if err != nil {
+		return err
+	}
+	// If a file has been closed and is not on disk, clear its diagnostics.
+	if _, _, err := fh.Read(ctx); err != nil {
+		return s.client.PublishDiagnostics(ctx, &protocol.PublishDiagnosticsParams{
+			URI:         protocol.URIFromSpanURI(uri),
+			Diagnostics: []protocol.Diagnostic{},
+			Version:     0,
+		})
+	}
+	return nil
 }
 
 func (s *Server) didModifyFiles(ctx context.Context, modifications []source.FileModification) (map[span.URI]source.Snapshot, error) {

--- a/cmd/govim/internal/golang_org_x_tools/packagesinternal/packages.go
+++ b/cmd/govim/internal/golang_org_x_tools/packagesinternal/packages.go
@@ -1,4 +1,27 @@
 // Package packagesinternal exposes internal-only fields from go/packages.
 package packagesinternal
 
+import "time"
+
+// Fields must match go list;
+type Module struct {
+	Path      string       // module path
+	Version   string       // module version
+	Versions  []string     // available module versions (with -versions)
+	Replace   *Module      // replaced by this module
+	Time      *time.Time   // time version was created
+	Update    *Module      // available update, if any (with -u)
+	Main      bool         // is this the main module?
+	Indirect  bool         // is this module only an indirect dependency of main module?
+	Dir       string       // directory holding files for this module, if any
+	GoMod     string       // path to go.mod file used when loading this module, if any
+	GoVersion string       // go version used in module
+	Error     *ModuleError // error loading module
+}
+type ModuleError struct {
+	Err string // the error itself
+}
+
 var GetForTest = func(p interface{}) string { return "" }
+
+var GetModule = func(p interface{}) *Module { return nil }

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.5.2
 	golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/tools v0.0.0-20200214225126-5916a50871fb
-	golang.org/x/tools/gopls v0.1.8-0.20200214225126-5916a50871fb
+	golang.org/x/tools v0.0.0-20200220051852-2086a0a691c0
+	golang.org/x/tools/gopls v0.1.8-0.20200220051852-2086a0a691c0
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191017151554-a3bc800455d5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200214225126-5916a50871fb h1:v/vJOBYLZ/j1iLRnB+xIrKSrcDL2mEvX8M8yx6cvs7M=
-golang.org/x/tools v0.0.0-20200214225126-5916a50871fb/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools/gopls v0.1.8-0.20200214225126-5916a50871fb h1:uzLz0UJbgtEmBOnzb9ADM9pQIZTrUjnScQ2ifv4nV/g=
-golang.org/x/tools/gopls v0.1.8-0.20200214225126-5916a50871fb/go.mod h1:gl6R36ojRXGBQy36p7BYYZBu495D+W3pYAX3UYwDTpM=
+golang.org/x/tools v0.0.0-20200220051852-2086a0a691c0 h1:K3udS2sjmoy0P+/d56DdLRrwHKTCkW+A179fa3swkyQ=
+golang.org/x/tools v0.0.0-20200220051852-2086a0a691c0/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools/gopls v0.1.8-0.20200220051852-2086a0a691c0 h1:GsUtvDdNxKDZfFCbwzGoPA9t6rbLf3pvIHRFgqlsl8g=
+golang.org/x/tools/gopls v0.1.8-0.20200220051852-2086a0a691c0/go.mod h1:gl6R36ojRXGBQy36p7BYYZBu495D+W3pYAX3UYwDTpM=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* go/internal/gcimporter: update TestImportedTypes for BImportData removal 2086a0a6
* internal/lsp/tests: fix regexp for removing links that contain versions 88b1720d
* go/analysis: add pass to check string(int) conversions d3d48f09
* internal/lsp: report use of disallowed internal packages 77adbdfd
* internal/lsp: clear diagnostics for deleted files 55b11c71
* internal/lsp: add module versions from "go list" to pkg.go.dev links 7c4b6277
* internal/lsp/cache: return concrete types where possible c4d4ea9c
* internal/lsp: limit diagnostics concurrency 33153249
* internal/jsonrpc2,internal/lsp/regtest: clean up some leaked tempfiles 66de4287
* internal/jsonrpc2: support serving over unix domain sockets 5fb17a1e
* internal/lsp/lsprpc: add a forwarder handler 741f65b5
* internal/lsp/tests: fix reset of golden files ca8c272a
* internal/lsp/cache: kill unused func fixAccidentalDecl 753a1d49
* internal/span: handle URI escaping better f8e42dc4
* internal/lsp/debug: drop memory debug threshold to 1GiB 8fd784fb
* internal/lsp: add scheme checks to CodeLens dc8ced65
* internal/jsonrpc2/servertest: support both TCP and pipe connection b320d3a0