### PR TITLE
cmd/govim: handle nil response to Hover

### DIFF
--- a/cmd/govim/hover.go
+++ b/cmd/govim/hover.go
@@ -38,7 +38,7 @@ func (v *vimstate) hoverMsgAt(pos types.Point, tdi protocol.TextDocumentIdentifi
 	if err != nil {
 		return "", fmt.Errorf("failed to get hover details: %v", err)
 	}
-	if *hovRes == (protocol.Hover{}) {
+	if hovRes == nil || *hovRes == (protocol.Hover{}) {
 		return "", nil
 	}
 	return strings.TrimSpace(hovRes.Contents.Value), nil


### PR DESCRIPTION
In the current gopls implementation, if there is nothing under the
cursor when we call Hover we simply get a zero value protocol.Hover
returned (albeit via a pointer variable).

As of de023d59a5d1 gopls now returns a zero value of type
*protocol.Hover. Hence where we previously assumed we would not get a
nil value we now do.

Fix that.