### PR TITLE
cmd/govim: add support for "fill struct" code action

### DIFF
--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -295,6 +295,10 @@ const (
 	// cursor position, no popup is shown. Moving the cursor or the mouse causes
 	// the popup to be dismissed.
 	CommandExperimentalSignatureHelp Command = "ExperimentalSignatureHelp"
+
+	// CommandFillStruct populates fields in the struct under the cursor. Each
+	// field will get the respective zero value as value.
+	CommandFillStruct Command = "FillStruct"
 )
 
 type Function string

--- a/cmd/govim/fillstruct.go
+++ b/cmd/govim/fillstruct.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/govim/govim"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
+)
+
+func (v *vimstate) fillStruct(flags govim.CommandFlags, args ...string) error {
+	b, point, err := v.bufCursorPos()
+	if err != nil {
+		return fmt.Errorf("failed to determine cursor position: %v", err)
+	}
+
+	textDoc := b.ToTextDocumentIdentifier()
+	params := &protocol.CodeActionParams{
+		TextDocument: textDoc,
+		Range:        protocol.Range{Start: point.ToPosition(), End: point.ToPosition()},
+		Context: protocol.CodeActionContext{
+			Only: []protocol.CodeActionKind{protocol.RefactorRewrite},
+		},
+	}
+
+	codeActions, err := v.server.CodeAction(context.Background(), params)
+	if err != nil {
+		return fmt.Errorf("codeAction failed: %v", err)
+	}
+
+	switch len(codeActions) {
+	case 0:
+	case 1:
+		// there should be just a single file
+		dcs := codeActions[0].Edit.DocumentChanges
+		switch len(dcs) {
+		case 1:
+			dc := dcs[0]
+			// verify that the URI and version of the edits match the buffer
+			euri := span.URI(dc.TextDocument.TextDocumentIdentifier.URI)
+			buri := b.URI()
+			if euri != buri {
+				return fmt.Errorf("got edits for file %v, but buffer is %v", euri, buri)
+			}
+			if ev := int(math.Round(dc.TextDocument.Version)); ev > 0 && ev != b.Version {
+				return fmt.Errorf("got edits for version %v, but current buffer version is %v", ev, b.Version)
+			}
+			edits := dc.Edits
+			if len(edits) != 0 {
+				if err := v.applyProtocolTextEdits(b, edits); err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("expected single file, saw: %v", len(dcs))
+		}
+	default:
+		return fmt.Errorf("don't know how to handle %v actions", len(codeActions))
+	}
+
+	return nil
+}

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -278,6 +278,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineCommand(string(config.CommandClearReferencesHighlights), g.vimstate.clearReferencesHighlights)
 	g.DefineAutoCommand("", govim.Events{govim.EventCompleteDone}, govim.Patterns{"*.go"}, false, g.vimstate.completeDone, "eval(expand('<abuf>'))", "v:completed_item")
 	g.DefineCommand(string(config.CommandExperimentalSignatureHelp), g.vimstate.signatureHelp)
+	g.DefineCommand(string(config.CommandFillStruct), g.vimstate.fillStruct)
 	g.defineHighlights()
 	if err := g.vimstate.signDefine(); err != nil {
 		return fmt.Errorf("failed to define signs: %v", err)

--- a/cmd/govim/testdata/scenario_default/fillstruct.txt
+++ b/cmd/govim/testdata/scenario_default/fillstruct.txt
@@ -1,0 +1,44 @@
+# Test that code action "fill struct" works
+
+vim ex 'e main.go'
+vim ex 'call cursor(10,13)'
+vim ex 'call execute(\"GOVIMFillStruct\")'
+vim ex 'w'
+cmp main.go main.go.golden
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+type foo struct {
+	b bool
+	s string
+	i int
+}
+
+func main() {
+	_ = foo{}
+}
+-- main.go.golden --
+package main
+
+type foo struct {
+	b bool
+	s string
+	i int
+}
+
+func main() {
+	_ = foo{
+		b: false,
+		s: "",
+		i: 0,
+	}
+}


### PR DESCRIPTION
Adds a new command, "GOVIMFillStruct", that populate fields with zero
value in a struct using gopls new code action "Fill struct".

Currently it must be called on an empty struct with the cursor above the
right bracket '}', see golang/go#39506.