### PR TITLE
cmd/govim: implement Implements in gopls

### DIFF
--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -225,6 +225,10 @@ const (
 	// CommandReferences finds references to the identifier under the cursor.
 	CommandReferences Command = "References"
 
+	// CommandImplements finds all interfaces implemented by the type of the
+	// identifier under the cursor.
+	CommandImplements Command = "Implements"
+
 	// CommandRename renames the identifier under the cursor. If provided with an
 	// argument, that argument is used as the new name. If not, the user is
 	// prompted for the new identifier name.

--- a/cmd/govim/implements.go
+++ b/cmd/govim/implements.go
@@ -8,16 +8,14 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 )
 
-func (v *vimstate) references(flags govim.CommandFlags, args ...string) error {
+func (v *vimstate) implements(flags govim.CommandFlags, args ...string) error {
 	v.quickfixIsDiagnostics = false
 	b, pos, err := v.cursorPos()
 	if err != nil {
 		return fmt.Errorf("failed to get current position: %v", err)
 	}
-	params := &protocol.ReferenceParams{
-		Context: protocol.ReferenceContext{
-			IncludeDeclaration: true,
-		},
+
+	params := &protocol.ImplementationParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{
 				URI: protocol.DocumentURI(b.URI()),
@@ -26,14 +24,14 @@ func (v *vimstate) references(flags govim.CommandFlags, args ...string) error {
 		},
 	}
 
-	refs, err := v.server.References(context.Background(), params)
+	implts, err := v.server.Implementation(context.Background(), params)
 	if err != nil {
-		return fmt.Errorf("called to gopls.References failed: %v", err)
+		return fmt.Errorf("call to gopls.Implementation failed: %v", err)
 	}
-	if len(refs) == 0 {
-		return fmt.Errorf("unexpected zero length of references")
+	if len(implts) == 0 {
+		return fmt.Errorf("unexpected zero length of implementations")
 	}
 
-	v.populateQuickfix(refs, true)
+	v.populateQuickfix(implts, false)
 	return nil
 }

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -298,6 +298,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineFunction(string(config.FunctionSetUserBusy), []string{"isBusy", "cursorPos"}, g.vimstate.setUserBusy)
 	g.DefineFunction(string(config.FunctionPopupSelection), []string{"id", "selected"}, g.vimstate.popupSelection)
 	g.DefineCommand(string(config.CommandReferences), g.vimstate.references)
+	g.DefineCommand(string(config.CommandImplements), g.vimstate.implements)
 	g.DefineCommand(string(config.CommandRename), g.vimstate.rename, govim.NArgsZeroOrOne)
 	g.DefineCommand(string(config.CommandStringFn), g.vimstate.stringfns, govim.RangeLine, govim.CompleteCustomList(PluginPrefix+config.FunctionStringFnComplete), govim.NArgsOneOrMore)
 	g.DefineFunction(string(config.FunctionStringFnComplete), []string{"ArgLead", "CmdLine", "CursorPos"}, g.vimstate.stringfncomplete)

--- a/cmd/govim/testdata/scenario_default/implements.txt
+++ b/cmd/govim/testdata/scenario_default/implements.txt
@@ -1,0 +1,76 @@
+# Test that the quickfix window gets populated with locations for the
+# GOVIMImplements command
+
+[short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'
+
+# Initial localtion population
+vim ex 'e main.go'
+vim ex 'call cursor (9,6)' #TODO: replcae with my values
+vim ex 'GOVIMImplements' # note this moves the cursor to the quickfix window
+vim ex 'call win_gotoid(win_findbuf(bufnr(\"main.go\"))[0])'
+vimexprwait locations.golden GOVIMTest_getqflist()
+
+# Introduce an error - locations should remain
+vim ex 'call cursor(14, 1)'
+vim ex 'call feedkeys(\"ofmt.Printf(\\\"%v\\\")\\<ESC>\", \"xt\")'
+sleep $GOVIM_ERRLOGMATCH_WAIT
+vimexprwait locations.golden GOVIMTest_getqflist()
+
+# Now use quickfix for errors
+vim ex 'GOVIMQuickfixDiagnostics'
+vimexprwait errors.golden GOVIMTest_getqflist()
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+import "fmt"
+
+type Foo interface {
+	Bar()
+}
+
+type Baz struct{}
+func (b Baz) Bar() {}
+
+func main() {
+	b := Baz{}
+	fmt.Printf("v: %v\n", b)
+}
+-- locations.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "type Foo interface {",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 15,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]

--- a/cmd/govim/util.go
+++ b/cmd/govim/util.go
@@ -3,7 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"sort"
+	"strings"
 
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	"github.com/govim/govim/cmd/govim/internal/types"
 )
 
@@ -43,4 +49,83 @@ func (v *vimstate) cursorPos() (b *types.Buffer, p types.Point, err error) {
 	}
 	p, err = types.PointFromVim(b, pos.Line, pos.Col)
 	return
+}
+
+// populateQuickfix populates and opens a quickfix window with a sorted
+// slice of locations. If shift is true the first element of the slice
+// will be skipped.
+func (v *vimstate) populateQuickfix(locs []protocol.Location, shift bool) {
+	// must be non-nil
+	qf := []quickfixEntry{}
+
+	for _, loc := range locs {
+		var buf *types.Buffer
+		for _, b := range v.buffers {
+			if b.Loaded && b.URI() == span.URI(loc.URI) {
+				buf = b
+			}
+		}
+		fn := span.URI(loc.URI).Filename()
+		if buf == nil {
+			byts, err := ioutil.ReadFile(fn)
+			if err != nil {
+				v.Logf("populateQuickfix: failed to read contents of %v: %v", fn, err)
+				continue
+			}
+			// create a temp buffer
+			buf = types.NewBuffer(-1, fn, byts, false)
+		}
+		// make fn relative for reporting purposes
+		fn, err := filepath.Rel(v.workingDirectory, fn)
+		if err != nil {
+			v.Logf("populateQuickfix: failed to call filepath.Rel(%q, %q): %v", v.workingDirectory, fn, err)
+			continue
+		}
+		p, err := types.PointFromPosition(buf, loc.Range.Start)
+		if err != nil {
+			v.Logf("popularQuickfix: failed to resolve position: %v", err)
+			continue
+		}
+		line, err := buf.Line(p.Line())
+		if err != nil {
+			v.Logf("popularQuickfix: location invalid in buffer: %v", err)
+			continue
+		}
+		qf = append(qf, quickfixEntry{
+			Filename: fn,
+			Lnum:     p.Line(),
+			Col:      p.Col(),
+			Text:     line,
+		})
+	}
+
+	var toSort []quickfixEntry
+
+	if shift {
+		toSort = qf[1:]
+	} else {
+		toSort = qf
+	}
+
+	sort.Slice(toSort, func(i, j int) bool {
+		lhs, rhs := toSort[i], toSort[j]
+		cmp := strings.Compare(lhs.Filename, rhs.Filename)
+		if cmp != 0 {
+			if lhs.Filename == qf[0].Filename {
+				return true
+			} else if rhs.Filename == qf[0].Filename {
+				return false
+			}
+		}
+		if cmp == 0 {
+			cmp = lhs.Lnum - rhs.Lnum
+		}
+		if cmp == 0 {
+			cmp = lhs.Col - rhs.Col
+		}
+		return cmp < 0
+	})
+
+	v.ChannelCall("setqflist", qf, "r")
+	v.ChannelEx("copen")
 }


### PR DESCRIPTION
This change adds the command GOVIMImplements which shows all
interfaces that the identifier under the cursor implements.

Fixes #577