### PR TITLE
cmd/govim: first cut of command-line mode to query "parent"

### DIFF
--- a/cmd/govim/child.go
+++ b/cmd/govim/child.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+)
+
+// commandName defines the top-level command names in child-parent mode
+type commandName string
+
+const (
+	cmdNameGopls commandName = "gopls"
+)
+
+// goplsMethodName defines the method names for the gopls command
+type goplsMethodName string
+
+const (
+	methodGoplsSymbol goplsMethodName = "Symbol"
+)
+
+// knownChildErr is a type used by a "child" instance of govim to bail out
+// of processing in such a way that the panic-ed error is then returned
+// to the caller of runAsChild
+type knownChildErr error
+
+func runAsChild() (err error) {
+	defer func() {
+		switch r := recover().(type) {
+		case nil:
+		case knownChildErr:
+			err = r
+		default:
+			panic(r)
+		}
+	}()
+
+	// errorf is a convenience function for throwning knownChildErr's
+	errorf := func(format string, args ...interface{}) {
+		panic(knownChildErr(fmt.Errorf(format, args...)))
+	}
+
+	// TODO: support TCP?
+	conn, err := net.Dial("unix", *fParent)
+	if err != nil {
+		errorf("failed to dial parent at %v: %v", *fParent, err)
+	}
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+
+	if err := enc.Encode(flagSet.Args()); err != nil {
+		return fmt.Errorf("failed to encode args: %v", err)
+	}
+
+	// decode is a convenience decoder that handles receving
+	// unexpected io.EOF errors
+	decode := func(thing string, i interface{}) {
+		err := dec.Decode(i)
+		if err == nil {
+			return
+		}
+		if err == io.EOF {
+			// By definition we have not seen an exit code yet
+			// because if we had we would have returned
+			errorf("connection closed before exit code received")
+		}
+		errorf("failed to decode %v: %v", thing, err)
+	}
+
+	// now continually decode until we get an io.EOF
+	for {
+		var dest encodeCode
+		decode("dest", &dest)
+		var val interface{}
+		switch dest {
+		case encodeCodeJSONStdout, encodeCodeJSONStderr:
+			var raw json.RawMessage
+			decode("value", &raw)
+			val = raw
+		case encodeCodeRawStdout, encodeCodeRawStderr:
+			var v string
+			decode("value", &v)
+			val = v
+		case encodeCodeExitCode:
+			var exitCode int
+			decode("exitCode", &exitCode)
+			return exitErr(exitCode)
+		default:
+			errorf("unknown destination for decoding: %v", dest)
+		}
+		switch dest {
+		case encodeCodeRawStdout, encodeCodeJSONStdout:
+			fmt.Fprintf(os.Stdout, "%s", val)
+		case encodeCodeRawStderr, encodeCodeJSONStderr:
+			fmt.Fprintf(os.Stderr, "%s", val)
+		default:
+			errorf("unknown destination for output: %v", dest)
+		}
+	}
+}

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -385,6 +385,11 @@ const (
 
 	// FunctionMotion moves the cursor according to the arguments provided.
 	FunctionMotion Function = "Motion"
+
+	// FunctionParentCommand returns a []string that represents the command that
+	// should be run to create a "child" instance of govim to communicate with
+	// its "parent" (the instance which responded to this function call)
+	FunctionParentCommand Function = "ParentCommand"
 )
 
 // FormatOnSave typed constants define the set of valid values that

