### PR TITLE
cmd/govim: add autoread loaded buffers support

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -120,6 +120,10 @@ function! s:validGoplsEnv(v)
   return [v:true, ""]
 endfunction
 
+function! s:validExperimentalAutoreadLoadedBuffers(v)
+  return s:validBool(a:v)
+endfunction
+
 function! s:validExperimentalMouseTriggeredHoverPopupOptions(v)
   if has_key(a:v, "line")
     if type(a:v["line"]) != 0
@@ -153,6 +157,7 @@ let s:validators = {
       \ "CompletionBudget": function("s:validCompletionBudget"),
       \ "TempModfile": function("s:validTempModfile"),
       \ "GoplsEnv": function("s:validGoplsEnv"),
+      \ "ExperimentalAutoreadLoadedBuffers": function("s:validExperimentalAutoreadLoadedBuffers"),
       \ "ExperimentalMouseTriggeredHoverPopupOptions": function("s:validExperimentalMouseTriggeredHoverPopupOptions"),
       \ "ExperimentalCursorTriggeredHoverPopupOptions": function("s:validExperimentalCursorTriggeredHoverPopupOptions"),
       \ }

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -151,6 +151,21 @@ type Config struct {
 	// GOFLAGS=-modfile=go.local.mod in order to use an alternative go.mod file.
 	GoplsEnv *map[string]string `json:",omitempty"`
 
+	// ExperimentalAutoreadLoadedBuffers is used to reload buffers that are
+	// changed outside vim even when they are loaded (e.g. running two vim
+	// sessions in the same workspace). This is achieved by running "checktime"
+	// when a file system event is handled. For this to work, vim must be
+	// configured to hide buffers instead of abandon them. It is also
+	// recommended to set autoread in vim to avoid a confirmation prompt when
+	// the buffer isn't modified.
+	// Recommended additions to vimrc:
+	//
+	// set hidden
+	// set autoread
+	//
+	// Default: false
+	ExperimentalAutoreadLoadedBuffers *bool `json:",omitempty"`
+
 	// ExperimentalMouseTriggeredHoverPopupOptions is a map of options to apply
 	// when creating hover-based popup windows triggered by the mouse hovering
 	// over an identifier. It corresponds to the second argument to popup_create

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -43,6 +43,9 @@ func (r *Config) Apply(v *Config) {
 	if v.GoplsEnv != nil {
 		r.GoplsEnv = v.GoplsEnv
 	}
+	if v.ExperimentalAutoreadLoadedBuffers != nil {
+		r.ExperimentalAutoreadLoadedBuffers = v.ExperimentalAutoreadLoadedBuffers
+	}
 	if v.ExperimentalMouseTriggeredHoverPopupOptions != nil {
 		r.ExperimentalMouseTriggeredHoverPopupOptions = v.ExperimentalMouseTriggeredHoverPopupOptions
 	}

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -21,26 +21,28 @@ type VimConfig struct {
 	CompletionBudget                             *string
 	TempModfile                                  *int
 	GoplsEnv                                     *map[string]string
+	ExperimentalAutoreadLoadedBuffers            *int
 	ExperimentalMouseTriggeredHoverPopupOptions  *map[string]interface{}
 	ExperimentalCursorTriggeredHoverPopupOptions *map[string]interface{}
 }
 
 func (c *VimConfig) ToConfig(d config.Config) config.Config {
 	v := config.Config{
-		FormatOnSave:              c.FormatOnSave,
-		QuickfixSigns:             boolVal(c.QuickfixSigns, d.QuickfixSigns),
-		QuickfixAutoDiagnostics:   boolVal(c.QuickfixAutoDiagnostics, d.QuickfixAutoDiagnostics),
-		HighlightDiagnostics:      boolVal(c.HighlightDiagnostics, d.HighlightDiagnostics),
-		HighlightReferences:       boolVal(c.HighlightReferences, d.HighlightReferences),
-		HoverDiagnostics:          boolVal(c.HoverDiagnostics, d.HoverDiagnostics),
-		CompletionDeepCompletions: boolVal(c.CompletionDeepCompletions, d.CompletionDeepCompletions),
-		CompletionMatcher:         c.CompletionMatcher,
-		Staticcheck:               boolVal(c.Staticcheck, d.Staticcheck),
-		CompleteUnimported:        boolVal(c.CompleteUnimported, d.CompleteUnimported),
-		GoImportsLocalPrefix:      stringVal(c.GoImportsLocalPrefix, d.GoImportsLocalPrefix),
-		CompletionBudget:          stringVal(c.CompletionBudget, d.CompletionBudget),
-		TempModfile:               boolVal(c.TempModfile, d.TempModfile),
-		GoplsEnv:                  copyStringValMap(c.GoplsEnv, d.GoplsEnv),
+		FormatOnSave:                      c.FormatOnSave,
+		QuickfixSigns:                     boolVal(c.QuickfixSigns, d.QuickfixSigns),
+		QuickfixAutoDiagnostics:           boolVal(c.QuickfixAutoDiagnostics, d.QuickfixAutoDiagnostics),
+		HighlightDiagnostics:              boolVal(c.HighlightDiagnostics, d.HighlightDiagnostics),
+		HighlightReferences:               boolVal(c.HighlightReferences, d.HighlightReferences),
+		HoverDiagnostics:                  boolVal(c.HoverDiagnostics, d.HoverDiagnostics),
+		CompletionDeepCompletions:         boolVal(c.CompletionDeepCompletions, d.CompletionDeepCompletions),
+		CompletionMatcher:                 c.CompletionMatcher,
+		Staticcheck:                       boolVal(c.Staticcheck, d.Staticcheck),
+		CompleteUnimported:                boolVal(c.CompleteUnimported, d.CompleteUnimported),
+		GoImportsLocalPrefix:              stringVal(c.GoImportsLocalPrefix, d.GoImportsLocalPrefix),
+		CompletionBudget:                  stringVal(c.CompletionBudget, d.CompletionBudget),
+		TempModfile:                       boolVal(c.TempModfile, d.TempModfile),
+		GoplsEnv:                          copyStringValMap(c.GoplsEnv, d.GoplsEnv),
+		ExperimentalAutoreadLoadedBuffers: boolVal(c.ExperimentalAutoreadLoadedBuffers, d.ExperimentalAutoreadLoadedBuffers),
 		ExperimentalMouseTriggeredHoverPopupOptions:  copyMap(c.ExperimentalMouseTriggeredHoverPopupOptions, d.ExperimentalMouseTriggeredHoverPopupOptions),
 		ExperimentalCursorTriggeredHoverPopupOptions: copyMap(c.ExperimentalCursorTriggeredHoverPopupOptions, d.ExperimentalCursorTriggeredHoverPopupOptions),
 	}

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -236,14 +236,15 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 	}
 	if defaults == nil {
 		defaults = &config.Config{
-			FormatOnSave:            vimconfig.FormatOnSaveVal(config.FormatOnSaveGoImportsGoFmt),
-			QuickfixAutoDiagnostics: vimconfig.BoolVal(true),
-			QuickfixSigns:           vimconfig.BoolVal(true),
-			Staticcheck:             vimconfig.BoolVal(false),
-			HighlightDiagnostics:    vimconfig.BoolVal(true),
-			HighlightReferences:     vimconfig.BoolVal(true),
-			HoverDiagnostics:        vimconfig.BoolVal(true),
-			TempModfile:             vimconfig.BoolVal(false),
+			FormatOnSave:                      vimconfig.FormatOnSaveVal(config.FormatOnSaveGoImportsGoFmt),
+			QuickfixAutoDiagnostics:           vimconfig.BoolVal(true),
+			QuickfixSigns:                     vimconfig.BoolVal(true),
+			Staticcheck:                       vimconfig.BoolVal(false),
+			HighlightDiagnostics:              vimconfig.BoolVal(true),
+			HighlightReferences:               vimconfig.BoolVal(true),
+			HoverDiagnostics:                  vimconfig.BoolVal(true),
+			TempModfile:                       vimconfig.BoolVal(false),
+			ExperimentalAutoreadLoadedBuffers: vimconfig.BoolVal(false),
 		}
 	}
 	// Overlay the initial user values on the defaults

--- a/cmd/govim/testdata/scenario_autoreadloadedbuffers/autoread_loaded_buffers.txt
+++ b/cmd/govim/testdata/scenario_autoreadloadedbuffers/autoread_loaded_buffers.txt
@@ -1,0 +1,64 @@
+# Test that the file watcher trigger autoread of loaded buffer.
+#
+# Note that 'hidden' is required to hide buffers instead of abandon
+# them, so that they are still loaded after switching to another buffer
+# 'autoread' is to prevent a prompt when there is no conflicting
+# content in the buffer versus file on disk.
+vim ex 'set hidden'
+vim ex 'set autoread'
+
+vim ex 'e const.go'
+vim ex 'e main.go'
+
+# "edit" the loaded file from outside of vim
+cp const.go.commented const.go
+
+vimexprwait errors.undeclared GOVIMTest_getqflist()
+
+# No warnings or errors during the test
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(Const1)
+}
+-- const.go --
+package main
+
+const (
+	Const1 = 1
+	Const2 = 2
+)
+-- const.go.commented --
+package main
+
+const (
+	// Const1 = 1
+	Const2 = 2
+)
+-- errors.undeclared --
+[
+  {
+    "bufname": "main.go",
+    "col": 14,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: Const1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]

--- a/cmd/govim/testdata/scenario_autoreadloadedbuffers/user_config.json
+++ b/cmd/govim/testdata/scenario_autoreadloadedbuffers/user_config.json
@@ -1,0 +1,3 @@
+{
+	"ExperimentalAutoreadLoadedBuffers": true
+}


### PR DESCRIPTION
If a file is updated on disk while it is open in vim, govim/gopls won't
pick up the change automatically.

This change adds a config setting "AutoreadLoadedBuffers" that is used
to reload buffers for files that change outside vim. It requires the
buffer to be "loaded" since it uses "checktime" to reload the file.

This feature is not enabled by default. Add the following to your vimrc
to enable it:

set autoread
set hidden
call govim#config#Set("AutoreadLoadedBuffers", 1)

"set autoread" will suppress a confirmation prompt when a buffer that
isn't modified is reloaded (a prompt will still be shown if the buffer
is modified). This line is optional.

"set hidden" will configure vim to keep buffers loaded when switched,
instead of the default that is to abandon them. This is required for the
feature to work with buffers that aren't switched away.