### PR TITLE
cmd/govim: trigger AST parsing after applyProtocolTextEdits

### DIFF
--- a/cmd/govim/testdata/scenario_bugs/bug_govim_940.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_govim_940.txt
@@ -1,0 +1,47 @@
+# Test case that verifies we have a fix for github.com/govim/govim/issues/940
+# When we receive text edits from gopls, our internal AST wasn't updated leading
+# to panics when using signature help for example.
+
+# Open main.go that lacks import statement for "fmt"
+vim ex 'e main.go'
+vimexprwait errors.golden GOVIMTest_getqflist()
+
+# Save the file so the import statment is added (and cursor is moved)
+vim ex 'call cursor(4,15)'
+vim ex 'w!'
+vimexprwait errors.empty GOVIMTest_getqflist()
+
+# Now trigger signature help, did panic before since the new buffer content didn't match our AST
+vim ex ':GOVIMExperimentalSignatureHelp'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+func main() {
+	fmt.Println("")
+}
+-- errors.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: fmt",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.empty --
+[]

--- a/cmd/govim/textedit.go
+++ b/cmd/govim/textedit.go
@@ -146,6 +146,7 @@ func (v *vimstate) applyProtocolTextEdits(b *types.Buffer, edits []protocol.Text
 	var newContents string
 	v.Parse(newContentsRes(), &newContents)
 	b.SetContents([]byte(newContents))
+	v.triggerBufferASTUpdate(b)
 	b.Version++
 	params := &protocol.DidChangeTextDocumentParams{
 		TextDocument: protocol.VersionedTextDocumentIdentifier{
@@ -158,6 +159,7 @@ func (v *vimstate) applyProtocolTextEdits(b *types.Buffer, edits []protocol.Text
 			},
 		},
 	}
+
 	return v.server.DidChange(context.Background(), params)
 }
 


### PR DESCRIPTION
Features that trigger applyProtocolTextEdits (such as organize imports
on save) didn't trigger an AST update. Calling functions that depend on
a fresh AST, like motion or signature help, could panic due to stale AST.

Fixes #940