--- a/cmd/govim/cpprotocol.go
+++ b/cmd/govim/cpprotocol.go
@@ -1,0 +1,56 @@
+package main
+
+// TODO: perhaps all this child-parent stuff is better housed in an internal helper
+// package
+
+// Child-parent protocol
+//
+// The child-parent protocol (better name required) defines the process by
+// which a child and parent instances of govim communicate. The principal use
+// case is being able to write scripts that run against an editor instance. The
+// motivating example here being fzf which uses a child instances to query
+// gopls (via the parent) for session symbol information.
+//
+// The parent instance exposes the command that should be run in order to
+// create that child instance that then connects to the parent. This is exposed
+// via the GOVIMParentCommand() Vim function.
+//
+// TODO: expose help information for the various commands etc
+//
+// The child and parent communicate using a Unix domain socket. Messages on the
+// wire are encoded JSON. The child starts by sending all of its non-flag args
+// to the parent. The parent is then responds with pairs of data. The pair
+// comprises a JSON-encoded number followed by a JSON-encoded value. The
+// following list of modes is supported:
+//
+// 0X - X is an integer representing the exit code the client should use
+// 1X - X is a string value that should be output to os.Stdout
+// 2X - X is a string value that should be output to os.Stderr
+// 3x - X is an interface{} value whose JSON representation should be output to os.Stdout
+// 4x - X is an interface{} value whose JSON representation should be output to os.Stderr
+//
+// If the parent instance encounters an error writing to the child's
+// connection, it assumes the child has closed the connected and it (the
+// parent) continues without error.
+
+type encodeCode int
+
+const (
+	encodeCodeExitCode encodeCode = iota
+	encodeCodeRawStdout
+	encodeCodeRawStderr
+	encodeCodeJSONStdout
+	encodeCodeJSONStderr
+)
+
+// Command is the interface implemented by parent (sub) comamnds
+type Command interface {
+	// Run is the implementation of the command. A Command is responseible for
+	// encoding its response (through sub commands) to the child.  This is
+	// typically done by all the commands in the hierarchy embedding the root
+	// *parentReq.
+	Run()
+
+	// Errorf is a convenience method for panic-ing with a knownParentError
+	Errorf(format string, args ...interface{})
+}

