### PR TITLE
cmd/govim: persist highlights for explicit GOVIMHighlightReferences call

### DIFF
--- a/cmd/govim/buffer_events.go
+++ b/cmd/govim/buffer_events.go
@@ -79,6 +79,10 @@ type bufChangedChange struct {
 // bufChanged(bufnr, start, end, added, changes)
 //
 func (v *vimstate) bufChanged(args ...json.RawMessage) (interface{}, error) {
+	// For now any change (in a .go file) causes an existing highlights to be removed
+	v.highlightingReferences = false
+	v.removeReferenceHighlight(nil)
+
 	bufnr := v.ParseInt(args[0])
 	b, ok := v.buffers[bufnr]
 	if !ok {

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -275,8 +275,13 @@ const (
 	CommandSuggestedFixes Command = "SuggestedFixes"
 
 	// CommandHighlightReferences highlights references to the identifier under
-	// the cursor.
+	// the cursor. The highlights are removed by a change to any file or a call
+	// to CommandClearReferencesHighlights.
 	CommandHighlightReferences Command = "HighlightReferences"
+
+	// CommandClearReferencesHighlights clears any highlighint of references
+	// added by a previous call to CommandHighlightReferences
+	CommandClearReferencesHighlights Command = "ClearReferencesHighlights"
 )
 
 type Function string

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -184,11 +184,6 @@ type govimplugin struct {
 	// contain old data. Call diagnostics() to get the latest instead.
 	diagnosticsCache *[]types.Diagnostic
 
-	// currentReferences is the range of each LSP documentHighlights under the cursor
-	// It is used to avoid updating the text property when the cursor is moved within the
-	// existing highlights.
-	currentReferences []*types.Range
-
 	// cancelDocHighlight is the function to cancel the ongoing LSP documentHighlight call. It must
 	// be called before assigning a new value (or nil) to it. It is nil when there is no ongoing
 	// call.
@@ -278,7 +273,8 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineCommand(string(config.CommandRename), g.vimstate.rename, govim.NArgsZeroOrOne)
 	g.DefineCommand(string(config.CommandStringFn), g.vimstate.stringfns, govim.RangeLine, govim.CompleteCustomList(PluginPrefix+config.FunctionStringFnComplete), govim.NArgsOneOrMore)
 	g.DefineFunction(string(config.FunctionStringFnComplete), []string{"ArgLead", "CmdLine", "CursorPos"}, g.vimstate.stringfncomplete)
-	g.DefineCommand(string(config.CommandHighlightReferences), g.vimstate.referenceHighlight)
+	g.DefineCommand(string(config.CommandHighlightReferences), g.vimstate.highlightReferences)
+	g.DefineCommand(string(config.CommandClearReferencesHighlights), g.vimstate.clearReferencesHighlights)
 	g.DefineAutoCommand("", govim.Events{govim.EventCompleteDone}, govim.Patterns{"*.go"}, false, g.vimstate.completeDone, "eval(expand('<abuf>'))", "v:completed_item")
 	g.defineHighlights()
 	if err := g.vimstate.signDefine(); err != nil {


### PR DESCRIPTION
When manually invoking GOVIMHighlightReferences, it makes sense to
persist the highlights for as long as we can. To be safe we assume that
making any change to any .go file will potentially invalidate the
highlighted references (we might relax this at a later stage). We also
add the GOVIMClearReferencesHighlights command to explicitly remove the
highlights.

As part of this same commit we:

* move the definition of currentReferences to vimstate where it belongs
  (it is only ever accessed on the vimstate "thread")
* Tidy up and simplify some logic regarding removal of highlights