### PR TITLE
test: add test of completion with additional text edits

### DIFF
--- a/cmd/govim/testdata/scenario_default/complete_additionaltextedits.txt
+++ b/cmd/govim/testdata/scenario_default/complete_additionaltextedits.txt
@@ -1,0 +1,73 @@
+# Test that ominfunc complete works when gopls sends additional text edits
+
+# Backup main.go
+cp main.go main.go.orig
+
+# Select candidate using cursor keys and enter
+cp main.go.orig main.go
+vim ex 'e! main.go'
+vim ex 'call cursor(12,1)'
+vim ex 'call feedkeys(\"A\\<C-X>\\<C-O>\\<Down>\\<Enter>\", \"xt\")'
+vim ex 'w'
+cmp main.go main.go.golden1
+
+[github.com/govim/govim/issues/836] skip
+
+# Select candidate using <C-N>/<C-P> and non-enter key
+cp main.go.orig main.go
+vim ex 'e! main.go'
+vim ex 'call cursor(12,1)'
+vim ex 'call feedkeys(\"A\\<C-X>\\<C-O>)\", \"xt\")'
+vim ex 'w'
+cmp main.go main.go.golden2
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+type foo struct {
+	aaa *string
+	bbb *string
+}
+
+func fn(s string) {}
+
+func main() {
+	var x foo
+	fn(x.
+}
+-- main.go.golden1 --
+package main
+
+type foo struct {
+	aaa *string
+	bbb *string
+}
+
+func fn(s string) {}
+
+func main() {
+	var x foo
+	fn(*x.bbb
+}
+-- main.go.golden2 --
+package main
+
+type foo struct {
+	aaa *string
+	bbb *string
+}
+
+func fn(s string) {}
+
+func main() {
+	var x foo
+	fn(*x.aaa)
+}

--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -59,6 +59,13 @@ let s:activeGovimCalls = 0
 augroup govimScheduler
 
 function s:ch_evalexpr(args)
+  " For all callbacks to govim (other than the handler ultimately responsible
+  " for a listener_add callback) we need to flush any pending delta
+  " notifications so that govim isn't ever working with stale buffer
+  " contents
+  if a:args[0] != "function" || a:args[1] != "function:GOVIM_internal_BufChanged"
+    call listener_flush()
+  endif
   if s:minVimSafeState
     let l:resp = ch_evalexpr(s:channel, a:args)
     if l:resp[0] != ""


### PR DESCRIPTION
This change adds a test of additional text edits sent by gopls.

Currently there is a data race where govim applies the additional
edits to a stale version of the buffer. The issue is tracked
in #830.

Updates #830