### PR TITLE
cmd/govim: add highlighting to signature help popup

### DIFF
--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -419,4 +419,9 @@ const (
 
 	// HighlightReferences is the group used to add text properties to references
 	HighlightReferences Highlight = "GOVIMReferences"
+
+	// HighlightSignature is the group used to add text properties to the signature help popup
+	HighlightSignature Highlight = "GOVIMSignature"
+	// HighlightSignatureParam is the group used to add text properties to the signature active parameter
+	HighlightSignatureParam Highlight = "GOVIMSignatureParam"
 )

--- a/cmd/govim/highlight.go
+++ b/cmd/govim/highlight.go
@@ -67,6 +67,18 @@ func (v *vimstate) textpropDefine() error {
 		Priority:  types.SeverityPriority[types.SeverityErr] + 1,
 	})
 
+	v.BatchChannelCall("prop_type_add", config.HighlightSignature, propDict{
+		Highlight: string(config.HighlightSignature),
+		Combine:   true,
+		Priority:  types.SeverityPriority[types.SeverityErr] + 1,
+	})
+
+	v.BatchChannelCall("prop_type_add", config.HighlightSignatureParam, propDict{
+		Highlight: string(config.HighlightSignatureParam),
+		Combine:   true,
+		Priority:  types.SeverityPriority[types.SeverityErr] + 1,
+	})
+
 	res := v.MustBatchEnd()
 	for i := range res {
 		if v.ParseInt(res[i]) != 0 {

--- a/cmd/govim/internal/types/popup.go
+++ b/cmd/govim/internal/types/popup.go
@@ -1,0 +1,20 @@
+package types
+
+// PopupLine is the internal representation of a single text line with text
+// propertiesin a vim popup. When creating popups using popup_create, the
+// first arg can be either a buffer number, a string, a list of strings or
+// a list of text lines with text properties.
+type PopupLine struct {
+	Text  string      `json:"text"`
+	Props []PopupProp `json:"props"`
+}
+
+// PopupProp is the internal representation of a single text property used
+// in a popup line. It describes where on that line the property begin
+// (where Col is 1-indexed) and the length. Type must be an existing
+// text property type (defined by calling prop_type_add in vim).
+type PopupProp struct {
+	Type string `json:"type"`
+	Col  int    `json:"col"`
+	Len  int    `json:"length"`
+}

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -359,6 +359,9 @@ func (g *govimplugin) defineHighlights() {
 		fmt.Sprintf("highlight default %s cterm=none gui=italic ctermfg=%d guifg=#8a8a8a", config.HighlightHoverDiagSrc, diagSrcColor),
 
 		fmt.Sprintf("highlight default %s term=reverse cterm=reverse gui=reverse", config.HighlightReferences),
+
+		fmt.Sprintf("highlight default link %s PMenu", config.HighlightSignature),
+		fmt.Sprintf("highlight default %s term=bold cterm=bold gui=bold", config.HighlightSignatureParam),
 	} {
 		g.vimstate.BatchChannelCall("execute", hi)
 	}


### PR DESCRIPTION
Add two new Highlight groups that are used to highlight the
experimental signature help popup. Both can be overridden by
adding custom highlights to vimrc, e.g.:

```
highlight GOVIMSignature ctermfg=red
highlight GOVIMSignatureParam cterm=NONE ctermfg=green
```
GOVIMSignature is applied to the entire popup, and
GOVIMSignatureParam to the active parameter as reported by gopls.