### PR TITLE
cmd/govim: switch ftdetect for go.mod files to be *.mod

### DIFF
--- a/ftdetect/go.vim
+++ b/ftdetect/go.vim
@@ -3,4 +3,4 @@
 
 " By default, vim associates .mod files with filetypes lprolog or modsim3.
 " Override these rather than using setfiletype.
-autocmd BufNewFile,BufRead go.mod setlocal filetype=gomod
+autocmd BufNewFile,BufRead *.mod setlocal filetype=gomod


### PR DESCRIPTION
In Go 1.14 the -modfile flag lands for cmd/go. This allows an alternate
go.mod file to be provided for reads/writes during module resolution.
The alternate file must have a .mod extension, hence we should update
our file detection logic to be for *.mod.