### PR TITLE
cmd/govim/config: add SymbolMatcher and SymbolStyle config

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -88,6 +88,22 @@ function! s:validCompletionMatcher(v)
   return [v:true, ""]
 endfunction
 
+function! s:validSymbolMatcher(v)
+  let valid = ["caseInsensitive", "caseSensitive", "fuzzy"]
+  if index(valid, a:v) < 0
+    return [v:false, "must be one of: ".string(valid)]
+  endif
+  return [v:true, ""]
+endfunction
+
+function! s:validSymbolStyle(v)
+  let valid = ["package", "dynamic", "full"]
+  if index(valid, a:v) < 0
+    return [v:false, "must be one of: ".string(valid)]
+  endif
+  return [v:true, ""]
+endfunction
+
 function! s:validStaticcheck(v)
   return s:validBool(a:v)
 endfunction
@@ -168,6 +184,8 @@ let s:validators = {
       \ "QuickfixAutoDiagnostics": function("s:validQuickfixAutoDiagnostics"),
       \ "CompletionDeepCompletions": function("s:validCompletionDeepCompletions"),
       \ "CompletionMatcher": function("s:validCompletionMatcher"),
+      \ "SymbolMatcher": function("s:validSymbolMatcher"),
+      \ "SymbolStyle": function("s:validSymbolStyle"),
       \ "QuickfixSigns": function("s:validQuickfixSigns"),
       \ "HighlightDiagnostics": function("s:validHighlightDiagnostics"),
       \ "HighlightReferences": function("s:validHighlightReferences"),

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -108,6 +108,18 @@ type Config struct {
 	// Default: CompletionMatcherFuzzy
 	CompletionMatcher *CompletionMatcher `json:",omitempty"`
 
+	// SymbolMatcher is a string value that tells gopls which matcher
+	// to use when computing workspace symbol candidates.
+	//
+	// Default: SymbolMatcherFuzzy
+	SymbolMatcher *SymbolMatcher `json:",omitempty"`
+
+	// SymbolStyle is a string value that tells gopls which qualification style
+	// to use when computing workspace symbol candidates.
+	//
+	// Default: SymbolStyleFull
+	SymbolStyle *SymbolStyle `json:",omitempty"`
+
 	// Staticcheck enables staticcheck analyses in gopls
 	//
 	// Default: false
@@ -414,6 +426,42 @@ const (
 	// CompletionMatcherCaseInsensitive specifies that gopls should use
 	// case-sensitive matching when computing completion candidates
 	CompletionMatcherCaseInsensitive CompletionMatcher = "caseInsensitive"
+)
+
+// SymbolMatcher typed constants define the set of valid values that
+// Config.SymbolMatcher can take
+type SymbolMatcher string
+
+const (
+	// SymbolMatcherFuzzy specifies that gopls should use fuzzy matching
+	// when computing workspace symbol candidates
+	SymbolMatcherFuzzy SymbolMatcher = "fuzzy"
+
+	// SymbolMatcherCaseSensitive specifies that gopls should use case sensitive
+	// matching when computing workspace symbol candidates
+	SymbolMatcherCaseSensitive SymbolMatcher = "caseSensitive"
+
+	// SymbolMatcherCaseInsensitive specifies that gopls should use case
+	// insensitive matching when computing workspace symbol candidates
+	SymbolMatcherCaseInsensitive SymbolMatcher = "caseInsensitive"
+)
+
+// SymbolStyle typed constants define the set of valid values that
+// Config.SymbolStyle can take
+type SymbolStyle string
+
+const (
+	// SymbolStyleFull specifies that gopls should fully qualify workspace
+	// symbol candidates
+	SymbolStyleFull SymbolStyle = "full"
+
+	// SymbolStylePackage specifies that gopls should package name-qualify
+	// workspace symbol candidates
+	SymbolStylePackage SymbolStyle = "package"
+
+	// SymbolStyleDynamic specifies that gopls should dynamic name-qualify
+	// workspace symbol candidates
+	SymbolStyleDynamic SymbolStyle = "dynamic"
 )
 
 // Highlight typed constants define the different highlight groups used by govim.

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -25,6 +25,12 @@ func (r *Config) Apply(v *Config) {
 	if v.CompletionMatcher != nil {
 		r.CompletionMatcher = v.CompletionMatcher
 	}
+	if v.SymbolMatcher != nil {
+		r.SymbolMatcher = v.SymbolMatcher
+	}
+	if v.SymbolStyle != nil {
+		r.SymbolStyle = v.SymbolStyle
+	}
 	if v.Staticcheck != nil {
 		r.Staticcheck = v.Staticcheck
 	}

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -30,6 +30,8 @@ const (
 	goplsEnv                  = "env"
 	goplsAnalyses             = "analyses"
 	goplsCodeLens             = "codelens"
+	goplsSymbolMatcher        = "symbolMatcher"
+	goplsSymbolStyle          = "symbolStyle"
 )
 
 var _ protocol.Client = (*govimplugin)(nil)

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -15,6 +15,8 @@ type VimConfig struct {
 	HoverDiagnostics                             *int
 	CompletionDeepCompletions                    *int
 	CompletionMatcher                            *config.CompletionMatcher
+	SymbolMatcher                                *config.SymbolMatcher
+	SymbolStyle                                  *config.SymbolStyle
 	Staticcheck                                  *int
 	CompleteUnimported                           *int
 	GoImportsLocalPrefix                         *string
@@ -39,6 +41,8 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		HoverDiagnostics:                  boolVal(c.HoverDiagnostics, d.HoverDiagnostics),
 		CompletionDeepCompletions:         boolVal(c.CompletionDeepCompletions, d.CompletionDeepCompletions),
 		CompletionMatcher:                 c.CompletionMatcher,
+		SymbolMatcher:                     c.SymbolMatcher,
+		SymbolStyle:                       c.SymbolStyle,
 		Staticcheck:                       boolVal(c.Staticcheck, d.Staticcheck),
 		CompleteUnimported:                boolVal(c.CompleteUnimported, d.CompleteUnimported),
 		GoImportsLocalPrefix:              stringVal(c.GoImportsLocalPrefix, d.GoImportsLocalPrefix),
@@ -57,6 +61,12 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 	}
 	if v.CompletionMatcher == nil {
 		v.CompletionMatcher = d.CompletionMatcher
+	}
+	if v.SymbolMatcher == nil {
+		v.SymbolMatcher = d.SymbolMatcher
+	}
+	if v.SymbolStyle == nil {
+		v.SymbolStyle = d.SymbolStyle
 	}
 	return v
 }
@@ -123,6 +133,14 @@ func copyMap(i, j *map[string]interface{}) *map[string]interface{} {
 		res[ck] = cv
 	}
 	return &res
+}
+
+func SymbolMatcherVal(v config.SymbolMatcher) *config.SymbolMatcher {
+	return &v
+}
+
+func SymbolStyleVal(v config.SymbolStyle) *config.SymbolStyle {
+	return &v
 }
 
 func FormatOnSaveVal(v config.FormatOnSave) *config.FormatOnSave {

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -222,6 +222,8 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 			HoverDiagnostics:                  vimconfig.BoolVal(true),
 			TempModfile:                       vimconfig.BoolVal(false),
 			ExperimentalAutoreadLoadedBuffers: vimconfig.BoolVal(false),
+			SymbolMatcher:                     vimconfig.SymbolMatcherVal(config.SymbolMatcherFuzzy),
+			SymbolStyle:                       vimconfig.SymbolStyleVal(config.SymbolStyleFull),
 		}
 	}
 	// Overlay the initial user values on the defaults


### PR DESCRIPTION
These correspond to gopls configurations that can be set on the session.