### PR TITLE
cmd/govim: disable flaky quickfix_empty_files and modfile_changes tests

### DIFF
--- a/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
@@ -10,6 +10,8 @@
 # the definition of DoIt to take an integer argument at which point all
 # diagnostics should disappear.
 
+[golang.org/issues/39646] skip
+
 # Create all the new files
 vim ex 'e p/p.go'
 vim ex 'r p/p.go.orig | 0d_'

--- a/cmd/govim/testdata/scenario_tempmodfile/modfile_changes.txt
+++ b/cmd/govim/testdata/scenario_tempmodfile/modfile_changes.txt
@@ -1,6 +1,8 @@
 # A simple test that verifies we get a diagnostic for imports
 # that are missing from our go.mod file
 
+[golang.org/issues/40269] skip
+
 [!go1.14] skip '-modfile only supported in Go 1.14'
 
 [short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'


### PR DESCRIPTION
Disable tests that are flaky on CI as a result of intermittent gopls
bugs, namely golang.org/issues/39646 and golang.org/issues/40269.

We have open issues against these bugs, so it doesn't make sense to
suffer the daily disappointment of a failing build against gopls@master,
or indeed have a sometimes-red (and therefore misleading) main build.