### PR TITLE
cmd/govim: add user enabled analyses configuration

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -44,14 +44,14 @@ endfunction
 
 function! s:validBool(v)
   if type(a:v) != 0  && type(a:v) != 6
-    return [v:false, "must be of type number or bool"
+    return [v:false, "must be of type number or bool"]
   endif
   return [v:true, ""]
 endfunction
 
 function! s:validString(v)
   if type(a:v) != 1
-    return [v:false, "must be of type string"
+    return [v:false, "must be of type string"]
   endif
   return [v:true, ""]
 endfunction
@@ -120,6 +120,19 @@ function! s:validGoplsEnv(v)
   return [v:true, ""]
 endfunction
 
+function! s:validAnalyses(v)
+  if type(a:v) != 4
+    return [v:false, "must be of type dict"]
+  endif
+  for [key, value] in items(a:v)
+      if type(value) != 0 && type(value) != 6
+          return [v:false, "value for key ".key." must be number or bool"]
+      endif
+  endfor
+  return [v:true, ""]
+endfunction
+
+
 function! s:validExperimentalAutoreadLoadedBuffers(v)
   return s:validBool(a:v)
 endfunction
@@ -161,6 +174,7 @@ let s:validators = {
       \ "CompletionBudget": function("s:validCompletionBudget"),
       \ "TempModfile": function("s:validTempModfile"),
       \ "GoplsEnv": function("s:validGoplsEnv"),
+      \ "Analyses": function("s:validAnalyses"),
       \ "ExperimentalAutoreadLoadedBuffers": function("s:validExperimentalAutoreadLoadedBuffers"),
       \ "ExperimentalMouseTriggeredHoverPopupOptions": function("s:validExperimentalMouseTriggeredHoverPopupOptions"),
       \ "ExperimentalCursorTriggeredHoverPopupOptions": function("s:validExperimentalCursorTriggeredHoverPopupOptions"),

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -151,6 +151,18 @@ type Config struct {
 	// GOFLAGS=-modfile=go.local.mod in order to use an alternative go.mod file.
 	GoplsEnv *map[string]string `json:",omitempty"`
 
+	// Analyses is a map of booleans (0 or 1 in VimScript) used to enable/disable
+	// specific analyses in gopls. Entries in the map are used to override
+	// defaults specified by gopls. A list of analyzers with their default value
+	// can be found in the gopls documentation (e.g.
+	// https://cs.opensource.google/go/tools/+/master:gopls/doc/analyzers.md for
+	// master).
+	//
+	// Example: govim#config#Set("Analyses", {"fillstruct": 1, "unreachable": 0})
+	//
+	// Default: nil
+	Analyses *map[string]bool `json:",omitempty"`
+
 	// ExperimentalAutoreadLoadedBuffers is used to reload buffers that are
 	// changed outside vim even when they are loaded (e.g. running two vim
 	// sessions in the same workspace). This is achieved by running "checktime"

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -43,6 +43,9 @@ func (r *Config) Apply(v *Config) {
 	if v.GoplsEnv != nil {
 		r.GoplsEnv = v.GoplsEnv
 	}
+	if v.Analyses != nil {
+		r.Analyses = v.Analyses
+	}
 	if v.ExperimentalAutoreadLoadedBuffers != nil {
 		r.ExperimentalAutoreadLoadedBuffers = v.ExperimentalAutoreadLoadedBuffers
 	}

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -26,6 +26,7 @@ const (
 	goplsTempModfile          = "tempModfile"
 	goplsVerboseOutput        = "verboseOutput"
 	goplsEnv                  = "env"
+	goplsAnalyses             = "analyses"
 )
 
 var _ protocol.Client = (*govimplugin)(nil)
@@ -135,6 +136,9 @@ func (g *govimplugin) Configuration(ctxt context.Context, params *protocol.Param
 	}
 	if os.Getenv(string(config.EnvVarGoplsVerbose)) == "true" {
 		goplsConfig[goplsVerboseOutput] = true
+	}
+	if conf.Analyses != nil {
+		goplsConfig[goplsAnalyses] = *conf.Analyses
 	}
 	if g.vimstate.config.GoplsEnv != nil {
 		// It is safe not to copy the map here because a new config setting from

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -21,6 +21,7 @@ type VimConfig struct {
 	CompletionBudget                             *string
 	TempModfile                                  *int
 	GoplsEnv                                     *map[string]string
+	Analyses                                     *map[string]int
 	ExperimentalAutoreadLoadedBuffers            *int
 	ExperimentalMouseTriggeredHoverPopupOptions  *map[string]interface{}
 	ExperimentalCursorTriggeredHoverPopupOptions *map[string]interface{}
@@ -43,6 +44,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		CompletionBudget:                  stringVal(c.CompletionBudget, d.CompletionBudget),
 		TempModfile:                       boolVal(c.TempModfile, d.TempModfile),
 		GoplsEnv:                          copyStringValMap(c.GoplsEnv, d.GoplsEnv),
+		Analyses:                          mergeBoolValMap(c.Analyses, d.Analyses),
 		ExperimentalAutoreadLoadedBuffers: boolVal(c.ExperimentalAutoreadLoadedBuffers, d.ExperimentalAutoreadLoadedBuffers),
 		ExperimentalMouseTriggeredHoverPopupOptions:  copyMap(c.ExperimentalMouseTriggeredHoverPopupOptions, d.ExperimentalMouseTriggeredHoverPopupOptions),
 		ExperimentalCursorTriggeredHoverPopupOptions: copyMap(c.ExperimentalCursorTriggeredHoverPopupOptions, d.ExperimentalCursorTriggeredHoverPopupOptions),
@@ -83,6 +85,25 @@ func copyStringValMap(i, j *map[string]string) *map[string]string {
 	res := make(map[string]string)
 	for ck, cv := range *toCopy {
 		res[ck] = cv
+	}
+	return &res
+}
+
+// mergeBoolValMap returns the union of i and j where conflicting keys use
+// the value from i.
+func mergeBoolValMap(i *map[string]int, j *map[string]bool) *map[string]bool {
+	res := make(map[string]bool)
+
+	if j != nil {
+		for ck, cv := range *j {
+			res[ck] = cv
+		}
+	}
+
+	if i != nil {
+		for ck, cv := range *i {
+			res[ck] = cv != 0
+		}
 	}
 	return &res
 }


### PR DESCRIPTION
As a part of gopls configuration the user can enable/disable specific
analyses.

A list of analyzers that can be enabled/disabled can be found in
[the gopls documentation](https://cs.opensource.google/go/tools/+/master:gopls/doc/analyzers.md) (note that the list isn't up to date):

Example:

`call govim#config#Set("Analyses", {"fillstruct": 1, "unreachable": 0})`