### PR TITLE
cmd/govim: fix "next" motion key mappings for top-level declarations

### DIFF
--- a/cmd/govim/testdata/scenario_default/motion.txt
+++ b/cmd/govim/testdata/scenario_default/motion.txt
@@ -3,12 +3,12 @@
 vim ex 'e main.go'
 
 # Next start of File.Decl
-vim ex 'normal ]]'
+vim ex 'normal ]['
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '\[3,1\]'
 
 # Next end of File.Decl
-vim ex 'normal ]['
+vim ex 'normal ]]'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '\[5,1\]'
 

--- a/cmd/govim/testdata/scenario_default/motion_bad_ast.txt
+++ b/cmd/govim/testdata/scenario_default/motion_bad_ast.txt
@@ -3,8 +3,8 @@
 vim ex 'e main.go'
 
 # Next start of File.Decl
-vim ex 'normal ]['
-vim ex 'normal ]['
+vim ex 'normal ]]'
+vim ex 'normal ]]'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '\[8,29\]'
 

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -17,6 +17,6 @@ if GOVIMPluginStatus() == "initcomplete"
   " Motions
   nnoremap <buffer> <silent> [[ :call GOVIMMotion("prev", "File.Decls.Pos()")<cr>
   nnoremap <buffer> <silent> [] :call GOVIMMotion("prev", "File.Decls.End()")<cr>
-  nnoremap <buffer> <silent> ]] :call GOVIMMotion("next", "File.Decls.Pos()")<cr>
-  nnoremap <buffer> <silent> ][ :call GOVIMMotion("next", "File.Decls.End()")<cr>
+  nnoremap <buffer> <silent> ][ :call GOVIMMotion("next", "File.Decls.Pos()")<cr>
+  nnoremap <buffer> <silent> ]] :call GOVIMMotion("next", "File.Decls.End()")<cr>
 endif


### PR DESCRIPTION
The "next" mappings are the wrong way around: ]] when to the start of
the next top-level declaration, ][ to the end.

Fix that by switching them around.