### PR TITLE
cmd/govim: add support for popups showing WorkDoneProgress

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -159,6 +159,10 @@ function! s:validExperimentalWorkaroundCompleteoptLongest(v)
   return s:validBool(a:v)
 endfunction
 
+function! s:validExperimentalProgressPopups(v)
+  return s:validBool(a:v)
+endfunction
+
 let s:validators = {
       \ "FormatOnSave": function("s:validFormatOnSave"),
       \ "QuickfixAutoDiagnostics": function("s:validQuickfixAutoDiagnostics"),
@@ -179,4 +183,5 @@ let s:validators = {
       \ "ExperimentalMouseTriggeredHoverPopupOptions": function("s:validExperimentalMouseTriggeredHoverPopupOptions"),
       \ "ExperimentalCursorTriggeredHoverPopupOptions": function("s:validExperimentalCursorTriggeredHoverPopupOptions"),
       \ "ExperimentalWorkaroundCompleteoptLongest": function("s:validExperimentalWorkaroundCompleteoptLongest"),
+      \ "ExperimentalProgressPopups": function("s:validExperimentalProgressPopups"),
       \ }

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -233,6 +233,17 @@ type Config struct {
 	// completeopt=menu,popup and Vim+govim will behave approximately like
 	// completeopt+=longest.
 	ExperimentalWorkaroundCompleteoptLongest *bool `json:",omitempty"`
+
+	// ExperimentalProgressPopups will, when enabled, show a notification
+	// popup when gopls run tasks that support reporting of progress.
+	// Examples of such reporting can be the initial workspace load, running
+	// tests or "go generate".
+	//
+	// This is an experimental feature that might go away in the future, be
+	// renamed etc.
+	//
+	// Default: false
+	ExperimentalProgressPopups *bool `json:",omitempty"`
 }
 
 type Command string
@@ -353,6 +364,8 @@ const (
 	FunctionSetUserBusy Function = InternalFunctionPrefix + "SetUserBusy"
 
 	FunctionPopupSelection Function = InternalFunctionPrefix + "PopupSelection"
+
+	FunctionProgressClosed Function = InternalFunctionPrefix + "ProgressClosed"
 
 	// FunctionStringFnComplete is an internal function used by govim to provide
 	// completion of arguments to CommandStringFn

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -58,4 +58,7 @@ func (r *Config) Apply(v *Config) {
 	if v.ExperimentalWorkaroundCompleteoptLongest != nil {
 		r.ExperimentalWorkaroundCompleteoptLongest = v.ExperimentalWorkaroundCompleteoptLongest
 	}
+	if v.ExperimentalProgressPopups != nil {
+		r.ExperimentalProgressPopups = v.ExperimentalProgressPopups
+	}
 }

--- a/cmd/govim/gopls.go
+++ b/cmd/govim/gopls.go
@@ -137,6 +137,8 @@ func (g *govimplugin) startGopls() error {
 	initParams.Capabilities.Workspace.DidChangeConfiguration.DynamicRegistration = true
 	initParams.Capabilities.Workspace.DidChangeWatchedFiles.DynamicRegistration = true
 
+	initParams.Capabilities.Window.WorkDoneProgress = true
+
 	if _, err := g.server.Initialize(context.Background(), initParams); err != nil {
 		return fmt.Errorf("failed to initialise gopls: %v", err)
 	}

--- a/cmd/govim/internal/types/popup.go
+++ b/cmd/govim/internal/types/popup.go
@@ -18,3 +18,12 @@ type PopupProp struct {
 	Col  int    `json:"col"`
 	Len  int    `json:"length"`
 }
+
+// ProgressPopup represents a vim popup placed in the upper right corner used
+// to show LSP progress. LinePos is used to stack multiple visible progress
+// popups.
+type ProgressPopup struct {
+	ID      int
+	Text    []string
+	LinePos int
+}

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -26,6 +26,7 @@ type VimConfig struct {
 	ExperimentalMouseTriggeredHoverPopupOptions  *map[string]interface{}
 	ExperimentalCursorTriggeredHoverPopupOptions *map[string]interface{}
 	ExperimentalWorkaroundCompleteoptLongest     *int
+	ExperimentalProgressPopups                   *int
 }
 
 func (c *VimConfig) ToConfig(d config.Config) config.Config {
@@ -49,6 +50,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		ExperimentalMouseTriggeredHoverPopupOptions:  copyMap(c.ExperimentalMouseTriggeredHoverPopupOptions, d.ExperimentalMouseTriggeredHoverPopupOptions),
 		ExperimentalCursorTriggeredHoverPopupOptions: copyMap(c.ExperimentalCursorTriggeredHoverPopupOptions, d.ExperimentalCursorTriggeredHoverPopupOptions),
 		ExperimentalWorkaroundCompleteoptLongest:     boolVal(c.ExperimentalWorkaroundCompleteoptLongest, d.ExperimentalWorkaroundCompleteoptLongest),
+		ExperimentalProgressPopups:                   boolVal(c.ExperimentalProgressPopups, d.ExperimentalProgressPopups),
 	}
 	if v.FormatOnSave == nil {
 		v.FormatOnSave = d.FormatOnSave

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -245,6 +245,7 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 			config:                *defaults,
 			quickfixIsDiagnostics: true,
 			suggestedFixesPopups:  make(map[int][]protocol.WorkspaceEdit),
+			progressPopups:        make(map[protocol.ProgressToken]*types.ProgressPopup),
 		},
 	}
 	res.vimstate.govimplugin = res
@@ -287,6 +288,7 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineCommand(string(config.CommandExperimentalSignatureHelp), g.vimstate.signatureHelp)
 	g.DefineCommand(string(config.CommandFillStruct), g.vimstate.fillStruct)
 	g.DefineCommand(string(config.CommandGCDetails), g.vimstate.toggleGCDetails)
+	g.DefineFunction(string(config.FunctionProgressClosed), []string{"id", "selected"}, g.vimstate.progressClosed)
 	g.defineHighlights()
 	if err := g.vimstate.signDefine(); err != nil {
 		return fmt.Errorf("failed to define signs: %v", err)

--- a/cmd/govim/progress.go
+++ b/cmd/govim/progress.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"sort"
+
+	"github.com/govim/govim/cmd/govim/config"
+	"github.com/govim/govim/cmd/govim/internal/types"
+)
+
+func (v *vimstate) handleProgress(popup *types.ProgressPopup, kind, title, message string) error {
+	switch kind {
+	case "begin":
+		w := v.ParseInt(v.ChannelCall("winwidth", 0))
+
+		popup.Text = []string{message}
+		popup.LinePos = 1
+		opts := map[string]interface{}{
+			"pos":      "topright",
+			"line":     popup.LinePos,
+			"col":      w,
+			"padding":  []int{0, 1, 0, 1},
+			"wrap":     false,
+			"close":    "click",
+			"title":    title,
+			"zindex":   300, // same as popup_notification()
+			"mapping":  0,
+			"border":   []string{},
+			"minwidth": 20, // same as popup_notification()
+			"callback": "GOVIM" + config.FunctionProgressClosed,
+		}
+		popup.ID = v.ParseInt(v.ChannelCall("popup_create", popup.Text, opts))
+	case "report":
+		popup.Text = append(popup.Text, message)
+		v.ChannelCall("popup_settext", popup.ID, popup.Text)
+	case "end":
+		popup.Text = append(popup.Text, message)
+		v.BatchStart()
+		v.BatchChannelCall("popup_settext", popup.ID, popup.Text)
+		v.BatchChannelCall("popup_setoptions", popup.ID, map[string]interface{}{
+			"time": 3000, // close after 3 seconds, as popup_notification()
+		})
+		v.MustBatchEnd()
+	}
+
+	v.rearrangeProgressPopups()
+	return nil
+}
+
+// rearrangeProgressPopups will move progress popups so that they are sorted by
+// popup ID and thus creation time.
+func (v *vimstate) rearrangeProgressPopups() {
+	popups := make([]*types.ProgressPopup, 0, len(v.progressPopups))
+	for _, p := range v.progressPopups {
+		if p != nil {
+			popups = append(popups, p)
+		}
+	}
+	if len(popups) == 0 {
+		return
+	}
+
+	sort.Slice(popups, func(i, j int) bool {
+		return popups[i].ID < popups[j].ID
+	})
+
+	v.BatchStart()
+	line := 1
+	for i := range popups {
+		if popups[i].LinePos != line {
+			popups[i].LinePos = line
+			v.BatchChannelCall("popup_setoptions",
+				popups[i].ID,
+				map[string]interface{}{"line": popups[i].LinePos},
+			)
+		}
+		line += len(popups[i].Text) + 1 // title + lines
+	}
+	v.MustBatchEnd()
+}


### PR DESCRIPTION
Add experimental support for popups showing WorkDoneProgress.
The feature is disabled by default, and can be enabled via .vimrc:

`call govim#config#Set("ExperimentalProgressPopups", 1)`

When enabled govim will create notification style popups in
the upper right corner when gopls report progress of a task
(e.g. initial workspace load, running tests or "go generate").

The popup will close itself afterwards.

Note that this is an experimental feature. It has rather limited
use initially since govim doesn't yet support running tests via
gopls for example.