### PR TITLE
cmd/govim: fix index out of range bug when flipping back to diagnostics

### DIFF
--- a/cmd/govim/diagnostics.go
+++ b/cmd/govim/diagnostics.go
@@ -86,7 +86,7 @@ func (v *vimstate) diagnostics() *[]types.Diagnostic {
 }
 
 func (v *vimstate) handleDiagnosticsChanged() error {
-	if err := v.updateQuickfix(false); err != nil {
+	if err := v.updateQuickfixWithDiagnostics(false, false); err != nil {
 		return err
 	}
 

--- a/cmd/govim/testdata/scenario_bugs/bug_govim_680.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_govim_680.txt
@@ -1,0 +1,47 @@
+# Test case that verifies we have a fix for github.com/govim/govim/issues/680
+
+# Open main.go and verify we have one error
+vim ex 'e main.go'
+vimexprwait errors.golden GOVIMTest_getqflist()
+
+# Find references to x then select the second instance
+vim ex 'call cursor(5,5)'
+vim ex 'GOVIMReferences'
+vim ex 'execute \"normal \\<Down>\\<Enter>\"'
+
+# Now flip back to diagnostics mode
+vim ex ':GOVIMQuickfixDiagnostics'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+import "fmt"
+
+var x int
+
+func main() {
+	fmt.Printf("%v, %v", x)
+}
+-- errors.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 8,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Printf format %v reads arg #2, but call has 1 arg",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -88,7 +88,7 @@ func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {
 			}
 		} else {
 			// QuickfixAutoDiagnostics is now on
-			if err := v.updateQuickfix(true); err != nil {
+			if err := v.updateQuickfixWithDiagnostics(true, false); err != nil {
 				return nil, fmt.Errorf("failed to update diagnostics: %v", err)
 			}
 		}


### PR DESCRIPTION
See the description in the linked issue.

Fixes #680