### PR TITLE
Revert "cmd/govim: try to unskip tests skipped on golang.org/issues/39646

### DIFF
--- a/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
@@ -10,6 +10,8 @@
 # the definition of DoIt to take an integer argument at which point all
 # diagnostics should disappear.
 
+[golang.org/issues/39646] skip
+
 # Create all the new files
 vim ex 'e p/p.go'
 vim ex 'r p/p.go.orig | 0d_'


### PR DESCRIPTION
This reverts commit c8c4a6f83808a8b9fab26293c3ed508da6b39d77.

Reason: test is still flakey