### PR TITLE
cmd/govim: add tests to verify turning off unimported completions works (#687)

### DIFF
--- a/cmd/govim/testdata/scenario_no_completeunimported/no_complete.txt
+++ b/cmd/govim/testdata/scenario_no_completeunimported/no_complete.txt
@@ -1,0 +1,41 @@
+# Test that completing of unimported std library packages is disabled
+# when CompleteUnimported=0
+
+vim ex 'e main.go'
+
+# Attempt unimported completion; we should get zero results.
+# If we did get results (from fmt) then attempting completion
+# would expand from fmt.Pr to fmt.Print, i.e. the longest match
+# of the returned candidates
+vim ex 'call cursor(4,1)'
+vim normal Sfmt.Pr
+vim ex 'execute \"normal A\\<C-X>\\<C-O>(\\\"Hello\\\")\"'
+
+vim ex 'noau w'
+exec cat main.go
+vim ex message
+
+# Check import has not been added
+vim ex 'noau w'
+cmp main.go main.go1.golden
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+func main() {
+	fmt.Pr
+}
+-- main.go1.golden --
+package main
+
+func main() {
+	fmt.Pr("Hello")
+}

--- a/cmd/govim/testdata/scenario_no_completeunimported/no_complete_empty_file.txt
+++ b/cmd/govim/testdata/scenario_no_completeunimported/no_complete_empty_file.txt
@@ -1,0 +1,42 @@
+# Test that completing of unimported std library packages is disabled
+# when files on disk are initially empty and CompleteUnimported=0
+
+# Setup new buffer and verify contents are as expected
+vim ex 'e main.go'
+vim ex 'r main.go.orig | 0d_'
+vim ex 'noau w! check'
+cmp check main.go.orig
+
+# Attempt unimported completion; we should get zero results.
+# If we did get results (from fmt) then attempting completion
+# would expand from fmt.Pr to fmt.Print, i.e. the longest match
+# of the returned candidates
+vim ex 'call cursor(4,1)'
+vim normal Sfmt.Pr
+vim ex 'execute \"normal A\\<C-X>\\<C-O>(\\\"Hello\\\")\"'
+
+# Check import was not added
+vim ex 'noau w'
+cmp main.go main.go1.golden
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+-- main.go.orig --
+package main
+
+func main() {
+
+}
+-- main.go1.golden --
+package main
+
+func main() {
+	fmt.Pr("Hello")
+}

--- a/cmd/govim/testdata/scenario_no_completeunimported/no_complete_new_file.txt
+++ b/cmd/govim/testdata/scenario_no_completeunimported/no_complete_new_file.txt
@@ -1,0 +1,42 @@
+# Test that completing of unimported std library packages is disabled for 
+# new files that are not saved to disk and CompleteUnimported=0
+
+# Setup new buffer and verify contents are as expected
+vim ex 'e main.go'
+vim ex 'r main.go.orig | 0d_'
+vim ex 'noau w! check'
+cmp check main.go.orig
+
+# Attempt unimported completion
+vim ex 'call cursor(4,1)'
+vim normal Sfmt.Pr
+vim ex 'execute \"normal A\\<C-X>\\<C-O>\\<C-N>\\<C-N>(\\\"Hello\\\")\"'
+
+# Attempt unimported completion; we should get zero results.
+# If we did get results (from fmt) then attempting completion
+# would expand from fmt.Pr to fmt.Print, i.e. the longest match
+# of the returned candidates
+vim ex 'call cursor(4,1)'
+vim normal Sfmt.Pr
+vim ex 'execute \"normal A\\<C-X>\\<C-O>(\\\"Hello\\\")\"'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go.orig --
+package main
+
+func main() {
+
+}
+-- main.go1.golden --
+package main
+
+func main() {
+	fmt.Pr("Hello")
+}

--- a/cmd/govim/testdata/scenario_no_completeunimported/user_config.json
+++ b/cmd/govim/testdata/scenario_no_completeunimported/user_config.json
@@ -1,0 +1,3 @@
+{
+	"CompleteUnimported": false
+}


### PR DESCRIPTION
Following d80f0e2 unimported completions are turned on by default. This
commit adds tests to ensure setting CompleteUnimported to false disables
completion for unimported packages.