### PR TITLE
deps: update x/tools and gopls to 9ee5ef7a

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/gocommand/invoke.go
+++ b/cmd/govim/internal/golang_org_x_tools/gocommand/invoke.go
@@ -12,9 +12,69 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
+	"sync"
 	"time"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/telemetry/event"
 )
+
+// An Runner will run go command invocations and serialize
+// them if it sees a concurrency error.
+type Runner struct {
+	// LoadMu guards packages.Load calls and associated state.
+	loadMu         sync.Mutex
+	serializeLoads int
+}
+
+// 1.13: go: updates to go.mod needed, but contents have changed
+// 1.14: go: updating go.mod: existing contents have changed since last read
+var modConcurrencyError = regexp.MustCompile(`go:.*go.mod.*contents have changed`)
+
+// Run calls Runner.RunRaw, serializing requests if they fight over
+// go.mod changes.
+func (runner *Runner) Run(ctx context.Context, inv Invocation) (*bytes.Buffer, error) {
+	stdout, _, friendly, _ := runner.RunRaw(ctx, inv)
+	return stdout, friendly
+}
+
+// Run calls Innvocation.RunRaw, serializing requests if they fight over
+// go.mod changes.
+func (runner *Runner) RunRaw(ctx context.Context, inv Invocation) (*bytes.Buffer, *bytes.Buffer, error, error) {
+	// We want to run invocations concurrently as much as possible. However,
+	// if go.mod updates are needed, only one can make them and the others will
+	// fail. We need to retry in those cases, but we don't want to thrash so
+	// badly we never recover. To avoid that, once we've seen one concurrency
+	// error, start serializing everything until the backlog has cleared out.
+	runner.loadMu.Lock()
+	var locked bool // If true, we hold the mutex and have incremented.
+	if runner.serializeLoads == 0 {
+		runner.loadMu.Unlock()
+	} else {
+		locked = true
+		runner.serializeLoads++
+	}
+	defer func() {
+		if locked {
+			runner.serializeLoads--
+			runner.loadMu.Unlock()
+		}
+	}()
+
+	for {
+		stdout, stderr, friendlyErr, err := inv.runRaw(ctx)
+		if friendlyErr == nil || !modConcurrencyError.MatchString(friendlyErr.Error()) {
+			return stdout, stderr, friendlyErr, err
+		}
+		event.Error(ctx, "Load concurrency error, will retry serially", err)
+		if !locked {
+			runner.loadMu.Lock()
+			runner.serializeLoads++
+			locked = true
+		}
+	}
+}
 
 // An Invocation represents a call to the go command.
 type Invocation struct {
@@ -26,16 +86,9 @@ type Invocation struct {
 	Logf       func(format string, args ...interface{})
 }
 
-// Run runs the invocation, returning its stdout and an error suitable for
-// human consumption, including stderr.
-func (i *Invocation) Run(ctx context.Context) (*bytes.Buffer, error) {
-	stdout, _, friendly, _ := i.RunRaw(ctx)
-	return stdout, friendly
-}
-
 // RunRaw is like RunPiped, but also returns the raw stderr and error for callers
 // that want to do low-level error handling/recovery.
-func (i *Invocation) RunRaw(ctx context.Context) (stdout *bytes.Buffer, stderr *bytes.Buffer, friendlyError error, rawError error) {
+func (i *Invocation) runRaw(ctx context.Context) (stdout *bytes.Buffer, stderr *bytes.Buffer, friendlyError error, rawError error) {
 	stdout = &bytes.Buffer{}
 	stderr = &bytes.Buffer{}
 	rawError = i.RunPiped(ctx, stdout, stderr)

--- a/cmd/govim/internal/golang_org_x_tools/imports/fix.go
+++ b/cmd/govim/internal/golang_org_x_tools/imports/fix.go
@@ -747,6 +747,8 @@ func getPackageExports(ctx context.Context, wrapped func(PackageExport), searchP
 type ProcessEnv struct {
 	LocalPrefix string
 
+	GocmdRunner *gocommand.Runner
+
 	BuildFlags []string
 
 	// If non-empty, these will be used instead of the
@@ -830,7 +832,7 @@ func (e *ProcessEnv) invokeGo(ctx context.Context, verb string, args ...string) 
 		Logf:       e.Logf,
 		WorkingDir: e.WorkingDir,
 	}
-	return inv.Run(ctx)
+	return e.GocmdRunner.Run(ctx, inv)
 }
 
 func addStdlibCandidates(pass *pass, refs references) {

--- a/cmd/govim/internal/golang_org_x_tools/imports/imports.go
+++ b/cmd/govim/internal/golang_org_x_tools/imports/imports.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/ast/astutil"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/gocommand"
 )
 
 // Options is golang.org/x/tools/imports.Options with extra internal-only options.
@@ -153,6 +154,10 @@ func initialize(filename string, src []byte, opt *Options) ([]byte, *Options, er
 			GOPROXY:     os.Getenv("GOPROXY"),
 			GOSUMDB:     os.Getenv("GOSUMDB"),
 		}
+	}
+	// Set the gocmdRunner if the user has not provided it.
+	if opt.Env.GocmdRunner == nil {
+		opt.Env.GocmdRunner = &gocommand.Runner{}
 	}
 	if src == nil {
 		b, err := ioutil.ReadFile(filename)

--- a/cmd/govim/internal/golang_org_x_tools/jsonrpc2/handler.go
+++ b/cmd/govim/internal/golang_org_x_tools/jsonrpc2/handler.go
@@ -18,28 +18,6 @@ import (
 // The handler should return ErrNotHandled if it could not handle the request.
 type Handler func(context.Context, *Request) error
 
-// Direction is used to indicate to a logger whether the logged message was being
-// sent or received.
-type Direction bool
-
-const (
-	// Send indicates the message is outgoing.
-	Send = Direction(true)
-	// Receive indicates the message is incoming.
-	Receive = Direction(false)
-)
-
-func (d Direction) String() string {
-	switch d {
-	case Send:
-		return "send"
-	case Receive:
-		return "receive"
-	default:
-		panic("unreachable")
-	}
-}
-
 // MethodNotFound is a Handler that replies to all call requests with the
 // standard method not found response.
 // This should normally be the final handler in a chain.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/analysis/nonewvars/nonewvars.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/analysis/nonewvars/nonewvars.go
@@ -37,8 +37,6 @@ var Analyzer = &analysis.Analyzer{
 	RunDespiteErrors: true,
 }
 
-const noNewVarsMsg = "no new variables on left side of :="
-
 func run(pass *analysis.Pass) (interface{}, error) {
 	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	errors := analysisinternal.GetTypeErrors(pass)
@@ -63,7 +61,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		for _, err := range errors {
-			if err.Msg != noNewVarsMsg {
+			if !FixesError(err.Msg) {
 				continue
 			}
 			if assignStmt.Pos() > err.Pos || err.Pos >= assignStmt.End() {
@@ -88,4 +86,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 	})
 	return nil, nil
+}
+
+func FixesError(msg string) bool {
+	return msg == "no new variables on left side of :="
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/analysis/noresultvalues/noresultvalues.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/analysis/noresultvalues/noresultvalues.go
@@ -34,8 +34,6 @@ var Analyzer = &analysis.Analyzer{
 	RunDespiteErrors: true,
 }
 
-const noResultValuesMsg = "no result values expected"
-
 func run(pass *analysis.Pass) (interface{}, error) {
 	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	errors := analysisinternal.GetTypeErrors(pass)
@@ -56,7 +54,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		for _, err := range errors {
-			if err.Msg != noResultValuesMsg {
+			if !FixesError(err.Msg) {
 				continue
 			}
 			if retStmt.Pos() >= err.Pos || err.Pos >= retStmt.End() {
@@ -82,4 +80,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 	})
 	return nil, nil
+}
+
+func FixesError(msg string) bool {
+	return msg == "no result values expected"
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/analysis/undeclaredname/undeclared.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/analysis/undeclaredname/undeclared.go
@@ -36,7 +36,7 @@ const undeclaredNamePrefix = "undeclared name: "
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, err := range analysisinternal.GetTypeErrors(pass) {
-		if !strings.HasPrefix(err.Msg, undeclaredNamePrefix) {
+		if !FixesError(err.Msg) {
 			continue
 		}
 		name := strings.TrimPrefix(err.Msg, undeclaredNamePrefix)
@@ -183,4 +183,8 @@ func baseIfStmt(path []ast.Node, index int) ast.Stmt {
 		break
 	}
 	return stmt.(ast.Stmt)
+}
+
+func FixesError(msg string) bool {
+	return strings.HasPrefix(msg, undeclaredNamePrefix)
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/analysis.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/analysis.go
@@ -23,7 +23,7 @@ import (
 	errors "golang.org/x/xerrors"
 )
 
-func (s *snapshot) Analyze(ctx context.Context, id string, analyzers []*analysis.Analyzer) ([]*source.Error, error) {
+func (s *snapshot) Analyze(ctx context.Context, id string, analyzers ...*analysis.Analyzer) ([]*source.Error, error) {
 	var roots []*actionHandle
 
 	for _, a := range analyzers {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
@@ -84,7 +84,7 @@ func (s *snapshot) load(ctx context.Context, scopes ...interface{}) error {
 	defer done()
 
 	cfg := s.Config(ctx)
-	pkgs, err := s.view.loadPackages(cfg, query...)
+	pkgs, err := packages.Load(cfg, query...)
 
 	// If the context was canceled, return early. Otherwise, we might be
 	// type-checking an incomplete result. Check the context directly,

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/mod.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/mod.go
@@ -20,6 +20,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/memoize"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/packagesinternal"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/telemetry/event"
 	errors "golang.org/x/xerrors"
@@ -220,7 +221,7 @@ func goModWhy(ctx context.Context, cfg *packages.Config, folder string, data *mo
 	for _, req := range data.origParsedFile.Require {
 		inv.Args = append(inv.Args, req.Mod.Path)
 	}
-	stdout, err := inv.Run(ctx)
+	stdout, err := packagesinternal.GetGoCmdRunner(cfg).Run(ctx, inv)
 	if err != nil {
 		return err
 	}
@@ -247,7 +248,7 @@ func dependencyUpgrades(ctx context.Context, cfg *packages.Config, folder string
 		Env:        cfg.Env,
 		WorkingDir: folder,
 	}
-	stdout, err := inv.Run(ctx)
+	stdout, err := packagesinternal.GetGoCmdRunner(cfg).Run(ctx, inv)
 	if err != nil {
 		return err
 	}
@@ -288,6 +289,7 @@ func (s *snapshot) ModTidyHandle(ctx context.Context, realfh source.FileHandle) 
 	cfg := s.Config(ctx)
 	options := s.View().Options()
 	folder := s.View().Folder().Filename()
+	gocmdRunner := s.view.gocmdRunner
 
 	wsPackages, err := s.WorkspacePackages(ctx)
 	if ctx.Err() != nil {
@@ -358,12 +360,9 @@ func (s *snapshot) ModTidyHandle(ctx context.Context, realfh source.FileHandle) 
 			Env:        cfg.Env,
 			WorkingDir: folder,
 		}
-		if _, err := inv.Run(ctx); err != nil {
-			// Ignore concurrency errors here.
-			if !modConcurrencyError.MatchString(err.Error()) {
-				return &modData{
-					err: err,
-				}
+		if _, err := gocmdRunner.Run(ctx, inv); err != nil {
+			return &modData{
+				err: err,
 			}
 		}
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
@@ -5,11 +5,9 @@
 package cache
 
 import (
-	"context"
 	"go/ast"
 	"go/types"
 
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/packagesinternal"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
@@ -124,47 +122,4 @@ func (p *pkg) Imports() []source.Package {
 
 func (p *pkg) Module() *packagesinternal.Module {
 	return p.module
-}
-
-func (s *snapshot) FindAnalysisError(ctx context.Context, pkgID, analyzerName, msg string, rng protocol.Range) (*source.Error, *source.Analyzer, error) {
-	analyzer := findAnalyzer(s, analyzerName)
-	if analyzer.Analyzer == nil {
-		return nil, nil, errors.Errorf("unexpected analyzer: %s", analyzerName)
-	}
-	if !analyzer.Enabled(s) {
-		return nil, nil, errors.Errorf("disabled analyzer: %s", analyzerName)
-	}
-	act, err := s.actionHandle(ctx, packageID(pkgID), analyzer.Analyzer)
-	if err != nil {
-		return nil, nil, err
-	}
-	errs, _, err := act.analyze(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, err := range errs {
-		if err.Category != analyzer.Analyzer.Name {
-			continue
-		}
-		if err.Message != msg {
-			continue
-		}
-		if protocol.CompareRange(err.Range, rng) != 0 {
-			continue
-		}
-		return err, &analyzer, nil
-	}
-	return nil, nil, errors.Errorf("no matching diagnostic for %s:%v", pkgID, analyzerName)
-}
-
-func findAnalyzer(s *snapshot, analyzerName string) source.Analyzer {
-	checked := s.View().Options().DefaultAnalyzers
-	if a, ok := checked[analyzerName]; ok {
-		return a
-	}
-	checked = s.View().Options().TypeErrorAnalyzers
-	if a, ok := checked[analyzerName]; ok {
-		return a
-	}
-	return source.Analyzer{}
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/gocommand"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
@@ -133,6 +134,7 @@ func (s *Session) createView(ctx context.Context, name string, folder span.URI, 
 			modHandles:        make(map[span.URI]*modHandle),
 		},
 		ignoredURIs: make(map[span.URI]struct{}),
+		gocmdRunner: &gocommand.Runner{},
 	}
 	v.snapshot.view = v
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/tools/go/packages"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/packagesinternal"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/telemetry/event"
 	errors "golang.org/x/xerrors"
@@ -94,7 +95,7 @@ func (s *snapshot) Config(ctx context.Context) *packages.Config {
 	verboseOutput := s.view.options.VerboseOutput
 	s.view.optionsMu.Unlock()
 
-	return &packages.Config{
+	cfg := &packages.Config{
 		Env:        env,
 		Dir:        s.view.folder.Filename(),
 		Context:    ctx,
@@ -117,6 +118,9 @@ func (s *snapshot) Config(ctx context.Context) *packages.Config {
 		},
 		Tests: true,
 	}
+	packagesinternal.SetGoCmdRunner(cfg, s.view.gocmdRunner)
+
+	return cfg
 }
 
 func (s *snapshot) buildOverlay() map[string][]byte {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
@@ -15,12 +15,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/tools/go/packages"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/gocommand"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/imports"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug"
@@ -111,9 +109,8 @@ type view struct {
 	// `go env` variables that need to be tracked.
 	gopath, gocache string
 
-	// LoadMu guards packages.Load calls and associated state.
-	loadMu         sync.Mutex
-	serializeLoads int
+	// gocmdRunner guards go command calls from concurrency errors.
+	gocmdRunner *gocommand.Runner
 }
 
 type builtinPackageHandle struct {
@@ -279,7 +276,7 @@ func (v *view) WriteEnv(ctx context.Context, w io.Writer) error {
 		Env:        env,
 		WorkingDir: v.Folder().Filename(),
 	}
-	stdout, err := inv.Run(ctx)
+	stdout, err := v.gocmdRunner.Run(ctx, inv)
 	if err != nil {
 		return err
 	}
@@ -364,6 +361,7 @@ func (v *view) buildProcessEnv(ctx context.Context) (*imports.ProcessEnv, error)
 		WorkingDir:  v.folder.Filename(),
 		BuildFlags:  buildFlags,
 		LocalPrefix: localPrefix,
+		GocmdRunner: v.gocmdRunner,
 	}
 	if verboseOutput {
 		processEnv.Logf = func(format string, args ...interface{}) {
@@ -734,7 +732,7 @@ func (v *view) getGoEnv(ctx context.Context, env []string) (string, error) {
 		Env:        env,
 		WorkingDir: v.Folder().Filename(),
 	}
-	stdout, err := inv.Run(ctx)
+	stdout, err := v.gocmdRunner.Run(ctx, inv)
 	if err != nil {
 		return "", err
 	}
@@ -767,50 +765,6 @@ func (v *view) getGoEnv(ctx context.Context, env []string) (string, error) {
 	return "", nil
 }
 
-// 1.13: go: updates to go.mod needed, but contents have changed
-// 1.14: go: updating go.mod: existing contents have changed since last read
-var modConcurrencyError = regexp.MustCompile(`go:.*go.mod.*contents have changed`)
-
-// LoadPackages calls packages.Load, serializing requests if they fight over
-// go.mod changes.
-func (v *view) loadPackages(cfg *packages.Config, patterns ...string) ([]*packages.Package, error) {
-	// We want to run go list calls concurrently as much as possible. However,
-	// if go.mod updates are needed, only one can make them and the others will
-	// fail. We need to retry in those cases, but we don't want to thrash so
-	// badly we never recover. To avoid that, once we've seen one concurrency
-	// error, start serializing everything until the backlog has cleared out.
-	// This could all be avoided on 1.14 by using multiple -modfiles.
-
-	v.loadMu.Lock()
-	var locked bool // If true, we hold the mutex and have incremented.
-	if v.serializeLoads == 0 {
-		v.loadMu.Unlock()
-	} else {
-		locked = true
-		v.serializeLoads++
-	}
-	defer func() {
-		if locked {
-			v.serializeLoads--
-			v.loadMu.Unlock()
-		}
-	}()
-
-	for {
-		pkgs, err := packages.Load(cfg, patterns...)
-		if err == nil || !modConcurrencyError.MatchString(err.Error()) {
-			return pkgs, err
-		}
-
-		event.Error(cfg.Context, "Load concurrency error, will retry serially", err)
-		if !locked {
-			v.loadMu.Lock()
-			v.serializeLoads++
-			locked = true
-		}
-	}
-}
-
 // This function will return the main go.mod file for this folder if it exists and whether the -modfile
 // flag exists for this version of go.
 func (v *view) modfileFlagExists(ctx context.Context, env []string) (bool, error) {
@@ -824,7 +778,7 @@ func (v *view) modfileFlagExists(ctx context.Context, env []string) (bool, error
 		Env:        append(env, "GO111MODULE=off"),
 		WorkingDir: v.Folder().Filename(),
 	}
-	stdout, err := inv.Run(ctx)
+	stdout, err := v.gocmdRunner.Run(ctx, inv)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/check.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/check.go
@@ -14,7 +14,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 )
 
-func (r *runner) Diagnostics(t *testing.T, uri span.URI, want []source.Diagnostic) {
+func (r *runner) Diagnostics(t *testing.T, uri span.URI, want []*source.Diagnostic) {
 	if len(want) == 1 && want[0].Message == "" {
 		return
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/debug/info.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/debug/info.go
@@ -50,10 +50,10 @@ func PrintVersionInfo(ctx context.Context, w io.Writer, verbose bool, mode Print
 	})
 	fmt.Fprint(w, "\n")
 	section(w, mode, "Go info", func() {
-		i := &gocommand.Invocation{
+		gocmdRunner := &gocommand.Runner{}
+		version, err := gocmdRunner.Run(ctx, gocommand.Invocation{
 			Verb: "version",
-		}
-		version, err := i.Run(ctx)
+		})
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/debug/trace.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/debug/trace.go
@@ -94,7 +94,7 @@ func (t *traces) ProcessEvent(ctx context.Context, ev event.Event, tags event.Ta
 			ParentID: span.ParentID,
 			Name:     span.Name,
 			Start:    span.Start().At,
-			Tags:     renderTags(span.Start().Tags()),
+			Tags:     renderTags(span.Start()),
 		}
 		t.unfinished[span.ID] = td
 		// and wire up parents if we have them
@@ -124,7 +124,7 @@ func (t *traces) ProcessEvent(ctx context.Context, ev event.Event, tags event.Ta
 		for i, event := range events {
 			td.Events[i] = traceEvent{
 				Time: event.At,
-				Tags: renderTags(event.Tags()),
+				Tags: renderTags(event),
 			}
 		}
 
@@ -170,10 +170,12 @@ func fillOffsets(td *traceData, start time.Time) {
 	}
 }
 
-func renderTags(tags event.TagIterator) string {
+func renderTags(tags event.TagList) string {
 	buf := &bytes.Buffer{}
-	for ; tags.Valid(); tags.Advance() {
-		fmt.Fprintf(buf, "%v ", tags.Tag())
+	for index := 0; tags.Valid(index); index++ {
+		if tag := tags.Tag(index); tag.Valid() {
+			fmt.Fprintf(buf, "%v ", tag)
+		}
 	}
 	return buf.String()
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
@@ -39,7 +39,7 @@ func (s *Server) diagnoseSnapshot(snapshot source.Snapshot) {
 
 // diagnose is a helper function for running diagnostics with a given context.
 // Do not call it directly.
-func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, alwaysAnalyze bool) map[diagnosticKey][]source.Diagnostic {
+func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, alwaysAnalyze bool) map[diagnosticKey][]*source.Diagnostic {
 	ctx, done := event.StartSpan(ctx, "lsp:background-worker")
 	defer done()
 
@@ -51,7 +51,7 @@ func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, alwaysA
 	}
 	defer func() { <-s.diagnosticsSema }()
 
-	allReports := make(map[diagnosticKey][]source.Diagnostic)
+	allReports := make(map[diagnosticKey][]*source.Diagnostic)
 	var reportsMu sync.Mutex
 	var wg sync.WaitGroup
 
@@ -123,7 +123,7 @@ func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, alwaysA
 	return allReports
 }
 
-func (s *Server) publishReports(ctx context.Context, snapshot source.Snapshot, reports map[diagnosticKey][]source.Diagnostic) {
+func (s *Server) publishReports(ctx context.Context, snapshot source.Snapshot, reports map[diagnosticKey][]*source.Diagnostic) {
 	// Check for context cancellation before publishing diagnostics.
 	if ctx.Err() != nil {
 		return
@@ -189,7 +189,7 @@ func (s *Server) publishReports(ctx context.Context, snapshot source.Snapshot, r
 
 // equalDiagnostics returns true if the 2 lists of diagnostics are equal.
 // It assumes that both a and b are already sorted.
-func equalDiagnostics(a, b []source.Diagnostic) bool {
+func equalDiagnostics(a, b []*source.Diagnostic) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -201,7 +201,7 @@ func equalDiagnostics(a, b []source.Diagnostic) bool {
 	return true
 }
 
-func toProtocolDiagnostics(diagnostics []source.Diagnostic) []protocol.Diagnostic {
+func toProtocolDiagnostics(diagnostics []*source.Diagnostic) []protocol.Diagnostic {
 	reports := []protocol.Diagnostic{}
 	for _, diag := range diagnostics {
 		related := make([]protocol.DiagnosticRelatedInformation, 0, len(diag.Related))

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/workspace.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/workspace.go
@@ -157,7 +157,8 @@ func (w *Workspace) RunGoCommand(ctx context.Context, verb string, args ...strin
 		Args:       args,
 		WorkingDir: w.workdir,
 	}
-	_, stderr, _, err := inv.RunRaw(ctx)
+	gocmdRunner := &gocommand.Runner{}
+	_, stderr, _, err := gocmdRunner.RunRaw(ctx, inv)
 	if err != nil {
 		return err
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/diagnostics.go
@@ -16,7 +16,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/telemetry/event"
 )
 
-func Diagnostics(ctx context.Context, snapshot source.Snapshot) (map[source.FileIdentity][]source.Diagnostic, map[string]*modfile.Require, error) {
+func Diagnostics(ctx context.Context, snapshot source.Snapshot) (map[source.FileIdentity][]*source.Diagnostic, map[string]*modfile.Require, error) {
 	// TODO: We will want to support diagnostics for go.mod files even when the -modfile flag is turned off.
 	realURI, tempURI := snapshot.View().ModFiles()
 
@@ -39,11 +39,11 @@ func Diagnostics(ctx context.Context, snapshot source.Snapshot) (map[source.File
 	if err != nil {
 		return nil, nil, err
 	}
-	reports := map[source.FileIdentity][]source.Diagnostic{
+	reports := map[source.FileIdentity][]*source.Diagnostic{
 		realfh.Identity(): {},
 	}
 	for _, e := range parseErrors {
-		diag := source.Diagnostic{
+		diag := &source.Diagnostic{
 			Message:        e.Message,
 			Range:          e.Range,
 			SuggestedFixes: e.SuggestedFixes,

--- a/cmd/govim/internal/golang_org_x_tools/lsp/server.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/server.go
@@ -88,7 +88,7 @@ type Server struct {
 type sentDiagnostics struct {
 	version      float64
 	identifier   string
-	sorted       []source.Diagnostic
+	sorted       []*source.Diagnostic
 	withAnalysis bool
 	snapshotID   uint64
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
@@ -497,10 +497,26 @@ func (r *OptionResult) setBool(b *bool) {
 
 func typeErrorAnalyzers() map[string]Analyzer {
 	return map[string]Analyzer{
-		fillreturns.Analyzer.Name:    {Analyzer: fillreturns.Analyzer, enabled: false},
-		nonewvars.Analyzer.Name:      {Analyzer: nonewvars.Analyzer, enabled: false},
-		noresultvalues.Analyzer.Name: {Analyzer: noresultvalues.Analyzer, enabled: false},
-		undeclaredname.Analyzer.Name: {Analyzer: undeclaredname.Analyzer, enabled: false},
+		fillreturns.Analyzer.Name: {
+			Analyzer:   fillreturns.Analyzer,
+			enabled:    false,
+			FixesError: fillreturns.FixesError,
+		},
+		nonewvars.Analyzer.Name: {
+			Analyzer:   nonewvars.Analyzer,
+			enabled:    false,
+			FixesError: nonewvars.FixesError,
+		},
+		noresultvalues.Analyzer.Name: {
+			Analyzer:   noresultvalues.Analyzer,
+			enabled:    false,
+			FixesError: noresultvalues.FixesError,
+		},
+		undeclaredname.Analyzer.Name: {
+			Analyzer:   undeclaredname.Analyzer,
+			enabled:    false,
+			FixesError: undeclaredname.FixesError,
+		},
 	}
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
@@ -621,13 +621,13 @@ func formatFunction(params []string, results []string, writeResultParens bool) s
 	return detail.String()
 }
 
-func SortDiagnostics(d []Diagnostic) {
+func SortDiagnostics(d []*Diagnostic) {
 	sort.Slice(d, func(i int, j int) bool {
 		return CompareDiagnostic(d[i], d[j]) < 0
 	})
 }
 
-func CompareDiagnostic(a, b Diagnostic) int {
+func CompareDiagnostic(a, b *Diagnostic) int {
 	if r := protocol.CompareRange(a.Range, b.Range); r != 0 {
 		return r
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -42,11 +42,7 @@ type Snapshot interface {
 	IsSaved(uri span.URI) bool
 
 	// Analyze runs the analyses for the given package at this snapshot.
-	Analyze(ctx context.Context, id string, analyzers []*analysis.Analyzer) ([]*Error, error)
-
-	// FindAnalysisError returns the analysis error represented by the diagnostic.
-	// This is used to get the SuggestedFixes associated with that error.
-	FindAnalysisError(ctx context.Context, pkgID, analyzerName, msg string, rng protocol.Range) (*Error, *Analyzer, error)
+	Analyze(ctx context.Context, pkgID string, analyzers ...*analysis.Analyzer) ([]*Error, error)
 
 	// ModTidyHandle returns a ModTidyHandle for the given go.mod file handle.
 	// This function can have no data or error if there is no modfile detected.
@@ -372,6 +368,11 @@ type Analyzer struct {
 	// If this is true, then we can apply the suggested fixes
 	// as part of a source.FixAll codeaction.
 	HighConfidence bool
+
+	// FixesError is only set for type-error analyzers.
+	// It reports true if the message provided indicates an error that could be
+	// fixed by the analyzer.
+	FixesError func(msg string) bool
 }
 
 func (a Analyzer) Enabled(snapshot Snapshot) bool {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/tests/tests.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/tests/tests.go
@@ -44,7 +44,7 @@ const (
 var UpdateGolden = flag.Bool("golden", false, "Update golden files")
 
 type CodeLens map[span.URI][]protocol.CodeLens
-type Diagnostics map[span.URI][]source.Diagnostic
+type Diagnostics map[span.URI][]*source.Diagnostic
 type CompletionItems map[token.Pos]*source.CompletionItem
 type Completions map[span.Span][]Completion
 type CompletionSnippets map[span.Span][]CompletionSnippet
@@ -116,7 +116,7 @@ type Data struct {
 
 type Tests interface {
 	CodeLens(*testing.T, span.URI, []protocol.CodeLens)
-	Diagnostics(*testing.T, span.URI, []source.Diagnostic)
+	Diagnostics(*testing.T, span.URI, []*source.Diagnostic)
 	Completion(*testing.T, span.Span, Completion, CompletionItems)
 	CompletionSnippet(*testing.T, span.Span, CompletionSnippet, bool, CompletionItems)
 	UnimportedCompletion(*testing.T, span.Span, Completion, CompletionItems)
@@ -907,7 +907,7 @@ func (data *Data) collectCodeLens(spn span.Span, title, cmd string) {
 
 func (data *Data) collectDiagnostics(spn span.Span, msgSource, msg, msgSeverity string) {
 	if _, ok := data.Diagnostics[spn.URI()]; !ok {
-		data.Diagnostics[spn.URI()] = []source.Diagnostic{}
+		data.Diagnostics[spn.URI()] = []*source.Diagnostic{}
 	}
 	m, err := data.Mapper(spn.URI())
 	if err != nil {
@@ -929,7 +929,7 @@ func (data *Data) collectDiagnostics(spn span.Span, msgSource, msg, msgSeverity 
 		severity = protocol.SeverityInformation
 	}
 	// This is not the correct way to do this, but it seems excessive to do the full conversion here.
-	want := source.Diagnostic{
+	want := &source.Diagnostic{
 		Range:    rng,
 		Severity: severity,
 		Source:   msgSource,

--- a/cmd/govim/internal/golang_org_x_tools/lsp/tests/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/tests/util.go
@@ -163,7 +163,7 @@ func summarizeWorkspaceSymbols(i int, want, got []protocol.SymbolInformation, re
 
 // DiffDiagnostics prints the diff between expected and actual diagnostics test
 // results.
-func DiffDiagnostics(uri span.URI, want, got []source.Diagnostic) string {
+func DiffDiagnostics(uri span.URI, want, got []*source.Diagnostic) string {
 	source.SortDiagnostics(want)
 	source.SortDiagnostics(got)
 
@@ -197,7 +197,7 @@ func DiffDiagnostics(uri span.URI, want, got []source.Diagnostic) string {
 	return ""
 }
 
-func summarizeDiagnostics(i int, uri span.URI, want, got []source.Diagnostic, reason string, args ...interface{}) string {
+func summarizeDiagnostics(i int, uri span.URI, want, got []*source.Diagnostic, reason string, args ...interface{}) string {
 	msg := &bytes.Buffer{}
 	fmt.Fprint(msg, "diagnostics failed")
 	if i >= 0 {

--- a/cmd/govim/internal/golang_org_x_tools/packagesinternal/packages.go
+++ b/cmd/govim/internal/golang_org_x_tools/packagesinternal/packages.go
@@ -1,7 +1,11 @@
 // Package packagesinternal exposes internal-only fields from go/packages.
 package packagesinternal
 
-import "time"
+import (
+	"time"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/gocommand"
+)
 
 // Fields must match go list;
 type Module struct {
@@ -25,3 +29,7 @@ type ModuleError struct {
 var GetForTest = func(p interface{}) string { return "" }
 
 var GetModule = func(p interface{}) *Module { return nil }
+
+var GetGoCmdRunner = func(config interface{}) *gocommand.Runner { return nil }
+
+var SetGoCmdRunner = func(config interface{}, runner *gocommand.Runner) {}

--- a/cmd/govim/internal/golang_org_x_tools/telemetry/event/event.go
+++ b/cmd/govim/internal/golang_org_x_tools/telemetry/event/event.go
@@ -68,21 +68,26 @@ func (ev Event) Format(f fmt.State, r rune) {
 			fmt.Fprintf(f, ": %v", err)
 		}
 	}
-	for it := ev.Tags(); it.Valid(); it.Advance() {
-		tag := it.Tag()
+	for index := 0; ev.Valid(index); index++ {
+		tag := ev.Tag(index)
 		// msg and err were both already printed above, so we skip them to avoid
 		// double printing
-		if tag.Key == Msg || tag.Key == Err {
+		if !tag.Valid() || tag.Key == Msg || tag.Key == Err {
 			continue
 		}
 		fmt.Fprintf(f, "\n\t%v", tag)
 	}
 }
 
-func (ev Event) Tags() TagIterator {
-	return ChainTagIterators(
-		NewTagIterator(ev.static[:]...),
-		NewTagIterator(ev.dynamic...))
+func (ev Event) Valid(index int) bool {
+	return index >= 0 && index < len(ev.static)+len(ev.dynamic)
+}
+
+func (ev Event) Tag(index int) Tag {
+	if index < len(ev.static) {
+		return ev.static[index]
+	}
+	return ev.dynamic[index-len(ev.static)]
 }
 
 func (ev Event) Find(key interface{}) Tag {

--- a/cmd/govim/internal/golang_org_x_tools/telemetry/export/log.go
+++ b/cmd/govim/internal/golang_org_x_tools/telemetry/export/log.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
+	"sync"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/telemetry/event"
 )
@@ -22,6 +24,8 @@ func LogWriter(w io.Writer, onlyErrors bool) event.Exporter {
 }
 
 type logWriter struct {
+	mu         sync.Mutex
+	buffer     [128]byte
 	writer     io.Writer
 	onlyErrors bool
 }
@@ -32,7 +36,66 @@ func (w *logWriter) ProcessEvent(ctx context.Context, ev event.Event, tagMap eve
 		if w.onlyErrors && event.Err.Get(tagMap) == nil {
 			return ctx
 		}
-		fmt.Fprintf(w.writer, "%v\n", ev)
+		w.mu.Lock()
+		defer w.mu.Unlock()
+
+		buf := w.buffer[:0]
+		if !ev.At.IsZero() {
+			w.writer.Write(ev.At.AppendFormat(buf, "2006/01/02 15:04:05 "))
+		}
+		msg := event.Msg.Get(tagMap)
+		io.WriteString(w.writer, msg)
+		if err := event.Err.Get(tagMap); err != nil {
+			io.WriteString(w.writer, ": ")
+			io.WriteString(w.writer, err.Error())
+		}
+		for index := 0; ev.Valid(index); index++ {
+			tag := ev.Tag(index)
+			if !tag.Valid() || tag.Key == event.Msg || tag.Key == event.Err {
+				continue
+			}
+			io.WriteString(w.writer, "\n\t")
+			io.WriteString(w.writer, tag.Key.Name())
+			io.WriteString(w.writer, "=")
+			switch key := tag.Key.(type) {
+			case *event.IntKey:
+				w.writer.Write(strconv.AppendInt(buf, int64(key.From(tag)), 10))
+			case *event.Int8Key:
+				w.writer.Write(strconv.AppendInt(buf, int64(key.From(tag)), 10))
+			case *event.Int16Key:
+				w.writer.Write(strconv.AppendInt(buf, int64(key.From(tag)), 10))
+			case *event.Int32Key:
+				w.writer.Write(strconv.AppendInt(buf, int64(key.From(tag)), 10))
+			case *event.Int64Key:
+				w.writer.Write(strconv.AppendInt(buf, key.From(tag), 10))
+			case *event.UIntKey:
+				w.writer.Write(strconv.AppendUint(buf, uint64(key.From(tag)), 10))
+			case *event.UInt8Key:
+				w.writer.Write(strconv.AppendUint(buf, uint64(key.From(tag)), 10))
+			case *event.UInt16Key:
+				w.writer.Write(strconv.AppendUint(buf, uint64(key.From(tag)), 10))
+			case *event.UInt32Key:
+				w.writer.Write(strconv.AppendUint(buf, uint64(key.From(tag)), 10))
+			case *event.UInt64Key:
+				w.writer.Write(strconv.AppendUint(buf, key.From(tag), 10))
+			case *event.Float32Key:
+				w.writer.Write(strconv.AppendFloat(buf, float64(key.From(tag)), 'E', -1, 32))
+			case *event.Float64Key:
+				w.writer.Write(strconv.AppendFloat(buf, key.From(tag), 'E', -1, 64))
+			case *event.BooleanKey:
+				w.writer.Write(strconv.AppendBool(buf, key.From(tag)))
+			case *event.StringKey:
+				w.writer.Write(strconv.AppendQuote(buf, key.From(tag)))
+			case *event.ErrorKey:
+				io.WriteString(w.writer, key.From(tag).Error())
+			case *event.ValueKey:
+				fmt.Fprint(w.writer, key.From(tag))
+			default:
+				fmt.Fprintf(w.writer, `"invalid key type %T"`, key)
+			}
+		}
+		io.WriteString(w.writer, "\n")
+
 	case ev.IsStartSpan():
 		if span := GetSpan(ctx); span != nil {
 			fmt.Fprintf(w.writer, "start: %v %v", span.Name, span.ID)

--- a/cmd/govim/internal/golang_org_x_tools/telemetry/export/metric/exporter.go
+++ b/cmd/govim/internal/golang_org_x_tools/telemetry/export/metric/exporter.go
@@ -37,8 +37,11 @@ func (e *Config) Exporter(output event.Exporter) event.Exporter {
 		mu.Lock()
 		defer mu.Unlock()
 		var metrics []Data
-		for it := ev.Tags(); it.Valid(); it.Advance() {
-			tag := it.Tag()
+		for index := 0; ev.Valid(index); index++ {
+			tag := ev.Tag(index)
+			if !tag.Valid() {
+				continue
+			}
 			id := tag.Key
 			if list := e.subscribers[id]; len(list) > 0 {
 				for _, s := range list {

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.5.2
 	golang.org/x/mod v0.2.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/tools v0.0.0-20200407143752-a3568bac92ae
-	golang.org/x/tools/gopls v0.0.0-20200407143752-a3568bac92ae
+	golang.org/x/tools v0.0.0-20200408132156-9ee5ef7a2c0d
+	golang.org/x/tools/gopls v0.0.0-20200408132156-9ee5ef7a2c0d
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -60,10 +60,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200407143752-a3568bac92ae h1:nMRC2i7oRGagyN5g3chxBF7gb2do/tIJ3ihoEnvYvsU=
-golang.org/x/tools v0.0.0-20200407143752-a3568bac92ae/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools/gopls v0.0.0-20200407143752-a3568bac92ae h1:b7u+rFYaL26Zm7Hej96ivDTDrjO0GHL8xdFEBX7PAAg=
-golang.org/x/tools/gopls v0.0.0-20200407143752-a3568bac92ae/go.mod h1:m15o/fW0bXZaTRApa0PY/GgOBfII91Yz7Qr43GebwKs=
+golang.org/x/tools v0.0.0-20200408132156-9ee5ef7a2c0d h1:2DXIdtvIYvvWOcAOsX81FwOUBoQoMZhosWn7KjXEl94=
+golang.org/x/tools v0.0.0-20200408132156-9ee5ef7a2c0d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools/gopls v0.0.0-20200408132156-9ee5ef7a2c0d h1:0FkzqDZzIcnr3qf0Zud/IQJ+X1Yj8mw1ulNaFZh36g8=
+golang.org/x/tools/gopls v0.0.0-20200408132156-9ee5ef7a2c0d/go.mod h1:m15o/fW0bXZaTRApa0PY/GgOBfII91Yz7Qr43GebwKs=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=


### PR DESCRIPTION
* internal/jsonrpc2: remove Direction 9ee5ef7a
* internal/telemetry: a faster logging exporter 888a00fb
* internal/lsp: make tag iteration allocation-free 6a751267
* internal/lsp/cache: add concurrency error check for go cmds 46bd65c8
* internal/lsp: add type error fixes to existing diagnostics 4d14fc9c
* gopls/docs: adding nvim-lsp option in gopls README file cd5a53e0