### PR TITLE
deps: upgrade x/tools and gopls to 57f3fb51

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
@@ -601,9 +601,10 @@ func (v *view) setBuildInformation(ctx context.Context, folder span.URI, env []s
 		return nil
 	}
 	// Copy the current go.mod file into the temporary go.mod file.
-	// The file's name will be of the format go.1234.mod.
-	// It's temporary go.sum file should have the corresponding format of go.1234.sum.
-	tempModFile, err := ioutil.TempFile("", "go.*.mod")
+	// The file's name will be of the format go.directory.1234.mod.
+	// It's temporary go.sum file should have the corresponding format of go.directory.1234.sum.
+	tmpPattern := fmt.Sprintf("go.%s.*.mod", filepath.Base(folder.Filename()))
+	tempModFile, err := ioutil.TempFile("", tmpPattern)
 	if err != nil {
 		return err
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion_keywords.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion_keywords.go
@@ -4,8 +4,6 @@ import (
 	"go/ast"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
-
-	errors "golang.org/x/xerrors"
 )
 
 const (
@@ -36,22 +34,48 @@ const (
 	VAR         = "var"
 )
 
-// keyword looks at the current scope of an *ast.Ident and recommends keywords
-func (c *completer) keyword() error {
-	keywordScore := float64(0.9)
-	if _, ok := c.path[0].(*ast.Ident); !ok {
-		// TODO(golang/go#34009): Support keyword completion in any context
-		return errors.Errorf("keywords are currently only recommended for identifiers")
-	}
-	// Track which keywords we've already determined are in a valid scope
-	// Use score to order keywords by how close we are to where they are useful
-	valid := make(map[string]float64)
+// addKeywordCompletions offers keyword candidates appropriate at the position.
+func (c *completer) addKeywordCompletions() {
+	const keywordScore = 0.9
 
-	// only suggest keywords at the begnning of a statement
+	seen := make(map[string]bool)
+
+	// addKeywords dedupes and adds completion items for the specified
+	// keywords with the specified score.
+	addKeywords := func(score float64, kws ...string) {
+		for _, kw := range kws {
+			if seen[kw] {
+				continue
+			}
+			seen[kw] = true
+
+			if c.matcher.Score(kw) > 0 {
+				c.items = append(c.items, CompletionItem{
+					Label:      kw,
+					Kind:       protocol.KeywordCompletion,
+					InsertText: kw,
+					Score:      score,
+				})
+			}
+		}
+	}
+
+	// If we are at the file scope, only offer decl keywords. We don't
+	// get *ast.Idents at the file scope because non-keyword identifiers
+	// turn into *ast.BadDecl, not *ast.Ident.
+	if len(c.path) == 1 || isASTFile(c.path[1]) {
+		addKeywords(keywordScore, TYPE, CONST, VAR, FUNC, IMPORT)
+		return
+	} else if _, ok := c.path[0].(*ast.Ident); !ok {
+		// Otherwise only offer keywords if the client is completing an identifier.
+		return
+	}
+
+	// Only suggest keywords if we are beginning a statement.
 	switch c.path[1].(type) {
 	case *ast.BlockStmt, *ast.CommClause, *ast.CaseClause, *ast.ExprStmt:
 	default:
-		return nil
+		return
 	}
 
 	// Filter out keywords depending on scope
@@ -62,7 +86,7 @@ func (c *completer) keyword() error {
 		case *ast.CaseClause:
 			// only recommend "fallthrough" and "break" within the bodies of a case clause
 			if c.pos > node.Colon {
-				valid[BREAK] = keywordScore
+				addKeywords(keywordScore, BREAK)
 				// "fallthrough" is only valid in switch statements.
 				// A case clause is always nested within a block statement in a switch statement,
 				// that block statement is nested within either a TypeSwitchStmt or a SwitchStmt.
@@ -70,45 +94,23 @@ func (c *completer) keyword() error {
 					continue
 				}
 				if _, ok := path[i+2].(*ast.SwitchStmt); ok {
-					valid[FALLTHROUGH] = keywordScore
+					addKeywords(keywordScore, FALLTHROUGH)
 				}
 			}
 		case *ast.CommClause:
 			if c.pos > node.Colon {
-				valid[BREAK] = keywordScore
+				addKeywords(keywordScore, BREAK)
 			}
 		case *ast.TypeSwitchStmt, *ast.SelectStmt, *ast.SwitchStmt:
-			valid[CASE] = keywordScore + lowScore
-			valid[DEFAULT] = keywordScore + lowScore
+			addKeywords(keywordScore+lowScore, CASE, DEFAULT)
 		case *ast.ForStmt:
-			valid[BREAK] = keywordScore
-			valid[CONTINUE] = keywordScore
+			addKeywords(keywordScore, BREAK, CONTINUE)
 		// This is a bit weak, functions allow for many keywords
 		case *ast.FuncDecl:
 			if node.Body != nil && c.pos > node.Body.Lbrace {
-				valid[DEFER] = keywordScore - lowScore
-				valid[RETURN] = keywordScore - lowScore
-				valid[FOR] = keywordScore - lowScore
-				valid[GO] = keywordScore - lowScore
-				valid[SWITCH] = keywordScore - lowScore
-				valid[SELECT] = keywordScore - lowScore
-				valid[IF] = keywordScore - lowScore
-				valid[ELSE] = keywordScore - lowScore
-				valid[VAR] = keywordScore - lowScore
-				valid[CONST] = keywordScore - lowScore
+				addKeywords(keywordScore-lowScore, DEFER, RETURN, FOR, GO, SWITCH, SELECT, IF, ELSE, VAR, CONST, GOTO, TYPE)
 			}
 		}
 	}
 
-	for ident, score := range valid {
-		if c.matcher.Score(ident) > 0 {
-			c.items = append(c.items, CompletionItem{
-				Label:      ident,
-				Kind:       protocol.KeywordCompletion,
-				InsertText: ident,
-				Score:      score,
-			})
-		}
-	}
-	return nil
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
@@ -420,6 +420,11 @@ func isPkgName(obj types.Object) bool {
 	return ok
 }
 
+func isASTFile(n ast.Node) bool {
+	_, ok := n.(*ast.File)
+	return ok
+}
+
 // isSelector returns the enclosing *ast.SelectorExpr when pos is in the
 // selector.
 func enclosingSelector(path []ast.Node, pos token.Pos) *ast.SelectorExpr {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/foo/foo.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/foo/foo.go
@@ -27,4 +27,4 @@ func _() {
 	}
 }
 
-type IntFoo int //@item(IntFoo, "IntFoo", "int", "type"),complete("", Foo, IntFoo, StructFoo)
+type IntFoo int //@item(IntFoo, "IntFoo", "int", "type")

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/keywords/keywords.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/keywords/keywords.go
@@ -1,5 +1,7 @@
 package keywords
 
+//@rank("", type),rank("", func),rank("", var),rank("", const),rank("", import)
+
 func _() {
 	var test int
 	var tChan chan int
@@ -42,7 +44,7 @@ func _() {
 
 	f //@complete(" //", for)
 	d //@complete(" //", defer)
-	g //@complete(" //", go)
+	g //@rank(" //", go),rank(" //", goto)
 	r //@complete(" //", return)
 	i //@complete(" //", if)
 	e //@complete(" //", else)
@@ -72,3 +74,4 @@ func _() {
 /* return */ //@item(return, "return", "", "keyword")
 /* var */ //@item(var, "var", "", "keyword")
 /* const */ //@item(const, "const", "", "keyword")
+/* goto */ //@item(goto, "goto", "", "keyword")

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/suggestedfix/has_suggested_fix.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/suggestedfix/has_suggested_fix.go
@@ -7,5 +7,5 @@ import (
 func goodbye() {
 	s := "hiiiiiii"
 	s = s //@suggestedfix("s = s")
-	log.Printf(s)
+	log.Print(s)
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/suggestedfix/has_suggested_fix.go.golden
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/suggestedfix/has_suggested_fix.go.golden
@@ -8,6 +8,6 @@ import (
 func goodbye() {
 	s := "hiiiiiii"
 	 //@suggestedfix("s = s")
-	log.Printf(s)
+	log.Print(s)
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/summary.txt.golden
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/summary.txt.golden
@@ -1,11 +1,11 @@
 -- summary --
 CodeLensCount = 0
-CompletionsCount = 228
+CompletionsCount = 226
 CompletionSnippetCount = 67
 UnimportedCompletionsCount = 11
 DeepCompletionsCount = 5
 FuzzyCompletionsCount = 8
-RankedCompletionsCount = 102
+RankedCompletionsCount = 109
 CaseSensitiveCompletionsCount = 4
 DiagnosticsCount = 38
 FoldingRangesCount = 2

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/rogpeppe/go-internal v1.5.2
 	golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/tools v0.0.0-20200220051852-2086a0a691c0
-	golang.org/x/tools/gopls v0.1.8-0.20200220051852-2086a0a691c0
+	golang.org/x/tools v0.0.0-20200221191710-57f3fb51f507
+	golang.org/x/tools/gopls v0.1.8-0.20200221191710-57f3fb51f507
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
-	honnef.co/go/tools v0.0.1-2019.2.3
+	honnef.co/go/tools v0.0.1-2020.1.2
 )

--- a/go.sum
+++ b/go.sum
@@ -45,7 +45,6 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e h1:JgcxKXxCjrA2tyDP/aNU9K0Ck
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee h1:WG0RUwxtNT4qqaXX3DPA8zHFNm/D9xaBpxzHt1WcA/E=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -57,12 +56,11 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.0.0-20191017151554-a3bc800455d5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200220051852-2086a0a691c0 h1:K3udS2sjmoy0P+/d56DdLRrwHKTCkW+A179fa3swkyQ=
-golang.org/x/tools v0.0.0-20200220051852-2086a0a691c0/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools/gopls v0.1.8-0.20200220051852-2086a0a691c0 h1:GsUtvDdNxKDZfFCbwzGoPA9t6rbLf3pvIHRFgqlsl8g=
-golang.org/x/tools/gopls v0.1.8-0.20200220051852-2086a0a691c0/go.mod h1:gl6R36ojRXGBQy36p7BYYZBu495D+W3pYAX3UYwDTpM=
+golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200221191710-57f3fb51f507 h1:zE128a8BUJqwFqwi8LxUnOdV3eSOGIzDhiIV/QW8eXc=
+golang.org/x/tools v0.0.0-20200221191710-57f3fb51f507/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools/gopls v0.1.8-0.20200221191710-57f3fb51f507 h1:rsTgU6X7kOJgccHwscAVIkg9rgTheAD16B74etd4UVA=
+golang.org/x/tools/gopls v0.1.8-0.20200221191710-57f3fb51f507/go.mod h1:LNKBLVza4L1Tpo4VhI7NznuFfCVAMzX2k+UZRsXNQcI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -77,8 +75,8 @@ gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 h1:yiW+nvdHb9LVqSHQBXfZCieqV
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH1EMZPLyqSMM8JbIavyFACoFNk=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
-honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+honnef.co/go/tools v0.0.1-2020.1.2 h1:8w2Ud1JmaU9M5os2j8aKMpPs4guVq+RMUN5phK2najE=
+honnef.co/go/tools v0.0.1-2020.1.2/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 mvdan.cc/sh/v3 v3.0.0-alpha1 h1:ao/4li6H9nZe5HDXA14cynXoq90+DLZz0HmjZE/qjhA=
 mvdan.cc/sh/v3 v3.0.0-alpha1/go.mod h1:hAMDEHexA8ZIIH2yeItRcTq3T2he5Ly8CVcsTst6QT8=
 mvdan.cc/xurls/v2 v2.1.0 h1:KaMb5GLhlcSX+e+qhbRJODnUUBvlw01jt4yrjFIHAuA=


### PR DESCRIPTION
* gopls: update Staticcheck to 2020.1.2 57f3fb51
* internal/lsp: create more descriptive temp go.mod name 9c32af92
* internal/lsp/regtest: skip flaky TestGoToStdlibDefinition fe62aff3
* internal/lsp/source: improve completions at file scope 8a925fa4
* internal/lsp/regtest: increase test timeout to 60s 947cbf19