### PR TITLE
ci: enable unstable (i.e. beta) go versions in vim master tests

### DIFF
--- a/.github/workflows/vim_master.yml
+++ b/.github/workflows/vim_master.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
+        stable: 'false'
         go-version: ${{ matrix.go-version }}
     - name: Run master tests
       run: ./_scripts/testVimMaster.sh

--- a/internal/cmd/genconfig/genconfig.go
+++ b/internal/cmd/genconfig/genconfig.go
@@ -312,6 +312,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
+        stable: 'false'
         go-version: ${{ matrix.go-version }}
     - name: Run master tests
       run: ./_scripts/testVimMaster.sh


### PR DESCRIPTION
GitHub action actions/setup-go@v2 require passing "with.stable = false"
to use Go releases that aren't considered stable (such as beta
releases).

Without this the scheduled vim master tests will fail when using go 1.15
beta 1 for example.