### PR TITLE
cmd/govim: echoerr when user tries to load using a bad version of Vim

### DIFF
--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -16,6 +16,11 @@ if !has("patch-8.1.1711")
   finish
 endif
 
+if has("patch-8.2.0452") && !has("patch-8.2.0466")
+  echoerr "Vim versions v8.2.0452 <= N < v8.2.0466 have a bug that affects govim. Please update to another version"
+  finish
+endif
+
 " TODO we are ignoring windows right now....
 let s:tmpdir = $TMPDIR
 if s:tmpdir == ""


### PR DESCRIPTION
Vim v8.2.0452 introduced a bug that affects govim, causing it to hang:

https://groups.google.com/forum/#!msg/vim_dev/AjQA8dE0EpY/miFlLh0PAwAJ

This bug was fixed in v8.2.0466.

Echo an error if the user is found to be using a bad version.

Fixes #837