### PR TITLE
cmd/govim/testdata/scenario_default: fix complete watched test for latest gopls changes

### DIFF
--- a/cmd/govim/testdata/scenario_default/complete_watched.txt
+++ b/cmd/govim/testdata/scenario_default/complete_watched.txt
@@ -10,6 +10,7 @@ vim ex 'w'
 cmp main.go main.go.golden
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
 # errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --

--- a/cmd/govim/testdata/scenario_default/complete_watched.txt
+++ b/cmd/govim/testdata/scenario_default/complete_watched.txt
@@ -4,13 +4,12 @@
 vim ex 'e main.go'
 cp const.go.orig const.go
 errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const.go'", Type:1\}'
-vim ex 'call cursor(6,16)'
+vim ex 'call cursor(6,17)'
 vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<C-N>\\<ESC>\", \"x\")'
 vim ex 'w'
 cmp main.go main.go.golden
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
-# Disabled pending resolution to https://github.com/golang/go/issues/34103
 # errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
 
 -- go.mod --
@@ -23,7 +22,7 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Println()
+	fmt.Println(C)
 }
 -- const.go.orig --
 package main

--- a/cmd/govim/testdata/scenario_default/complete_watched.txt
+++ b/cmd/govim/testdata/scenario_default/complete_watched.txt
@@ -5,7 +5,7 @@ vim ex 'e main.go'
 cp const.go.orig const.go
 errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const.go'", Type:1\}'
 vim ex 'call cursor(6,17)'
-vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<C-N>\\<ESC>\", \"x\")'
+vim ex 'call feedkeys(\"i\\<C-X>\\<C-O>\\<C-N>\\<ESC>\", \"x\")'
 vim ex 'w'
 cmp main.go main.go.golden
 


### PR DESCRIPTION
https://golang.org/cl/223877 changed the behavior of `gopls` to prefer unexported symbols to exported ones. Add a `C` prefix to the complete watched tests to avoid relying on this behavior.