### PR TITLE
cmd/govim: do not remove highlights on delta when auto-highlighting

### DIFF
--- a/cmd/govim/buffer_events.go
+++ b/cmd/govim/buffer_events.go
@@ -79,9 +79,12 @@ type bufChangedChange struct {
 // bufChanged(bufnr, start, end, added, changes)
 //
 func (v *vimstate) bufChanged(args ...json.RawMessage) (interface{}, error) {
-	// For now any change (in a .go file) causes an existing highlights to be removed
-	v.highlightingReferences = false
-	v.removeReferenceHighlight(nil)
+	// For now, if we are "manually" highlighting, any change (in a .go file)
+	// causes an existing highlights to be removed.
+	if v.highlightingReferences {
+		v.highlightingReferences = false
+		v.removeReferenceHighlight(nil)
+	}
 
 	bufnr := v.ParseInt(args[0])
 	b, ok := v.buffers[bufnr]


### PR DESCRIPTION
In 3139f797 I incorrectly removed all reference highlights when a delta
is received. However, the logic prior to that change was that highlights
would only be moved (even in insert mode) if the cursor falls outside of
a highlighted range.

Therefore, we adopt exactly the logic that @leitzler proposed in #852 to
only remove highlights on delta if we are in manual highlighting mode.