### PR TITLE
govim: move plugin errorchan read to avoid deadlock

### DIFF
--- a/govim.go
+++ b/govim.go
@@ -312,6 +312,10 @@ func (g *govimImpl) load() error {
 		g.Logf("No build info available")
 	}
 
+	g.tomb.Go(func() error {
+		return <-g.pluginErrCh
+	})
+
 	if g.plugin != nil {
 		g.pluginErrCh = make(chan error)
 		err := g.DoProto(func() error {
@@ -340,9 +344,6 @@ func (g *govimImpl) load() error {
 			return err
 		}
 
-		g.tomb.Go(func() error {
-			return <-g.pluginErrCh
-		})
 	}
 
 	select {


### PR DESCRIPTION
If Init() fails, for example gopls exits, we might end
up in a deadlock since we don't read the plugin error channel
until after Init().

This change moves the reading goroutine so that it is started before
Init().