### PR TITLE
govim: move plugin errorchan read to avoid data race

### DIFF
--- a/govim.go
+++ b/govim.go
@@ -312,12 +312,13 @@ func (g *govimImpl) load() error {
 		g.Logf("No build info available")
 	}
 
-	g.tomb.Go(func() error {
-		return <-g.pluginErrCh
-	})
-
 	if g.plugin != nil {
 		g.pluginErrCh = make(chan error)
+
+		g.tomb.Go(func() error {
+			return <-g.pluginErrCh
+		})
+
 		err := g.DoProto(func() error {
 			var details struct {
 				Version     string


### PR DESCRIPTION
Embarrassing enough PR 828 fixed the deadlock but introduced a data
race where the plugin error channel was read in a goroutine created
before the channel was created.

This change fixes the data race by moving the reading goroutine to be
started after the channel creation.