### PR TITLE
cmd/govim: drop test skip based on golang.org/issues/36743

### DIFF
--- a/cmd/govim/testdata/scenario_default/rename.txt
+++ b/cmd/govim/testdata/scenario_default/rename.txt
@@ -8,8 +8,6 @@ vim ex 'silent noautocmd wall'
 cmp main.go main.go.banana
 cmp other.go other.go.banana
 
-[golang.org/issues/36743] skip
-
 # Rename of an identifier in another package
 vim ex 'call cursor(14,16)'
 vim ex 'call execute(\"GOVIMRename Goodbye\")'


### PR DESCRIPTION
golang.org/issues/36743 has now been resolved. It appears therefore that
we can re-enable this part of the scenario_default/rename test.