### PR TITLE
cmd/govim: remove one of the file watchers

### DIFF
--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -322,22 +322,6 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 		return err
 	}
 
-	// Temporary fix for the fact that gopls does not yet support watching (via
-	// the client) changed files: https://github.com/golang/go/issues/31553
-	gomodpath, err := goModPath(g.vimstate.workingDirectory)
-	if err != nil {
-		return fmt.Errorf("failed to derive go.mod path: %v", err)
-	}
-
-	if gomodpath != "" {
-		// i.e. we are in a module
-		mw, err := newModWatcher(g, gomodpath)
-		if err != nil {
-			return fmt.Errorf("failed to create modWatcher for %v: %v", gomodpath, err)
-		}
-		g.modWatcher = mw
-	}
-
 	return nil
 }
 
@@ -468,8 +452,6 @@ func (g *govimplugin) startGopls() error {
 		return fmt.Errorf("failed to call gopls.Initialized: %v", err)
 	}
 
-	// Temporary fix for the fact that gopls does not yet support watching (via
-	// the client) changed files: https://github.com/golang/go/issues/31553
 	gomodpath, err := goModPath(g.vimstate.workingDirectory)
 	if err != nil {
 		return fmt.Errorf("failed to derive go.mod path: %v", err)

--- a/cmd/govim/watcher.go
+++ b/cmd/govim/watcher.go
@@ -27,13 +27,9 @@ type modWatcher struct {
 
 	// watches is the set of current watches "open" in the watcher
 	watches map[string]bool
-
-	// files is a map of open files and the current version known to gopls
-	// that are _not_ being handled by Vim in open buffers
-	files map[string]int
 }
 
-func (mw *modWatcher) close() error { return mw.watcher.Close() }
+func (m *modWatcher) close() error { return m.watcher.Close() }
 
 // newWatcher returns a new watcher that will "watch" on the Go files in the
 // module identified by gomodpath
@@ -54,7 +50,6 @@ func newModWatcher(plug *govimplugin, gomodpath string) (*modWatcher, error) {
 		watcher:     w,
 		root:        dirpath,
 		watches:     make(map[string]bool),
-		files:       make(map[string]int),
 	}
 
 	go res.watch()


### PR DESCRIPTION
There are currently two file watchers being started, one in Init(...)
and one in startGopls(...). This leads to duplicate
DidChangeWatchedFiles calls to gopls.

Remove one of them, as well as a dated comment about this being a
temporary fix.

This change also removes a field "files" (on the modwatcher struct)
that isn't used anymore.