### PR TITLE
cmd/govim: fix completion candidate additional text edits for dups

### DIFF
--- a/cmd/govim/complete.go
+++ b/cmd/govim/complete.go
@@ -89,7 +89,7 @@ func (v *vimstate) completeDone(args ...json.RawMessage) error {
 	}
 	var match *protocol.CompletionItem
 	for _, c := range v.lastCompleteResults.Items {
-		if c.Label == chosen.Abbr {
+		if c.Label == chosen.Abbr && c.Detail == chosen.Menu {
 			match = &c
 			break
 		}


### PR DESCRIPTION
In e10617c6 we permitted "duplicate" candidates in completion results.
(These items are not in fact duplicates because they are distinguished
by their detail.) However, we failed to fix the logic that matches the
chosen completion candidate versus the list of options; we also need to
include the detail.

Fix that and track adding a test in #867.