### PR TITLE
deps: upgrade x/tools and gopls to 066e0c02

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/debug/serve.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/debug/serve.go
@@ -49,7 +49,7 @@ type Instance struct {
 
 	LogWriter io.Writer
 
-	ocagent    export.Exporter
+	ocagent    *ocagent.Exporter
 	prometheus *prometheus.Exporter
 	rpcs       *rpcs
 	traces     *traces
@@ -537,12 +537,6 @@ func (i *Instance) Metric(ctx context.Context, data telemetry.MetricData) {
 	}
 	if i.rpcs != nil {
 		i.rpcs.Metric(ctx, data)
-	}
-}
-
-func (i *Instance) Flush() {
-	if i.ocagent != nil {
-		i.ocagent.Flush()
 	}
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/lsprpc.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/lsprpc.go
@@ -318,7 +318,7 @@ func startRemote(goplsPath, network, address string) error {
 	args := []string{"serve",
 		"-listen", fmt.Sprintf(`%s;%s`, network, address),
 		"-listen.timeout", "1m",
-		"-debug", ":0",
+		"-debug", "localhost:0",
 		"-logfile", "auto",
 	}
 	cmd := exec.Command(goplsPath, args...)

--- a/cmd/govim/internal/golang_org_x_tools/telemetry/export/export.go
+++ b/cmd/govim/internal/golang_org_x_tools/telemetry/export/export.go
@@ -26,8 +26,6 @@ type Exporter interface {
 	Log(context.Context, telemetry.Event)
 
 	Metric(context.Context, telemetry.MetricData)
-
-	Flush()
 }
 
 var (
@@ -106,13 +104,4 @@ func Metric(ctx context.Context, data telemetry.MetricData) {
 		return
 	}
 	exporter.Metric(ctx, data)
-}
-
-func Flush() {
-	exporterMu.Lock()
-	defer exporterMu.Unlock()
-	if exporter == nil {
-		return
-	}
-	exporter.Flush()
 }

--- a/cmd/govim/internal/golang_org_x_tools/telemetry/export/log.go
+++ b/cmd/govim/internal/golang_org_x_tools/telemetry/export/log.go
@@ -34,4 +34,3 @@ func (w *logWriter) Log(ctx context.Context, event telemetry.Event) {
 	fmt.Fprintf(w.writer, "%v\n", event)
 }
 func (w *logWriter) Metric(context.Context, telemetry.MetricData) {}
-func (w *logWriter) Flush()                                       {}

--- a/cmd/govim/internal/golang_org_x_tools/telemetry/export/ocagent/ocagent.go
+++ b/cmd/govim/internal/golang_org_x_tools/telemetry/export/ocagent/ocagent.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/telemetry"
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/telemetry/export"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/telemetry/export/ocagent/wire"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/telemetry/tag"
 )
@@ -43,7 +42,7 @@ func Discover() *Config {
 	}
 }
 
-type exporter struct {
+type Exporter struct {
 	mu      sync.Mutex
 	config  Config
 	spans   []*telemetry.Span
@@ -53,11 +52,11 @@ type exporter struct {
 // Connect creates a process specific exporter with the specified
 // serviceName and the address of the ocagent to which it will upload
 // its telemetry.
-func Connect(config *Config) export.Exporter {
+func Connect(config *Config) *Exporter {
 	if config == nil || config.Address == "off" {
 		return nil
 	}
-	exporter := &exporter{config: *config}
+	exporter := &Exporter{config: *config}
 	if exporter.config.Start.IsZero() {
 		exporter.config.Start = time.Now()
 	}
@@ -85,23 +84,23 @@ func Connect(config *Config) export.Exporter {
 	return exporter
 }
 
-func (e *exporter) StartSpan(ctx context.Context, span *telemetry.Span) {}
+func (e *Exporter) StartSpan(ctx context.Context, span *telemetry.Span) {}
 
-func (e *exporter) FinishSpan(ctx context.Context, span *telemetry.Span) {
+func (e *Exporter) FinishSpan(ctx context.Context, span *telemetry.Span) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.spans = append(e.spans, span)
 }
 
-func (e *exporter) Log(context.Context, telemetry.Event) {}
+func (e *Exporter) Log(context.Context, telemetry.Event) {}
 
-func (e *exporter) Metric(ctx context.Context, data telemetry.MetricData) {
+func (e *Exporter) Metric(ctx context.Context, data telemetry.MetricData) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.metrics = append(e.metrics, data)
 }
 
-func (e *exporter) Flush() {
+func (e *Exporter) Flush() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	spans := make([]*wire.Span, len(e.spans))
@@ -149,7 +148,7 @@ func (cfg *Config) buildNode() *wire.Node {
 	}
 }
 
-func (e *exporter) send(endpoint string, message interface{}) {
+func (e *Exporter) send(endpoint string, message interface{}) {
 	blob, err := json.Marshal(message)
 	if err != nil {
 		errorInExport("ocagent failed to marshal message for %v: %v", endpoint, err)

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.5.2
 	golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/tools v0.0.0-20200228135638-5c7c66ced534
-	golang.org/x/tools/gopls v0.1.8-0.20200228135638-5c7c66ced534
+	golang.org/x/tools v0.0.0-20200301222351-066e0c02454c
+	golang.org/x/tools/gopls v0.1.8-0.20200301222351-066e0c02454c
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -57,10 +57,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200228135638-5c7c66ced534 h1:XVzrScQUlfS6ssloilmEJdJhlMDtnculCx+0zmVHSA8=
-golang.org/x/tools v0.0.0-20200228135638-5c7c66ced534/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools/gopls v0.1.8-0.20200228135638-5c7c66ced534 h1:F9jVYLQnpJSTkxaVWlymEVRhb7g4SzlcsBV+j5c66BY=
-golang.org/x/tools/gopls v0.1.8-0.20200228135638-5c7c66ced534/go.mod h1:3Zj0dq5cCIMoIi/qOBNykuYuHBiyu+626Z6eJPZDYWY=
+golang.org/x/tools v0.0.0-20200301222351-066e0c02454c h1:FD7jysxM+EJqg5UYYy3XYDsAiUickFsn4UiaanJkf8c=
+golang.org/x/tools v0.0.0-20200301222351-066e0c02454c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools/gopls v0.1.8-0.20200301222351-066e0c02454c h1:gERcDNdy9selA1pxrhEp/spTNRIAoLDuOxnOdnIyNrs=
+golang.org/x/tools/gopls v0.1.8-0.20200301222351-066e0c02454c/go.mod h1:3Zj0dq5cCIMoIi/qOBNykuYuHBiyu+626Z6eJPZDYWY=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/lsp/lsprpc: use localhost for remote gopls debug interface 066e0c02
* internal/telemetry: remove Flush method from exporter 71482053
* go/packages: drop imports of reflect in tests of import graph a628ca32