### PR TITLE
cmd/govim: allow duplicate items in completion candidates

### DIFF
--- a/cmd/govim/complete.go
+++ b/cmd/govim/complete.go
@@ -64,6 +64,7 @@ func (v *vimstate) complete(args ...json.RawMessage) (interface{}, error) {
 				Menu:     i.Detail,
 				Word:     i.TextEdit.NewText,
 				Info:     i.Documentation,
+				Dup:      1,
 				UserData: "govim",
 			})
 		}

--- a/complete.go
+++ b/complete.go
@@ -27,6 +27,7 @@ type CompleteItem struct {
 	Info     string `json:"info"`
 	Menu     string `json:"menu"`
 	UserData string `json:"user_data"`
+	Dup      int    `json:"dup"`
 }
 
 type CompleteInfo struct {


### PR DESCRIPTION
When it comes to unimported completions, it is entirely possible that
two packages might have the same name. Generally however, we rely
entirely on gopls to "dedupe" the completion candidate list. So make
this change unconditionally is safe.