### PR TITLE
cmd/govim: add "Toggle gc annotation details" feature

### DIFF
--- a/cmd/govim/code_lens.go
+++ b/cmd/govim/code_lens.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/govim/govim"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+)
+
+// toggleGCDetails calls gopls CommandToggleDetails (via CodeLens) that enable/disable
+// compiler annotations as diagnostics for a package. Current cursor position is used
+// to determine which package to toggle.
+func (v *vimstate) toggleGCDetails(flags govim.CommandFlags, args ...string) error {
+	cb, _, err := v.bufCursorPos()
+	if err != nil {
+		return fmt.Errorf("failed to determine cursor position: %v", err)
+	}
+	res, err := v.server.CodeLens(context.Background(), &protocol.CodeLensParams{
+		TextDocument: cb.ToTextDocumentIdentifier(),
+	})
+	if err != nil {
+		return fmt.Errorf("codeLens failed: %v", err)
+	}
+
+	var cmd *protocol.Command
+	for i := range res {
+		cl := res[i]
+		if cl.Command.Command != source.CommandToggleDetails.Name {
+			continue
+		}
+		if cmd != nil {
+			return fmt.Errorf("got multiple gc_detail commands from gopls, can't handle")
+		}
+		cmd = &cl.Command
+	}
+	if cmd == nil {
+		return nil
+	}
+
+	if _, err = v.server.ExecuteCommand(context.Background(),
+		&protocol.ExecuteCommandParams{
+			Command:   cmd.Command,
+			Arguments: cmd.Arguments,
+		}); err != nil {
+		return fmt.Errorf("execute command failed: %v", err)
+	}
+	return nil
+}

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -311,6 +311,13 @@ const (
 	// CommandFillStruct populates fields in the struct under the cursor. Each
 	// field will get the respective zero value as value.
 	CommandFillStruct Command = "FillStruct"
+
+	// CommandGCDetails toggles go compiler annotation details for the current
+	// package. When enabled gopls will include diagnostics of information
+	// severity with decisions about inlining, escapes, etc.
+	//
+	// Note that this feature is experimental in gopls.
+	CommandGCDetails Command = "GCDetails"
 )
 
 type Function string

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/govim/govim"
 	"github.com/govim/govim/cmd/govim/config"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	"github.com/kr/pretty"
 )
@@ -27,6 +28,7 @@ const (
 	goplsVerboseOutput        = "verboseOutput"
 	goplsEnv                  = "env"
 	goplsAnalyses             = "analyses"
+	goplsCodeLens             = "codelens"
 )
 
 var _ protocol.Client = (*govimplugin)(nil)
@@ -139,6 +141,9 @@ func (g *govimplugin) Configuration(ctxt context.Context, params *protocol.Param
 	}
 	if conf.Analyses != nil {
 		goplsConfig[goplsAnalyses] = *conf.Analyses
+	}
+	goplsConfig[goplsCodeLens] = map[string]bool{
+		source.CommandToggleDetails.Name: true, // gc_details
 	}
 	if g.vimstate.config.GoplsEnv != nil {
 		// It is safe not to copy the map here because a new config setting from

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -286,6 +286,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineAutoCommand("", govim.Events{govim.EventCompleteDone}, govim.Patterns{"*.go"}, false, g.vimstate.completeDone, "eval(expand('<abuf>'))", "v:completed_item")
 	g.DefineCommand(string(config.CommandExperimentalSignatureHelp), g.vimstate.signatureHelp)
 	g.DefineCommand(string(config.CommandFillStruct), g.vimstate.fillStruct)
+	g.DefineCommand(string(config.CommandGCDetails), g.vimstate.toggleGCDetails)
 	g.defineHighlights()
 	if err := g.vimstate.signDefine(); err != nil {
 		return fmt.Errorf("failed to define signs: %v", err)

--- a/cmd/govim/testdata/scenario_default/codelens_gc_details.txt
+++ b/cmd/govim/testdata/scenario_default/codelens_gc_details.txt
@@ -1,0 +1,102 @@
+# Tests CodeLens "gc_details" that, when enabled gopls will include diagnostics of information
+# severity with decisions about inlining, escapes, etc.
+
+[!go1.14] skip 'gc_details require at least Go 1.14'
+
+# Compiler details are reported using "information" severity
+vim ex 'e main.go'
+vim ex 'GOVIMGCDetails'
+[go1.14] [!go1.15] vimexprwait errors.go114.golden GOVIMTest_getqflist()
+[go1.15] vimexprwait errors.go115.golden GOVIMTest_getqflist()
+
+
+[short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'
+# Test that details can be disabled
+vim ex 'GOVIMGCDetails'
+sleep $GOVIM_ERRLOGMATCH_WAIT
+vimexprwait errors.empty GOVIMTest_getqflist()
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+func main() {
+	fn()
+}
+
+func fn() {}
+-- errors.empty --
+[]
+-- errors.go114.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "canInlineFunction(cost: 2)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 4,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "inlineCall(main.fn)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "canInlineFunction(cost: 0)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.go115.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "canInlineFunction(cost: 2)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "canInlineFunction(cost: 0)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]


### PR DESCRIPTION
Add "Toggle gc annotation details" as new command, "GOVIMGCDetails".

The feature is toggled per package. When enabled, gopls will include
diagnostics of information severity with decisions about inlining,
escapes, etc.

Note that this is an experimental code lens feature in gopls that
might change or be removed.