--- a/cmd/govim/flag.go
+++ b/cmd/govim/flag.go
@@ -9,6 +9,7 @@ import (
 var (
 	flagSet = flag.NewFlagSet("govim", flag.ContinueOnError)
 	fTail   = flagSet.Bool("tail", false, "whether to also log output to stdout")
+	fParent = flagSet.String("parent", "", "the Unix Domain Socket on which a parent instance can be contacted")
 )
 
 func init() { flagSet.Usage = usage }
@@ -17,10 +18,16 @@ func usage() {
 	fmt.Fprintf(os.Stderr, `
 Usage of govim:
 
-	govim [-tail] /path/to/gopls
+	govim [-tail] [-parent /path/to/uds] gopls ...
 
 `[1:])
 	flagSet.PrintDefaults()
+}
+
+type exitErr int
+
+func (e exitErr) Error() string {
+	return fmt.Sprintf("exit code: %v", int(e))
 }
 
 type usageErr string
@@ -43,6 +50,8 @@ func main1() int {
 		fmt.Fprintln(os.Stderr, err)
 		flagSet.Usage()
 		return 2
+	case exitErr:
+		return int(err)
 	case flagErr:
 		return 2
 	}

--- a/cmd/govim/parent.go
+++ b/cmd/govim/parent.go
@@ -1,0 +1,370 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/govim/govim"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/kr/pretty"
+)
+
+// startParentServer is called during the init phase of cmd/govim. It starts a
+// Unix Domain Sockets server to allow for communication from a child instance
+func (g *govimplugin) startParentServer() error {
+	td, err := ioutil.TempDir("", "govim-parent-child-*")
+	if err != nil {
+		return fmt.Errorf("failed to create a temp dir for the socket file: %v", err)
+	}
+	socketFile := filepath.Join(td, "socket")
+	g.socketDir = td
+	// TODO: support TCP?
+	l, err := net.Listen("unix", socketFile)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %v: %v", socketFile, err)
+	}
+	g.socketListener = l
+	g.parentCallArgs = []string{
+		os.Args[0],
+		"-parent",
+		socketFile,
+	}
+	g.tomb.Go(g.runParentServer)
+	return nil
+}
+
+func (g *govimplugin) runParentServer() error {
+	for {
+		// We assume for now that we will only ever receive sequential calls from
+		// a single client, given the main use-case is fzf calling this in
+		// response to a user typing input into the Symbol fuzzy finder.
+		//
+		// If we need to change this assumption we will need to think carefully
+		// about sequencing, especially if we start to allow govim commands a la
+		// testdriver instead of just pass through calls to gopls endpoints that
+		// are known to be side-effect free.
+		//
+		// Again we keep things simple for now to assume that each accepted
+		// connection will handle exactly one request, and therefore send exactly
+		// one response.
+		conn, err := g.socketListener.Accept()
+		if err != nil {
+			// TODO: any more definite way of determining that we have safely
+			// been shutdown?
+			break
+		}
+		g.Logf("New child-parent request")
+		req := &parentReq{
+			govimplugin: g,
+		}
+		if err := req.handle(conn); err != nil {
+			g.Logf("child-parent request failed: %v", err)
+		}
+	}
+	g.Logf("Child-parent listener shutdown")
+	return nil
+}
+
+// parentReq is the root command that is Run in response to a child request.
+// It holds the key aspects of handling a query from a child instance. Sub
+// commands embed the instance of *parentReq; more generally, sub command
+// instances embed parent command instances.
+type parentReq struct {
+	*govimplugin
+	conn    net.Conn
+	enc     *json.Encoder
+	dec     *json.Decoder
+	encLock sync.Mutex
+}
+
+// *parentReq implements Command
+var _ Command = (*parentReq)(nil)
+
+// knownParentErr is a type used by a "parent" instance of govim to bail out of
+// command processing in such a way that the panic-ed error is then returned to
+// child as raw output on os.Stderr
+type knownParentErr struct {
+	err      error
+	exitCode int
+}
+
+// Errorf implements Command.Errorf
+func (p *parentReq) Errorf(format string, args ...interface{}) {
+	panic(knownParentErr{err: fmt.Errorf(format, args...)})
+}
+
+// Logf is a convenience wrapper around *govimplugin.Logf to make outputting
+// of parent-originated log messages easier
+func (p *parentReq) Logf(format string, args ...interface{}) {
+	p.govimplugin.Logf("parent: "+format, args...)
+}
+
+// PrintfStdout encodes the formatted string to be returned for raw
+// output to os.Stdout
+func (p *parentReq) PrintfStdout(format string, args ...interface{}) {
+	p.printf(encodeCodeRawStdout, fmt.Sprintf(format, args...))
+}
+
+// PrintfStderr encodes the formatted string to be returned for raw
+// output to os.Stderr
+func (p *parentReq) PrintfStderr(format string, args ...interface{}) {
+	p.printf(encodeCodeRawStderr, fmt.Sprintf(format, args...))
+}
+
+func (p *parentReq) printf(dest encodeCode, format string, args ...interface{}) {
+	p.encode(dest, fmt.Sprintf(format, args...))
+}
+
+// EncodeStdout encodes v to be returned for JSON-encoded output to os.Stdout
+func (p *parentReq) EncodeStdout(v interface{}) {
+	p.encode(encodeCodeJSONStdout, v)
+}
+
+// EncodeStderr encodes v to be returned for JSON-encoded output to os.Stderr
+func (p *parentReq) EncodeStderr(v interface{}) {
+	p.encode(encodeCodeJSONStderr, v)
+}
+
+// encode is the single point of encoding for all responses from parent to
+// child. Don't call this directly; call one of the Encode* or Printf*
+// methods instead.
+func (p *parentReq) encode(dest encodeCode, v interface{}) {
+	p.encLock.Lock()
+	defer p.encLock.Unlock()
+	errorf := func(format string, args ...interface{}) {
+		panic(encodeError(fmt.Errorf(format, args...)))
+	}
+	if err := p.enc.Encode(dest); err != nil {
+		errorf("failed to encode response dest: %v", err)
+	}
+	if err := p.enc.Encode(v); err != nil {
+		errorf("failed to encode value: %v", err)
+	}
+}
+
+// encodeError is used to distinguish encoding errors (that is the parent
+// encoding responses to the child) from other errors. If the parent encounters
+// an encodeError it is simply ignored because it is assumed the child quit,
+// taking the connection with it.
+type encodeError error
+
+// handle responds to the client returning a nil-nil error
+// only in the case of a fatal communication error with the client
+func (p *parentReq) handle(conn net.Conn) (retErr error) {
+	p.Logf("handling new connection from child")
+	p.conn = conn
+	p.enc = json.NewEncoder(conn)
+	p.dec = json.NewDecoder(conn)
+
+	// Ignore all encodeError panics
+	defer func() {
+		switch r := recover().(type) {
+		case nil:
+		case encodeError:
+		default:
+			panic(r)
+		}
+	}()
+
+	// Handle knownParentErr panics by sending the Error() to the child as raw
+	// os.Stderr output. Also ensure that in the case of no panics we send the
+	// exit code to the child.
+	defer func() {
+		var err error
+		var exitCode int
+		switch r := recover().(type) {
+		case nil:
+		case knownParentErr:
+			// A knownError is one that we knowingly threw within
+			// a command
+			err = r.err
+			if r.exitCode != 0 {
+				exitCode = r.exitCode
+			} else {
+				exitCode = -1
+			}
+		default:
+			// This is serious trouble
+			panic(r)
+		}
+		if err != nil {
+			p.encode(encodeCodeRawStderr, err.Error())
+		}
+		p.encode(encodeCodeExitCode, exitCode)
+		p.Logf("closing connection")
+		p.conn.Close()
+	}()
+
+	// We simply run p
+	p.Run()
+	return
+}
+
+// Run implements Command.Run()
+func (p *parentReq) Run() {
+	var args []string
+	if err := p.dec.Decode(&args); err != nil {
+		p.Errorf("failed to decode args slice: %v", err)
+	}
+	p.Logf("parentReq got args: %v", pretty.Sprint(args))
+
+	// At this point args will be something like
+	//
+	//     gopls Symbol -quickfix govim main
+	//
+	// where "govim" and "main" are arguments to Symbol and
+	// -quickfix is a flag to Symbol.
+	if len(args) == 0 {
+		p.Errorf("expected command")
+	}
+	cmdStr := commandName(args[0])
+
+	var cmd Command
+	switch cmdStr {
+	case cmdNameGopls:
+		cmd = newGoplsCmd(p, args[1:])
+	default:
+		p.Errorf("unknown command: %v", cmdStr)
+	}
+	cmd.Run()
+}
+
+// goplsCmd is a sub Command of parentReq responsible for handling requests
+// against the LSP/gopls API
+type goplsCmd struct {
+	*parentReq
+	fs *flag.FlagSet
+}
+
+// *goplsCmd implemenets Command
+var _ Command = (*goplsCmd)(nil)
+
+func newGoplsCmd(parent *parentReq, args []string) *goplsCmd {
+	g := &goplsCmd{
+		parentReq: parent,
+	}
+	g.fs = flag.NewFlagSet("gopls", flag.ContinueOnError)
+	if err := g.fs.Parse(args); err != nil {
+		g.Errorf("failed to parse args [%v]: %v", strings.Join(args, " "), err)
+	}
+	return g
+}
+
+// Errorf implements Command.Errorf
+func (g *goplsCmd) Errorf(format string, args ...interface{}) {
+	g.parentReq.Errorf("gopls: "+format, args...)
+}
+
+// Run implements Command.Run()
+func (g *goplsCmd) Run() {
+	args := g.fs.Args()
+	g.Logf("goplsCmd got args: %v", pretty.Sprint(args))
+	if len(args) == 0 {
+		g.Errorf("expected method")
+	}
+	cmdStr := goplsMethodName(args[0])
+	var cmd Command
+	switch cmdStr {
+	case methodGoplsSymbol:
+		cmd = newGoplsSymbolCmd(g, args[1:])
+	default:
+		g.Errorf("unknown method: %v", cmdStr)
+	}
+	cmd.Run()
+}
+
+// goplsSymbolCmd is a sub Command of goplsCmd responsible for handling a call
+// to the gopls Symbol method
+type goplsSymbolCmd struct {
+	*goplsCmd
+	fs        *flag.FlagSet
+	fQuickfix *bool
+	fRel      *bool
+}
+
+func newGoplsSymbolCmd(parent *goplsCmd, args []string) *goplsSymbolCmd {
+	g := &goplsSymbolCmd{
+		goplsCmd: parent,
+	}
+	g.fs = flag.NewFlagSet("goplsSymbol", flag.ContinueOnError)
+	g.fQuickfix = g.fs.Bool("quickfix", false, "format output in quickfix style")
+	g.fRel = g.fs.Bool("rel", false, "output filenames relative to the working directory (only with -quickfix)")
+	if err := g.fs.Parse(args); err != nil {
+		g.Errorf("failed to parse args [%v]: %v", strings.Join(args, " "), err)
+	}
+	return g
+}
+
+// Errorf implements Command.Errorf
+func (g *goplsSymbolCmd) Errorf(format string, args ...interface{}) {
+	g.goplsCmd.Errorf("symbol: "+format, args...)
+}
+
+// Run implements Command.Run()
+func (g *goplsSymbolCmd) Run() {
+	g.Logf("goplsSymbolCmd got args: %v", pretty.Sprint(g.fs.Args()))
+	if len(g.fs.Args()) == 0 {
+		// no error - simply not results
+		return
+	}
+	query := strings.Join(g.fs.Args(), " ")
+	symbolReq := &protocol.WorkspaceSymbolParams{
+		Query: query,
+	}
+	symbolResp, err := g.server.Symbol(context.Background(), symbolReq)
+	if err != nil {
+		g.Errorf("failed to call gopls.Symbol: %v", err)
+	}
+
+	if !*g.fQuickfix {
+		// we return the raw LSP response. It's highly unlikely this would ever
+		// be useful because the locations are in terms of UTF16 code points.
+		//
+		// See https://github.com/golang/go/issues/38274
+		g.EncodeStdout(symbolResp)
+		return
+	}
+
+	var qfs []quickfixEntry
+	var qferr error
+	v := g.vimstate
+	done := make(chan struct{})
+	// Note at this point we can't schedule something in Vim because Vim is most likely
+	// blocked waiting on an external command, e.g. fzf. So instead we enqueue a call
+	g.Enqueue(func(_g govim.Govim) error {
+		defer func() {
+			if recover() == nil {
+				close(done)
+			}
+		}()
+		for _, si := range symbolResp {
+			qf, err := v.locationToQuickfix(si.Location, *g.fRel)
+			if err != nil {
+				qferr = err
+				return nil
+			}
+			qf.Text = si.Name
+			qfs = append(qfs, qf)
+		}
+		return nil
+	})
+	<-done
+
+	if qferr != nil {
+		g.Errorf("failed to convert locations to quickfix entires: %v", err)
+	}
+
+	if *g.fQuickfix {
+		for _, q := range qfs {
+			g.PrintfStdout("%v:%v:%v: %v\n", q.Filename, q.Lnum, q.Col, q.Text)
+		}
+	}
+}

--- a/cmd/govim/util.go
+++ b/cmd/govim/util.go
@@ -180,3 +180,7 @@ func (v *vimstate) populateQuickfix(locs []protocol.Location, shift bool) {
 	v.ChannelCall("setqflist", qfs, "r")
 	v.ChannelEx("copen")
 }
+
+func (v *vimstate) parentCommand(args ...json.RawMessage) (interface{}, error) {
+	return v.parentCallArgs, nil
+}


### PR DESCRIPTION
This enables govim to be used with fzf and other such Vim plugins that
require a client program in order to run a command. In the case of fzf,
the client instance of govim is used in order to re-query the parent
instance, which in turn calls on to gopls' workspace symbol search. This
allows the search results within fzf to be refined on each key stroke.

This approach, however, is not specific to fzf. Hence some configuration
of Vim/fzf is required. For a sample .vimrc configuration see:

https://github.com/govim/govim/wiki/vimrc-tips#-tip-use-fzf-with-workspace-symbol-search

Fixes #795