### PR TITLE
cmd/govim: track go.mod files

### DIFF
--- a/cmd/govim/buffer_events.go
+++ b/cmd/govim/buffer_events.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/govim/govim/cmd/govim/config"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/types"
 )
 
@@ -153,7 +154,7 @@ func (v *vimstate) handleBufferEvent(b *types.Buffer) error {
 	if b.Version == 1 {
 		params := &protocol.DidOpenTextDocumentParams{
 			TextDocument: protocol.TextDocumentItem{
-				LanguageID: "go",
+				LanguageID: source.DetectLanguage("", b.URI().Filename()).String(),
 				URI:        protocol.DocumentURI(b.URI()),
 				Version:    float64(b.Version),
 				Text:       string(b.Contents()),

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -258,7 +258,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.vimstate.workingDirectory = g.ParseString(g.ChannelCall("getcwd", -1))
 	g.DefineFunction(string(config.FunctionBalloonExpr), []string{}, g.vimstate.balloonExpr)
 	g.DefineAutoCommand("", govim.Events{govim.EventBufUnload}, govim.Patterns{"*.go"}, false, g.vimstate.bufUnload, "eval(expand('<abuf>'))")
-	g.DefineAutoCommand("", govim.Events{govim.EventBufRead, govim.EventBufNewFile}, govim.Patterns{"*.go"}, false, g.vimstate.bufReadPost, exprAutocmdCurrBufInfo)
+	g.DefineAutoCommand("", govim.Events{govim.EventBufRead, govim.EventBufNewFile}, govim.Patterns{"*.go", "go.mod"}, false, g.vimstate.bufReadPost, exprAutocmdCurrBufInfo)
 	g.DefineAutoCommand("", govim.Events{govim.EventBufWritePre}, govim.Patterns{"*.go"}, false, g.vimstate.formatCurrentBuffer, "eval(expand('<abuf>'))")
 	g.DefineAutoCommand("", govim.Events{govim.EventBufWritePost}, govim.Patterns{"*.go"}, false, g.vimstate.bufWritePost, "eval(expand('<abuf>'))")
 	g.DefineFunction(string(config.FunctionComplete), []string{"findarg", "base"}, g.vimstate.complete)


### PR DESCRIPTION
Gopls supports some features for go.mod files that can work "out of the box" except that they are not tracked in govim -- see https://golang.org/issue/31999. In particular, I was trying to use govim
to test hovering for go.mod files.

Add support for tracking go.mod files when they are opened in govim.

Updates #616