### PR TITLE
cmd/govim: support multiple fillstruct edits

### DIFF
--- a/cmd/govim/fillstruct.go
+++ b/cmd/govim/fillstruct.go
@@ -30,34 +30,36 @@ func (v *vimstate) fillStruct(flags govim.CommandFlags, args ...string) error {
 		return fmt.Errorf("codeAction failed: %v", err)
 	}
 
-	switch len(codeActions) {
-	case 0:
-	case 1:
+	if len(codeActions) == 0 {
+		return nil
+	}
+
+	buri := b.URI()
+	var edits []protocol.TextEdit
+	for _, ca := range codeActions {
 		// there should be just a single file
-		dcs := codeActions[0].Edit.DocumentChanges
+		dcs := ca.Edit.DocumentChanges
 		switch len(dcs) {
 		case 1:
 			dc := dcs[0]
 			// verify that the URI and version of the edits match the buffer
 			euri := span.URI(dc.TextDocument.TextDocumentIdentifier.URI)
-			buri := b.URI()
 			if euri != buri {
 				return fmt.Errorf("got edits for file %v, but buffer is %v", euri, buri)
 			}
 			if ev := int(math.Round(dc.TextDocument.Version)); ev > 0 && ev != b.Version {
 				return fmt.Errorf("got edits for version %v, but current buffer version is %v", ev, b.Version)
 			}
-			edits := dc.Edits
-			if len(edits) != 0 {
-				if err := v.applyProtocolTextEdits(b, edits); err != nil {
-					return err
-				}
-			}
+			edits = append(edits, dc.Edits...)
 		default:
 			return fmt.Errorf("expected single file, saw: %v", len(dcs))
 		}
-	default:
-		return fmt.Errorf("don't know how to handle %v actions", len(codeActions))
+	}
+
+	if len(edits) != 0 {
+		if err := v.applyProtocolTextEdits(b, edits); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/govim/testdata/scenario_default/fillstruct.txt
+++ b/cmd/govim/testdata/scenario_default/fillstruct.txt
@@ -1,7 +1,9 @@
 # Test that code action "fill struct" works
 
 vim ex 'e main.go'
-vim ex 'call cursor(10,13)'
+vim ex 'call cursor(14,1)'
+vim ex 'call execute(\"GOVIMFillStruct\")'
+vim ex 'call cursor(12,10)'
 vim ex 'call execute(\"GOVIMFillStruct\")'
 vim ex 'w'
 cmp main.go main.go.golden
@@ -23,8 +25,12 @@ type foo struct {
 	i int
 }
 
+func fn(a, b foo) {}
+
 func main() {
 	_ = foo{}
+
+    fn(foo{}, foo{})
 }
 -- main.go.golden --
 package main
@@ -35,10 +41,22 @@ type foo struct {
 	i int
 }
 
+func fn(a, b foo) {}
+
 func main() {
 	_ = foo{
 		b: false,
 		s: "",
 		i: 0,
 	}
+
+	fn(foo{
+		b: false,
+		s: "",
+		i: 0,
+	}, foo{
+		b: false,
+		s: "",
+		i: 0,
+	})
 }


### PR DESCRIPTION
Gopls updated fillstruct to always report results for the entire current
line. If there are more than one struct to fill on the same line, govim
now supports handling all edits sent by gopls.