### PR TITLE
cmd/govim: fix embarrassingly bad bug in buffer listener reset

### DIFF
--- a/cmd/govim/buffer_events.go
+++ b/cmd/govim/buffer_events.go
@@ -211,10 +211,11 @@ func (v *vimstate) bufUnloadImpl(bufnr int) error {
 	}
 
 	v.ChannelCall("listener_remove", b.Listener)
+	b.Listener = 0
+
 	if !bufferOfInterestToGopls(b) {
 		return nil
 	}
-	b.Listener = 0
 	params := &protocol.DidCloseTextDocumentParams{
 		TextDocument: b.ToTextDocumentIdentifier(),
 	}

--- a/cmd/govim/testdata/scenario_default/non_go_file_navigation.txt
+++ b/cmd/govim/testdata/scenario_default/non_go_file_navigation.txt
@@ -1,0 +1,17 @@
+# Test that moving between various non .go files (more specifically, files that
+# are not of interest to gopls) works. This ensures we exercise the buffer
+# life-cycle methods, as well as some of the existing Vim bugs, and hence
+# ensuring the govim workarounds for these bugs work.
+
+vim ex 'e a.txt'
+vim ex 'e b.txt'
+vim ex 'e a.txt'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- a.txt --
+a
+-- b.txt --
+b


### PR DESCRIPTION
We were only setting a buffer's listener to 0 (i.e. no listener) on
unload for buffers that were of interest to gopls. Hence for non-gopls
buffers we were getting strange lifecycle errors.

Add a test to verify that moving around between non gopls buffers works,
a test that failed before this fix.