### PR TITLE
deps: update x/tools and gopls to 9fc00b0a

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/os_darwin.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/os_darwin.go
@@ -1,6 +1,7 @@
 // Copyright 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package cache
 
 import (

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
@@ -131,10 +131,9 @@ func (s *snapshot) FindAnalysisError(ctx context.Context, pkgID, analyzerName, m
 	if analyzer.Analyzer == nil {
 		return nil, nil, errors.Errorf("unexpected analyzer: %s", analyzerName)
 	}
-	if !analyzer.Enabled {
+	if !analyzer.Enabled(s) {
 		return nil, nil, errors.Errorf("disabled analyzer: %s", analyzerName)
 	}
-
 	act, err := s.actionHandle(ctx, packageID(pkgID), analyzer.Analyzer)
 	if err != nil {
 		return nil, nil, err

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/cmd.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/cmd.go
@@ -263,7 +263,6 @@ func (c *connection) initialize(ctx context.Context, options func(*source.Option
 	params.InitializationOptions = map[string]interface{}{
 		"matcher": matcherString[opts.Matcher],
 	}
-
 	if _, err := c.Server.Initialize(ctx, params); err != nil {
 		return err
 	}
@@ -374,8 +373,13 @@ func (c *cmdClient) Configuration(ctx context.Context, p *protocol.ParamConfigur
 			env[l[0]] = l[1]
 		}
 		results[i] = map[string]interface{}{
-			"env":     env,
-			"go-diff": true,
+			"env": env,
+			"analyses": map[string]bool{
+				"fillreturns":    true,
+				"nonewvars":      true,
+				"noresultvalues": true,
+				"undeclaredname": true,
+			},
 		}
 	}
 	return results, nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion_builtin.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion_builtin.go
@@ -59,6 +59,9 @@ func (c *completer) builtinArgType(obj types.Object, call *ast.CallExpr, parentI
 
 	switch obj.Name() {
 	case "append":
+		if parentInf.objType == nil {
+			break
+		}
 		inf.objType = parentInf.objType
 
 		// Check if we are completing the variadic append() param.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/diagnostics.go
@@ -274,14 +274,8 @@ func missingModulesDiagnostics(ctx context.Context, snapshot Snapshot, reports m
 
 func analyses(ctx context.Context, snapshot Snapshot, reports map[FileIdentity][]Diagnostic, ph PackageHandle, analyses map[string]Analyzer) error {
 	var analyzers []*analysis.Analyzer
-	for name, a := range analyses {
-		if enabled, ok := snapshot.View().Options().UserEnabledAnalyses[name]; ok {
-			if enabled {
-				analyzers = append(analyzers, a.Analyzer)
-			}
-			continue
-		}
-		if !a.Enabled {
+	for _, a := range analyses {
+		if !a.Enabled(snapshot) {
 			continue
 		}
 		analyzers = append(analyzers, a.Analyzer)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"time"
 
+	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/asmdecl"
 	"golang.org/x/tools/go/analysis/passes/assign"
 	"golang.org/x/tools/go/analysis/passes/atomic"
@@ -196,6 +197,10 @@ type Hooks struct {
 	URLRegexp          *regexp.Regexp
 	DefaultAnalyzers   map[string]Analyzer
 	TypeErrorAnalyzers map[string]Analyzer
+}
+
+func (o Options) AddDefaultAnalyzer(a *analysis.Analyzer) {
+	o.DefaultAnalyzers[a.Name] = Analyzer{Analyzer: a, enabled: true}
 }
 
 type ExperimentalOptions struct {
@@ -414,12 +419,10 @@ func (o *Options) set(name string, value interface{}) OptionResult {
 	case "tempModfile":
 		result.setBool(&o.TempModfile)
 
-	// Deprecated settings.
+	// Replaced settings.
 	case "experimentalDisabledAnalyses":
 		result.State = OptionDeprecated
-
-	case "wantSuggestedFixes":
-		result.State = OptionDeprecated
+		result.Replacement = "analyses"
 
 	case "disableDeepCompletion":
 		result.State = OptionDeprecated
@@ -444,6 +447,10 @@ func (o *Options) set(name string, value interface{}) OptionResult {
 	case "caseSensitiveCompletion":
 		result.State = OptionDeprecated
 		result.Replacement = "matcher"
+
+	// Deprecated settings.
+	case "wantSuggestedFixes":
+		result.State = OptionDeprecated
 
 	case "noIncrementalSync":
 		result.State = OptionDeprecated
@@ -490,49 +497,49 @@ func (r *OptionResult) setBool(b *bool) {
 
 func typeErrorAnalyzers() map[string]Analyzer {
 	return map[string]Analyzer{
-		fillreturns.Analyzer.Name:    {Analyzer: fillreturns.Analyzer, Enabled: true},
-		nonewvars.Analyzer.Name:      {Analyzer: nonewvars.Analyzer, Enabled: true},
-		noresultvalues.Analyzer.Name: {Analyzer: noresultvalues.Analyzer, Enabled: true},
-		undeclaredname.Analyzer.Name: {Analyzer: undeclaredname.Analyzer, Enabled: true},
+		fillreturns.Analyzer.Name:    {Analyzer: fillreturns.Analyzer, enabled: false},
+		nonewvars.Analyzer.Name:      {Analyzer: nonewvars.Analyzer, enabled: false},
+		noresultvalues.Analyzer.Name: {Analyzer: noresultvalues.Analyzer, enabled: false},
+		undeclaredname.Analyzer.Name: {Analyzer: undeclaredname.Analyzer, enabled: false},
 	}
 }
 
 func defaultAnalyzers() map[string]Analyzer {
 	return map[string]Analyzer{
 		// The traditional vet suite:
-		asmdecl.Analyzer.Name:      {Analyzer: asmdecl.Analyzer, Enabled: true},
-		assign.Analyzer.Name:       {Analyzer: assign.Analyzer, Enabled: true},
-		atomic.Analyzer.Name:       {Analyzer: atomic.Analyzer, Enabled: true},
-		atomicalign.Analyzer.Name:  {Analyzer: atomicalign.Analyzer, Enabled: true},
-		bools.Analyzer.Name:        {Analyzer: bools.Analyzer, Enabled: true},
-		buildtag.Analyzer.Name:     {Analyzer: buildtag.Analyzer, Enabled: true},
-		cgocall.Analyzer.Name:      {Analyzer: cgocall.Analyzer, Enabled: true},
-		composite.Analyzer.Name:    {Analyzer: composite.Analyzer, Enabled: true},
-		copylock.Analyzer.Name:     {Analyzer: copylock.Analyzer, Enabled: true},
-		errorsas.Analyzer.Name:     {Analyzer: errorsas.Analyzer, Enabled: true},
-		httpresponse.Analyzer.Name: {Analyzer: httpresponse.Analyzer, Enabled: true},
-		loopclosure.Analyzer.Name:  {Analyzer: loopclosure.Analyzer, Enabled: true},
-		lostcancel.Analyzer.Name:   {Analyzer: lostcancel.Analyzer, Enabled: true},
-		nilfunc.Analyzer.Name:      {Analyzer: nilfunc.Analyzer, Enabled: true},
-		printf.Analyzer.Name:       {Analyzer: printf.Analyzer, Enabled: true},
-		shift.Analyzer.Name:        {Analyzer: shift.Analyzer, Enabled: true},
-		stdmethods.Analyzer.Name:   {Analyzer: stdmethods.Analyzer, Enabled: true},
-		structtag.Analyzer.Name:    {Analyzer: structtag.Analyzer, Enabled: true},
-		tests.Analyzer.Name:        {Analyzer: tests.Analyzer, Enabled: true},
-		unmarshal.Analyzer.Name:    {Analyzer: unmarshal.Analyzer, Enabled: true},
-		unreachable.Analyzer.Name:  {Analyzer: unreachable.Analyzer, Enabled: true},
-		unsafeptr.Analyzer.Name:    {Analyzer: unsafeptr.Analyzer, Enabled: true},
-		unusedresult.Analyzer.Name: {Analyzer: unusedresult.Analyzer, Enabled: true},
+		asmdecl.Analyzer.Name:      {Analyzer: asmdecl.Analyzer, enabled: true},
+		assign.Analyzer.Name:       {Analyzer: assign.Analyzer, enabled: true},
+		atomic.Analyzer.Name:       {Analyzer: atomic.Analyzer, enabled: true},
+		atomicalign.Analyzer.Name:  {Analyzer: atomicalign.Analyzer, enabled: true},
+		bools.Analyzer.Name:        {Analyzer: bools.Analyzer, enabled: true},
+		buildtag.Analyzer.Name:     {Analyzer: buildtag.Analyzer, enabled: true},
+		cgocall.Analyzer.Name:      {Analyzer: cgocall.Analyzer, enabled: true},
+		composite.Analyzer.Name:    {Analyzer: composite.Analyzer, enabled: true},
+		copylock.Analyzer.Name:     {Analyzer: copylock.Analyzer, enabled: true},
+		errorsas.Analyzer.Name:     {Analyzer: errorsas.Analyzer, enabled: true},
+		httpresponse.Analyzer.Name: {Analyzer: httpresponse.Analyzer, enabled: true},
+		loopclosure.Analyzer.Name:  {Analyzer: loopclosure.Analyzer, enabled: true},
+		lostcancel.Analyzer.Name:   {Analyzer: lostcancel.Analyzer, enabled: true},
+		nilfunc.Analyzer.Name:      {Analyzer: nilfunc.Analyzer, enabled: true},
+		printf.Analyzer.Name:       {Analyzer: printf.Analyzer, enabled: true},
+		shift.Analyzer.Name:        {Analyzer: shift.Analyzer, enabled: true},
+		stdmethods.Analyzer.Name:   {Analyzer: stdmethods.Analyzer, enabled: true},
+		structtag.Analyzer.Name:    {Analyzer: structtag.Analyzer, enabled: true},
+		tests.Analyzer.Name:        {Analyzer: tests.Analyzer, enabled: true},
+		unmarshal.Analyzer.Name:    {Analyzer: unmarshal.Analyzer, enabled: true},
+		unreachable.Analyzer.Name:  {Analyzer: unreachable.Analyzer, enabled: true},
+		unsafeptr.Analyzer.Name:    {Analyzer: unsafeptr.Analyzer, enabled: true},
+		unusedresult.Analyzer.Name: {Analyzer: unusedresult.Analyzer, enabled: true},
 
 		// Non-vet analyzers
-		deepequalerrors.Analyzer.Name:  {Analyzer: deepequalerrors.Analyzer, Enabled: true},
-		sortslice.Analyzer.Name:        {Analyzer: sortslice.Analyzer, Enabled: true},
-		testinggoroutine.Analyzer.Name: {Analyzer: testinggoroutine.Analyzer, Enabled: true},
-		unusedparams.Analyzer.Name:     {Analyzer: unusedparams.Analyzer, Enabled: false},
+		deepequalerrors.Analyzer.Name:  {Analyzer: deepequalerrors.Analyzer, enabled: true},
+		sortslice.Analyzer.Name:        {Analyzer: sortslice.Analyzer, enabled: true},
+		testinggoroutine.Analyzer.Name: {Analyzer: testinggoroutine.Analyzer, enabled: true},
+		unusedparams.Analyzer.Name:     {Analyzer: unusedparams.Analyzer, enabled: false},
 
 		// gofmt -s suite:
-		simplifycompositelit.Analyzer.Name: {Analyzer: simplifycompositelit.Analyzer, Enabled: true, HighConfidence: true},
-		simplifyrange.Analyzer.Name:        {Analyzer: simplifyrange.Analyzer, Enabled: true, HighConfidence: true},
-		simplifyslice.Analyzer.Name:        {Analyzer: simplifyslice.Analyzer, Enabled: true, HighConfidence: true},
+		simplifycompositelit.Analyzer.Name: {Analyzer: simplifycompositelit.Analyzer, enabled: true, HighConfidence: true},
+		simplifyrange.Analyzer.Name:        {Analyzer: simplifyrange.Analyzer, enabled: true, HighConfidence: true},
+		simplifyslice.Analyzer.Name:        {Analyzer: simplifyslice.Analyzer, enabled: true, HighConfidence: true},
 	}
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -367,11 +367,18 @@ const (
 // that let the user know how to use the analyzer.
 type Analyzer struct {
 	Analyzer *analysis.Analyzer
-	Enabled  bool
+	enabled  bool
 
 	// If this is true, then we can apply the suggested fixes
 	// as part of a source.FixAll codeaction.
 	HighConfidence bool
+}
+
+func (a Analyzer) Enabled(snapshot Snapshot) bool {
+	if enabled, ok := snapshot.View().Options().UserEnabledAnalyses[a.Analyzer.Name]; ok {
+		return enabled
+	}
+	return a.enabled
 }
 
 // Package represents a Go package that has been type-checked. It maintains

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/append/append.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/append/append.go
@@ -17,3 +17,4 @@ func _() {
 	// Don't add "..." to append() argument.
 	bar(append()) //@snippet("))", appendStrings, "aStrings", "aStrings")
 }
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/append/append2.go.in
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/primarymod/append/append2.go.in
@@ -1,0 +1,5 @@
+package append
+
+func _() {
+	_ = append(a, struct) //@complete(")")
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/summary.txt.golden
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/testdata/lsp/summary.txt.golden
@@ -1,6 +1,6 @@
 -- summary --
 CodeLensCount = 2
-CompletionsCount = 237
+CompletionsCount = 238
 CompletionSnippetCount = 75
 UnimportedCompletionsCount = 11
 DeepCompletionsCount = 5

--- a/cmd/govim/internal/golang_org_x_tools/lsp/tests/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/tests/util.go
@@ -503,3 +503,19 @@ func FormatFolderName(folder string) string {
 	}
 	return folder
 }
+
+func EnableAllAnalyzers(snapshot source.Snapshot, opts *source.Options) {
+	if opts.UserEnabledAnalyses == nil {
+		opts.UserEnabledAnalyses = make(map[string]bool)
+	}
+	for _, a := range opts.DefaultAnalyzers {
+		if !a.Enabled(snapshot) {
+			opts.UserEnabledAnalyses[a.Analyzer.Name] = true
+		}
+	}
+	for _, a := range opts.TypeErrorAnalyzers {
+		if !a.Enabled(snapshot) {
+			opts.UserEnabledAnalyses[a.Analyzer.Name] = true
+		}
+	}
+}

--- a/cmd/govim/testdata/scenario_default/signs_unload_load_buffer.txt
+++ b/cmd/govim/testdata/scenario_default/signs_unload_load_buffer.txt
@@ -4,8 +4,6 @@
 vim ex 'e main.go'
 vimexprwait placed_main.golden 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 
-[golang.org/issues/38136] skip
-
 # open other.go and add a broken statement to get an error that masks the warnings
 vim ex 'e other.go'
 vim call append '[6,"asd"]'

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.5.2
 	golang.org/x/mod v0.2.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/tools v0.0.0-20200401192744-099440627f01
-	golang.org/x/tools/gopls v0.1.8-0.20200401192744-099440627f01
+	golang.org/x/tools v0.0.0-20200402175326-9fc00b0a7ff6
+	golang.org/x/tools/gopls v0.1.8-0.20200402175326-9fc00b0a7ff6
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -65,10 +65,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200401192744-099440627f01 h1:ysQJ/fU6laLOZJseIeOqXl6Mo+lw5z6b7QHnmUKjW+k=
-golang.org/x/tools v0.0.0-20200401192744-099440627f01/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools/gopls v0.1.8-0.20200401192744-099440627f01 h1:ERszbyn31kM8LmxBw2BhlJ9PDtlhzukTpgokiJ63Gfk=
-golang.org/x/tools/gopls v0.1.8-0.20200401192744-099440627f01/go.mod h1:m15o/fW0bXZaTRApa0PY/GgOBfII91Yz7Qr43GebwKs=
+golang.org/x/tools v0.0.0-20200402175326-9fc00b0a7ff6 h1:c4A1wTbj8JHFXg/hy4CA3odkH/SX170ZzHVRo1lnd7k=
+golang.org/x/tools v0.0.0-20200402175326-9fc00b0a7ff6/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools/gopls v0.1.8-0.20200402175326-9fc00b0a7ff6 h1:pcv8QWJ8EhGL1cutAMvHkMqkSQ60a++m76VV35NjcJc=
+golang.org/x/tools/gopls v0.1.8-0.20200402175326-9fc00b0a7ff6/go.mod h1:m15o/fW0bXZaTRApa0PY/GgOBfII91Yz7Qr43GebwKs=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
As part of this, unskip the following test:

  cmd/govim/testdata/scenario_default/signs_unload_load_buffer.txt

* internal/lsp: fix panic in builtin completions 9fc00b0a
* internal/lsp/source: propose loaded unimported package names first 0a46fa39
* internal/lsp: temporarily disable type error analyzers by default 3304cfb0
* internal/lsp: add a mutex around the view's options 2d9ba733
* internal/lsp/source: add a replacement for experimentalDisabledAnalyses 69646383

Fixes #839