### PR TITLE
cmd/govim: workaround BufWinEnter without BufNew bug

### DIFF
--- a/cmd/govim/testdata/scenario_bugs/bug_vim_5694.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_vim_5694.txt
@@ -1,0 +1,9 @@
+# Verify that we have successfully worked-around the bug described in
+# https://github.com/vim/vim/issues/5694
+
+vim ex 'tabe .'
+vim ex 'tabe .'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'


### PR DESCRIPTION
Because of https://github.com/vim/vim/issues/5694 we can find ourselves
in a situation where we get a BufDelete or BufWinEnter for a buffer we
know nothing about. Hence we need to ignore the event or force create
that buffer as a workaround respectively.