### PR TITLE
cmd/govim: remove govim workaround for Configuration loading

### DIFF
--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -96,26 +96,6 @@ func (g *govimplugin) WorkspaceFolders(context.Context) ([]protocol.WorkspaceFol
 func (g *govimplugin) Configuration(ctxt context.Context, params *protocol.ParamConfiguration) ([]interface{}, error) {
 	defer absorbShutdownErr()
 
-	// TODO this is a rather fragile workaround for https://github.com/golang/go/issues/35817
-	// It's fragile because we are relying on gopls not handling any requests until the response
-	// to Configuration is received and processed. In practice this appears to currently be
-	// the case but there is no guarantee of this going forward. Rather we hope that a fix
-	// for https://github.com/golang/go/issues/35817 lands sooner rather than later at whic
-	// point this workaround can go.
-	//
-	// We also use a lock here because, despite it appearing that will only be a single
-	// Configuration call and that if there were more they would be serial, we can't rely on
-	// this.
-	defer func() {
-		g.initalConfigurationCalledLock.Lock()
-		defer g.initalConfigurationCalledLock.Unlock()
-		select {
-		case <-g.initalConfigurationCalled:
-		default:
-			close(g.initalConfigurationCalled)
-		}
-	}()
-
 	g.logGoplsClientf("Configuration: %v", pretty.Sprint(params))
 
 	g.vimstate.configLock.Lock()


### PR DESCRIPTION
In 2db04e591 we added a workaround for a problem with gopls calling the
client Configuration method out of order. Subsequent changes in gopls
have made this workaround unnecessary. Hence, we now remove that
workaround.