### PR TITLE
deps: update x/tools and gopls to 6ec2cde9

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/mod/module"
 	"golang.org/x/tools/go/packages"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag"
@@ -256,7 +257,6 @@ func typeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode source
 		mode:            mode,
 		goFiles:         make([]*source.ParsedGoFile, len(m.goFiles)),
 		compiledGoFiles: make([]*source.ParsedGoFile, len(m.compiledGoFiles)),
-		module:          m.module,
 		imports:         make(map[packagePath]*pkg),
 		typesSizes:      m.typesSizes,
 		typesInfo: &types.Info{
@@ -267,6 +267,18 @@ func typeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode source
 			Selections: make(map[*ast.SelectorExpr]*types.Selection),
 			Scopes:     make(map[ast.Node]*types.Scope),
 		},
+	}
+	// If this is a replaced module in the workspace, the version is
+	// meaningless, and we don't want clients to access it.
+	if m.module != nil {
+		version := m.module.Version
+		if version == source.WorkspaceModuleVersion {
+			version = ""
+		}
+		pkg.version = &module.Version{
+			Path:    m.module.Path,
+			Version: version,
+		}
 	}
 	var (
 		files        = make([]*ast.File, len(m.compiledGoFiles))

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
@@ -91,7 +91,7 @@ func (s *snapshot) load(ctx context.Context, scopes ...interface{}) error {
 	cfg := s.config(ctx)
 
 	cleanup := func() {}
-	
+
 	var modFH, sumFH source.FileHandle
 	var err error
 	if s.view.modURI != "" {
@@ -108,7 +108,7 @@ func (s *snapshot) load(ctx context.Context, scopes ...interface{}) error {
 	}
 
 	switch {
-	case s.view.workspaceMode&workspaceModule != 0:
+	case s.view.workspaceMode&usesWorkspaceModule != 0:
 		var (
 			tmpDir span.URI
 			err    error

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/mod.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/mod.go
@@ -233,7 +233,7 @@ func (s *snapshot) ModWhy(ctx context.Context, fh source.FileHandle) (map[string
 		for _, req := range pm.File.Require {
 			args = append(args, req.Mod.Path)
 		}
-		stdout, err := snapshot.RunGoCommand(ctx, "mod", args)
+		stdout, err := snapshot.runGoCommandWithConfig(ctx, cfg, "mod", args)
 		if err != nil {
 			return &modWhyData{err: err}
 		}
@@ -329,7 +329,7 @@ func (s *snapshot) ModUpgrade(ctx context.Context, fh source.FileHandle) (map[st
 			// (see golang/go#38711).
 			args = append([]string{"-mod", "readonly"}, args...)
 		}
-		stdout, err := snapshot.RunGoCommand(ctx, "list", args)
+		stdout, err := snapshot.runGoCommandWithConfig(ctx, cfg, "list", args)
 		if err != nil {
 			return &modUpgradeData{err: err}
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
@@ -8,7 +8,7 @@ import (
 	"go/ast"
 	"go/types"
 
-	"golang.org/x/tools/go/packages"
+	"golang.org/x/mod/module"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	errors "golang.org/x/xerrors"
@@ -22,7 +22,7 @@ type pkg struct {
 	compiledGoFiles []*source.ParsedGoFile
 	errors          []*source.Error
 	imports         map[packagePath]*pkg
-	module          *packages.Module
+	version         *module.Version
 	typeErrors      []types.Error
 	types           *types.Package
 	typesInfo       *types.Info
@@ -133,6 +133,6 @@ func (p *pkg) Imports() []source.Package {
 	return result
 }
 
-func (p *pkg) Module() *packages.Module {
-	return p.module
+func (p *pkg) Version() *module.Version {
+	return p.version
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
@@ -173,7 +173,7 @@ func (s *Session) createView(ctx context.Context, name string, folder span.URI, 
 		name:               name,
 		folder:             folder,
 		root:               folder,
-		modules:            make(map[span.URI]*module),
+		modules:            make(map[span.URI]*moduleRoot),
 		filesByURI:         make(map[span.URI]*fileBase),
 		filesByBase:        make(map[string][]*fileBase),
 	}
@@ -206,13 +206,20 @@ func (s *Session) createView(ctx context.Context, name string, folder span.URI, 
 	}
 
 	// Find all of the modules in the workspace.
-	if err := v.findAndBuildWorkspaceModule(ctx, options); err != nil {
+	if err := v.findWorkspaceModules(ctx, options); err != nil {
 		return nil, nil, func() {}, err
 	}
 
 	// Now that we have set all required fields,
 	// check if the view has a valid build configuration.
 	v.setBuildConfiguration()
+
+	// Build the workspace module, if needed.
+	if options.ExperimentalWorkspaceModule {
+		if err := v.buildWorkspaceModule(ctx); err != nil {
+			return nil, nil, func() {}, err
+		}
+	}
 
 	// We have v.goEnv now.
 	v.processEnv = &imports.ProcessEnv{
@@ -240,13 +247,13 @@ func (s *Session) createView(ctx context.Context, name string, folder span.URI, 
 	return v, v.snapshot, v.snapshot.generation.Acquire(ctx), nil
 }
 
-// findAndBuildWorkspaceModule walks the view's root folder, looking for go.mod
-// files. Any that are found are added to the view's set of modules, which are
-// then used to construct the workspace module.
+// findWorkspaceModules walks the view's root folder, looking for go.mod files.
+// Any that are found are added to the view's set of modules, which are then
+// used to construct the workspace module.
 //
 // It assumes that the caller has not yet created the view, and therefore does
 // not lock any of the internal data structures before accessing them.
-func (v *View) findAndBuildWorkspaceModule(ctx context.Context, options source.Options) error {
+func (v *View) findWorkspaceModules(ctx context.Context, options source.Options) error {
 	// If the user is intentionally limiting their workspace scope, add their
 	// folder to the roots and return early.
 	if !options.ExpandWorkspaceToModule {
@@ -257,11 +264,9 @@ func (v *View) findAndBuildWorkspaceModule(ctx context.Context, options source.O
 		return nil
 	}
 
-	v.workspaceMode |= workspaceModule
-
 	// Walk the view's folder to find all modules in the view.
 	root := v.root.Filename()
-	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -284,15 +289,39 @@ func (v *View) findAndBuildWorkspaceModule(ctx context.Context, options source.O
 		// so add it to the view.
 		modURI := span.URIFromPath(path)
 		rootURI := span.URIFromPath(filepath.Dir(path))
-		v.modules[rootURI] = &module{
+		v.modules[rootURI] = &moduleRoot{
 			rootURI: rootURI,
 			modURI:  modURI,
 			sumURI:  span.URIFromPath(sumFilename(modURI)),
 		}
 		return nil
-	}); err != nil {
-		return err
+	})
+}
+
+func (v *View) buildWorkspaceModule(ctx context.Context) error {
+	// If the view has an invalid configuration, don't build the workspace
+	// module.
+	if !v.hasValidBuildConfiguration {
+		return nil
 	}
+	// If the view is not in a module and contains no modules, but still has a
+	// valid workspace configuration, do not create the workspace module.
+	// It could be using GOPATH or a different build system entirely.
+	if v.modURI == "" && len(v.modules) == 0 && v.hasValidBuildConfiguration {
+		return nil
+	}
+	v.workspaceMode |= moduleMode
+
+	// Don't default to multi-workspace mode if one of the modules contains a
+	// vendor directory. We still have to decide how to handle vendoring.
+	for _, mod := range v.modules {
+		if info, _ := os.Stat(filepath.Join(mod.rootURI.Filename(), "vendor")); info != nil {
+			return nil
+		}
+	}
+
+	v.workspaceMode |= usesWorkspaceModule
+
 	// If the user does not have a gopls.mod, we need to create one, based on
 	// modules we found in the user's workspace.
 	var err error

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
@@ -181,6 +181,10 @@ func (s *snapshot) RunGoCommandDirect(ctx context.Context, verb string, args []s
 
 func (s *snapshot) RunGoCommand(ctx context.Context, verb string, args []string) (*bytes.Buffer, error) {
 	cfg := s.config(ctx)
+	return s.runGoCommandWithConfig(ctx, cfg, verb, args)
+}
+
+func (s *snapshot) runGoCommandWithConfig(ctx context.Context, cfg *packages.Config, verb string, args []string) (*bytes.Buffer, error) {
 	_, runner, inv, cleanup, err := s.goCommandInvocation(ctx, cfg, true, verb, args)
 	if err != nil {
 		return nil, err
@@ -217,10 +221,13 @@ func (s *snapshot) goCommandInvocation(ctx context.Context, cfg *packages.Config
 		}
 		cfg.BuildFlags = append(cfg.BuildFlags, fmt.Sprintf("-modfile=%s", tmpURI.Filename()))
 	}
-	if s.view.modURI != "" && verb != "mod" && verb != "get" {
-		modFH, err := s.GetFile(ctx, s.view.modURI)
-		if err != nil {
-			return "", nil, nil, cleanup, err
+	if verb != "mod" && verb != "get" {
+		var modFH source.FileHandle
+		if s.view.modURI != "" {
+			modFH, err = s.GetFile(ctx, s.view.modURI)
+			if err != nil {
+				return "", nil, nil, cleanup, err
+			}
 		}
 		modMod, err := s.view.needsModEqualsMod(ctx, modFH)
 		if err != nil {
@@ -1245,15 +1252,13 @@ func (s *snapshot) buildBuiltinPackage(ctx context.Context, goFiles []string) er
 	return nil
 }
 
-const workspaceModuleVersion = "v0.0.0-00010101000000-000000000000"
-
 // buildWorkspaceModule generates a workspace module given the modules in the
 // the workspace.
 func (s *snapshot) buildWorkspaceModule(ctx context.Context) (*modfile.File, error) {
 	file := &modfile.File{}
 	file.AddModuleStmt("gopls-workspace")
 
-	paths := make(map[string]*module)
+	paths := make(map[string]*moduleRoot)
 	for _, mod := range s.view.modules {
 		fh, err := s.view.snapshot.GetFile(ctx, mod.modURI)
 		if err != nil {
@@ -1263,9 +1268,12 @@ func (s *snapshot) buildWorkspaceModule(ctx context.Context) (*modfile.File, err
 		if err != nil {
 			return nil, err
 		}
+		if parsed.File.Module == nil {
+			return nil, fmt.Errorf("no module declaration for %s", mod.modURI)
+		}
 		path := parsed.File.Module.Mod.Path
 		paths[path] = mod
-		file.AddNewRequire(path, workspaceModuleVersion, false)
+		file.AddNewRequire(path, source.WorkspaceModuleVersion, false)
 		if err := file.AddReplace(path, "", mod.rootURI.Filename(), ""); err != nil {
 			return nil, err
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
@@ -84,10 +84,6 @@ type EditorConfig struct {
 
 	// EnableStaticcheck enables staticcheck analyzers.
 	EnableStaticcheck bool
-
-	// ExperimentalWorkspaceModule enables the experimental support for
-	// multi-module workspaces.
-	ExperimentalWorkspaceModule bool
 }
 
 // NewEditor Creates a new Editor.
@@ -196,9 +192,8 @@ func (e *Editor) configuration() map[string]interface{} {
 	if e.Config.EnableStaticcheck {
 		config["staticcheck"] = true
 	}
-	if e.Config.ExperimentalWorkspaceModule {
-		config["experimentalWorkspaceModule"] = true
-	}
+	// Default to using the experimental workspace module mode.
+	config["experimentalWorkspaceModule"] = true
 
 	return config
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/link.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/link.go
@@ -179,10 +179,10 @@ func moduleAtVersion(ctx context.Context, snapshot source.Snapshot, target strin
 	if err != nil {
 		return "", "", false
 	}
-	if impPkg.Module() == nil {
+	if impPkg.Version() == nil {
 		return "", "", false
 	}
-	version, modpath := impPkg.Module().Version, impPkg.Module().Path
+	version, modpath := impPkg.Version().Version, impPkg.Version().Path
 	if modpath == "" || version == "" {
 		return "", "", false
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/diagnostics.go
@@ -89,11 +89,17 @@ func ExtractGoCommandError(ctx context.Context, snapshot source.Snapshot, fh sou
 		if match == nil || len(match) < 3 {
 			continue
 		}
-		v.Path = match[1]
-		v.Version = match[2]
-		if err := module.Check(v.Path, v.Version); err == nil {
-			break
+		path, version := match[1], match[2]
+		// Any module versions that come from the workspace module should not
+		// be shown to the user.
+		if version == source.WorkspaceModuleVersion {
+			continue
 		}
+		if err := module.Check(path, version); err != nil {
+			continue
+		}
+		v.Path, v.Version = path, version
+		break
 	}
 	pm, err := snapshot.ParseMod(ctx, fh)
 	if err != nil {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
@@ -201,10 +201,10 @@ func moduleAtVersion(path string, i *IdentifierInfo) (string, string, bool) {
 	if err != nil {
 		return "", "", false
 	}
-	if impPkg.Module() == nil {
+	if impPkg.Version() == nil {
 		return "", "", false
 	}
-	version, modpath := impPkg.Module().Version, impPkg.Module().Path
+	version, modpath := impPkg.Version().Version, impPkg.Version().Path
 	if modpath == "" || version == "" {
 		return "", "", false
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -14,8 +14,8 @@ import (
 	"io"
 
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 	"golang.org/x/tools/go/analysis"
-	"golang.org/x/tools/go/packages"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/imports"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
@@ -473,7 +473,7 @@ type Package interface {
 	GetImport(pkgPath string) (Package, error)
 	MissingDependencies() []string
 	Imports() []Package
-	Module() *packages.Module
+	Version() *module.Version
 }
 
 type Error struct {
@@ -508,3 +508,9 @@ var (
 	InconsistentVendoring = errors.New("inconsistent vendoring")
 	PackagesLoadError     = errors.New("packages.Load error")
 )
+
+// WorkspaceModuleVersion is the nonexistent pseudoversion used in the
+// construction of the workspace module. It is exported so that we can make
+// sure not to show this version to end users in error messages, to avoid
+// confusion.
+const WorkspaceModuleVersion = "v0.0.0-goplsworkspace"

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/workspace_symbol.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/workspace_symbol.go
@@ -12,6 +12,8 @@ import (
 	"go/types"
 	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/fuzzy"
@@ -401,46 +403,35 @@ func (sc *symbolCollector) walkFilesDecls(decls []ast.Decl) {
 	for _, decl := range decls {
 		switch decl := decl.(type) {
 		case *ast.FuncDecl:
-			fn := decl.Name.Name
 			kind := protocol.Function
+			var recv *ast.Ident
 			if decl.Recv != nil {
 				kind = protocol.Method
 				switch typ := decl.Recv.List[0].Type.(type) {
 				case *ast.StarExpr:
-					fn = typ.X.(*ast.Ident).Name + "." + fn
+					recv = typ.X.(*ast.Ident)
 				case *ast.Ident:
-					fn = typ.Name + "." + fn
+					recv = typ
 				}
 			}
-			sc.match(fn, kind, decl.Name)
+			if recv != nil {
+				sc.match(decl.Name.Name, kind, decl.Name, recv)
+			} else {
+				sc.match(decl.Name.Name, kind, decl.Name)
+			}
 		case *ast.GenDecl:
 			for _, spec := range decl.Specs {
 				switch spec := spec.(type) {
 				case *ast.TypeSpec:
-					target := spec.Name.Name
-					sc.match(target, typeToKind(sc.current.pkg.GetTypesInfo().TypeOf(spec.Type)), spec.Name)
-					switch st := spec.Type.(type) {
-					case *ast.StructType:
-						for _, field := range st.Fields.List {
-							sc.walkField(field, protocol.Field, target)
-						}
-					case *ast.InterfaceType:
-						for _, field := range st.Methods.List {
-							kind := protocol.Method
-							if len(field.Names) == 0 {
-								kind = protocol.Interface
-							}
-							sc.walkField(field, kind, target)
-						}
-					}
+					sc.match(spec.Name.Name, typeToKind(sc.current.pkg.GetTypesInfo().TypeOf(spec.Type)), spec.Name)
+					sc.walkType(spec.Type, spec.Name)
 				case *ast.ValueSpec:
 					for _, name := range spec.Names {
-						target := name.Name
 						kind := protocol.Variable
 						if decl.Tok == token.CONST {
 							kind = protocol.Constant
 						}
-						sc.match(target, kind, name)
+						sc.match(name.Name, kind, name)
 					}
 				}
 			}
@@ -448,16 +439,32 @@ func (sc *symbolCollector) walkFilesDecls(decls []ast.Decl) {
 	}
 }
 
-func (sc *symbolCollector) walkField(field *ast.Field, kind protocol.SymbolKind, prefix string) {
+// walkType processes symbols related to a type expression. path is path of
+// nested type identifiers to the type expression.
+func (sc *symbolCollector) walkType(typ ast.Expr, path ...*ast.Ident) {
+	switch st := typ.(type) {
+	case *ast.StructType:
+		for _, field := range st.Fields.List {
+			sc.walkField(field, protocol.Field, protocol.Field, path...)
+		}
+	case *ast.InterfaceType:
+		for _, field := range st.Methods.List {
+			sc.walkField(field, protocol.Interface, protocol.Method, path...)
+		}
+	}
+}
+
+// walkField processes symbols related to the struct field or interface method.
+//
+// unnamedKind and namedKind are the symbol kinds if the field is resp. unnamed
+// or named. path is the path of nested identifiers containing the field.
+func (sc *symbolCollector) walkField(field *ast.Field, unnamedKind, namedKind protocol.SymbolKind, path ...*ast.Ident) {
 	if len(field.Names) == 0 {
-		name := types.ExprString(field.Type)
-		target := prefix + "." + name
-		sc.match(target, kind, field)
-		return
+		sc.match(types.ExprString(field.Type), unnamedKind, field, path...)
 	}
 	for _, name := range field.Names {
-		target := prefix + "." + name.Name
-		sc.match(target, kind, name)
+		sc.match(name.Name, namedKind, name, path...)
+		sc.walkType(field.Type, append(path, name)...)
 	}
 }
 
@@ -491,25 +498,66 @@ func typeToKind(typ types.Type) protocol.SymbolKind {
 // match finds matches and gathers the symbol identified by name, kind and node
 // via the symbolCollector's matcher after first de-duping against previously
 // seen symbols.
-func (sc *symbolCollector) match(name string, kind protocol.SymbolKind, node ast.Node) {
+//
+// path specifies the identifier path to a nested field or interface method.
+func (sc *symbolCollector) match(name string, kind protocol.SymbolKind, node ast.Node, path ...*ast.Ident) {
 	if !node.Pos().IsValid() || !node.End().IsValid() {
 		return
 	}
 
-	// Arbitrary factors to apply to the match score for the purpose of
-	// downranking results.
-	//
-	// There is no science behind this, other than the principle that symbols
-	// outside of a workspace should be downranked. Adjust as necessary.
-	const (
-		nonWorkspaceFactor = 0.5
-	)
-	factor := 1.0
-	if !sc.current.isWorkspace {
-		factor *= nonWorkspaceFactor
+	isExported := isExported(name)
+	if len(path) > 0 {
+		var nameBuilder strings.Builder
+		for _, ident := range path {
+			nameBuilder.WriteString(ident.Name)
+			nameBuilder.WriteString(".")
+			if !ident.IsExported() {
+				isExported = false
+			}
+		}
+		nameBuilder.WriteString(name)
+		name = nameBuilder.String()
 	}
+
+	// Factors to apply to the match score for the purpose of downranking
+	// results.
+	//
+	// These numbers were crudely calibrated based on trial-and-error using a
+	// small number of sample queries. Adjust as necessary.
+	//
+	// All factors are multiplicative, meaning if more than one applies they are
+	// multiplied together.
+	const (
+		// nonWorkspaceFactor is applied to symbols outside of any active
+		// workspace. Developers are less likely to want to jump to code that they
+		// are not actively working on.
+		nonWorkspaceFactor = 0.5
+		// nonWorkspaceUnexportedFactor is applied to unexported symbols outside of
+		// any active workspace. Since one wouldn't usually jump to unexported
+		// symbols to understand a package API, they are particularly irrelevant.
+		nonWorkspaceUnexportedFactor = 0.5
+		// fieldFactor is applied to fields and interface methods. One would
+		// typically jump to the type definition first, so ranking fields highly
+		// can be noisy.
+		fieldFactor = 0.5
+	)
 	symbol, score := sc.symbolizer(name, sc.current.pkg, sc.matcher)
-	score *= factor
+
+	// Downrank symbols outside of the workspace.
+	if !sc.current.isWorkspace {
+		score *= nonWorkspaceFactor
+		if !isExported {
+			score *= nonWorkspaceUnexportedFactor
+		}
+	}
+
+	// Downrank fields.
+	if len(path) > 0 {
+		score *= fieldFactor
+	}
+
+	// Avoid the work below if we know this score will not be sorted into the
+	// results.
 	if score <= sc.res[len(sc.res)-1].score {
 		return
 	}
@@ -537,6 +585,16 @@ func (sc *symbolCollector) match(name string, kind protocol.SymbolKind, node ast
 		copy(sc.res[insertAt+1:], sc.res[insertAt:len(sc.res)-1])
 	}
 	sc.res[insertAt] = si
+}
+
+// isExported reports if a token is exported. Copied from
+// token.IsExported (go1.13+).
+//
+// TODO: replace usage with token.IsExported once go1.12 is no longer
+// supported.
+func isExported(name string) bool {
+	ch, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(ch)
 }
 
 // pkgView holds information related to a package that we are going to walk.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/tests/tests.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/tests/tests.go
@@ -221,8 +221,7 @@ func Context(t testing.TB) context.Context {
 	return context.Background()
 }
 
-func DefaultOptions() source.Options {
-	o := source.DefaultOptions()
+func DefaultOptions(o *source.Options) {
 	o.SupportedCodeActions = map[source.FileKind]map[protocol.CodeActionKind]bool{
 		source.Go: {
 			protocol.SourceOrganizeImports: true,
@@ -241,7 +240,7 @@ func DefaultOptions() source.Options {
 	o.InsertTextFormat = protocol.SnippetTextFormat
 	o.CompletionBudget = time.Minute
 	o.HierarchicalDocumentSymbolSupport = true
-	return o
+	o.ExperimentalWorkspaceModule = true
 }
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.6.2
 	golang.org/x/mod v0.3.0
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/tools v0.0.0-20200915031644-64986481280e
-	golang.org/x/tools/gopls v0.0.0-20200915031644-64986481280e
+	golang.org/x/tools v0.0.0-20200916122506-6ec2cde9631b
+	golang.org/x/tools/gopls v0.0.0-20200916122506-6ec2cde9631b
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -69,10 +69,10 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200828161849-5deb26317202/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200915031644-64986481280e h1:tfSNPIxC48Azhz4nLSPskz/yE9R6ftFRK8pfgfqWUAc=
-golang.org/x/tools v0.0.0-20200915031644-64986481280e/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
-golang.org/x/tools/gopls v0.0.0-20200915031644-64986481280e h1:PobhK1I9iQoB4vjSJbv3Z68PaQ4cAU8OwTMgh2hDP+c=
-golang.org/x/tools/gopls v0.0.0-20200915031644-64986481280e/go.mod h1:ZKEbBWLaHDNmr7igDh2FBZr7V0r1eonT0J5lLqVmCw0=
+golang.org/x/tools v0.0.0-20200916122506-6ec2cde9631b h1:0Dg4Zh7bmF8ZxmLynSVH+U9+W84+APb1O4tkz/wfq4Y=
+golang.org/x/tools v0.0.0-20200916122506-6ec2cde9631b/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools/gopls v0.0.0-20200916122506-6ec2cde9631b h1:a9i7zMpW8g2fJC6oh1lklCL0eeYrPuR5rqqhXKgmBX0=
+golang.org/x/tools/gopls v0.0.0-20200916122506-6ec2cde9631b/go.mod h1:ZKEbBWLaHDNmr7igDh2FBZr7V0r1eonT0J5lLqVmCw0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/lsp/source: add some additional symbol downranking 6ec2cde9
* gopls/internal/regtest: remove ExpectNow e20053b7
* gopls/internal/regtest: simplify regtest EditorConfig 797bd0f0
* gopls/internal/regtest: add an InitialWorkspaceLoad expectation cbbbe623
* gopls/internal/regtest: move expectations to their own file bf5c620a
* internal/lsp: enable multi-module workspace mode by default in tests f4cefd1c
* internal/lsp/cache: fix -mod=mod for workspace module setups 2db8f0ff