### PR TITLE
Revert "cmd/govim: use gopls serve command explicitly"

### DIFF
--- a/cmd/govim/gopls.go
+++ b/cmd/govim/gopls.go
@@ -29,7 +29,7 @@ func (g *govimplugin) startGopls() error {
 
 	g.ChannelExf("let s:gopls_logfile=%q", logfile.Name())
 
-	goplsArgs := []string{"serve", "-rpc.trace", "-logfile", logfile.Name()}
+	goplsArgs := []string{"-rpc.trace", "-logfile", logfile.Name()}
 	if flags, err := util.Split(os.Getenv(string(config.EnvVarGoplsFlags))); err != nil {
 		g.Logf("invalid env var %s: %v", config.EnvVarGoplsFlags, err)
 	} else {


### PR DESCRIPTION
Reverts govim/govim#898.

From https://github.com/govim/govim/pull/898#issuecomment-653936668:
> We do run into some issues with our GOVIM_GOPLS_FLAGS env var that I, for example, use to set -remote=auto (and -ocagent). Since these two flags aren't a part of serve, gopls fails to start.
> I suggest that we revert this one until we have a nice solution for passing flags to gopls, unless the near future is too close :)

