### PR TITLE
deps: update x/tools and gopls to 63098cc4

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/imports/fix.go
+++ b/cmd/govim/internal/golang_org_x_tools/imports/fix.go
@@ -920,11 +920,6 @@ func (e *ProcessEnv) buildContext() (*build.Context, error) {
 	// Populate it only if present.
 	rc := reflect.ValueOf(&ctx).Elem()
 	dir := rc.FieldByName("Dir")
-	if !dir.IsValid() {
-		// Working drafts of Go 1.14 named the field "WorkingDir" instead.
-		// TODO(bcmills): Remove this case after the Go 1.14 beta has been released.
-		dir = rc.FieldByName("WorkingDir")
-	}
 	if dir.IsValid() && dir.Kind() == reflect.String {
 		dir.SetString(e.WorkingDir)
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/cache.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/cache.go
@@ -115,10 +115,14 @@ func readFile(ctx context.Context, uri span.URI, modTime time.Time) *fileHandle 
 
 func (c *Cache) NewSession(ctx context.Context) *Session {
 	index := atomic.AddInt64(&sessionIndex, 1)
+	options := source.DefaultOptions().Clone()
+	if c.options != nil {
+		c.options(options)
+	}
 	s := &Session{
 		cache:       c,
 		id:          strconv.FormatInt(index, 10),
-		options:     source.DefaultOptions(),
+		options:     options,
 		overlays:    make(map[span.URI]*overlay),
 		gocmdRunner: &gocommand.Runner{},
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/cmd.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/cmd.go
@@ -211,9 +211,9 @@ func (app *Application) connect(ctx context.Context) (*connection, error) {
 	case strings.HasPrefix(app.Remote, "internal@"):
 		internalMu.Lock()
 		defer internalMu.Unlock()
-		opts := source.DefaultOptions()
+		opts := source.DefaultOptions().Clone()
 		if app.options != nil {
-			app.options(&opts)
+			app.options(opts)
 		}
 		key := fmt.Sprintf("%s %v", app.wd, opts)
 		if c := internalConnections[key]; c != nil {
@@ -271,9 +271,9 @@ func (c *connection) initialize(ctx context.Context, options func(*source.Option
 	params.Capabilities.Workspace.Configuration = true
 
 	// Make sure to respect configured options when sending initialize request.
-	opts := source.DefaultOptions()
+	opts := source.DefaultOptions().Clone()
 	if options != nil {
-		options(&opts)
+		options(opts)
 	}
 	params.Capabilities.TextDocument.Hover = protocol.HoverClientCapabilities{
 		ContentFormat: []protocol.MarkupKind{opts.PreferredContentFormat},

--- a/cmd/govim/internal/golang_org_x_tools/lsp/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/completion.go
@@ -104,7 +104,7 @@ func (s *Server) completion(ctx context.Context, params *protocol.CompletionPara
 	}, nil
 }
 
-func toProtocolCompletionItems(candidates []completion.CompletionItem, rng protocol.Range, options source.Options) []protocol.CompletionItem {
+func toProtocolCompletionItems(candidates []completion.CompletionItem, rng protocol.Range, options *source.Options) []protocol.CompletionItem {
 	var (
 		items                  = make([]protocol.CompletionItem, 0, len(candidates))
 		numDeepCompletionsSeen int

--- a/cmd/govim/internal/golang_org_x_tools/lsp/general.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/general.go
@@ -39,7 +39,7 @@ func (s *Server) initialize(ctx context.Context, params *protocol.ParamInitializ
 	options := s.session.Options()
 	defer func() { s.session.SetOptions(options) }()
 
-	if err := s.handleOptionResults(ctx, source.SetOptions(&options, params.InitializationOptions)); err != nil {
+	if err := s.handleOptionResults(ctx, source.SetOptions(options, params.InitializationOptions)); err != nil {
 		return nil, err
 	}
 	options.ForClientCapabilities(params.Capabilities)
@@ -205,8 +205,11 @@ func (s *Server) addFolders(ctx context.Context, folders []protocol.WorkspaceFol
 			work.end(fmt.Sprintf("Error loading packages: %s", err))
 			continue
 		}
+		var swg sync.WaitGroup
+		swg.Add(1)
 		go func() {
-			view.AwaitInitialized(ctx)
+			defer swg.Done()
+			snapshot.AwaitInitialized(ctx)
 			work.end("Finished loading packages.")
 		}()
 
@@ -226,6 +229,7 @@ func (s *Server) addFolders(ctx context.Context, folders []protocol.WorkspaceFol
 		wg.Add(1)
 		go func() {
 			s.diagnoseDetached(snapshot)
+			swg.Wait()
 			release()
 			wg.Done()
 		}()

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/code_lens.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/code_lens.go
@@ -44,6 +44,9 @@ func upgradeLens(ctx context.Context, snapshot source.Snapshot, fh source.FileHa
 		if !ok {
 			continue
 		}
+		if req.Syntax == nil {
+			continue
+		}
 		// Get the range of the require directive.
 		rng, err := positionsToRange(fh.URI(), pm.Mapper, req.Syntax.Start, req.Syntax.End)
 		if err != nil {
@@ -103,6 +106,9 @@ func tidyLens(ctx context.Context, snapshot source.Snapshot, fh source.FileHandl
 	if err != nil {
 		return nil, err
 	}
+	if pm.File == nil || pm.File.Module == nil || pm.File.Module.Syntax == nil {
+		return nil, fmt.Errorf("no parsed go.mod for %s", fh.URI())
+	}
 	rng, err := positionsToRange(pm.Mapper.URI, pm.Mapper, pm.File.Module.Syntax.Start, pm.File.Module.Syntax.End)
 	if err != nil {
 		return nil, err
@@ -125,6 +131,9 @@ func vendorLens(ctx context.Context, snapshot source.Snapshot, fh source.FileHan
 	pm, err := snapshot.ParseMod(ctx, fh)
 	if err != nil {
 		return nil, err
+	}
+	if pm.File == nil || pm.File.Module == nil || pm.File.Module.Syntax == nil {
+		return nil, fmt.Errorf("no parsed go.mod for %s", fh.URI())
 	}
 	rng, err := positionsToRange(pm.Mapper.URI, pm.Mapper, pm.File.Module.Syntax.Start, pm.File.Module.Syntax.End)
 	if err != nil {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/hover.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/hover.go
@@ -104,7 +104,7 @@ func Hover(ctx context.Context, snapshot source.Snapshot, fh source.FileHandle, 
 	}, nil
 }
 
-func formatExplanation(text string, req *modfile.Require, options source.Options, isPrivate bool) string {
+func formatExplanation(text string, req *modfile.Require, options *source.Options, isPrivate bool) string {
 	text = strings.TrimSuffix(text, "\n")
 	splt := strings.Split(text, "\n")
 	length := len(splt)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/diagnostics.go
@@ -221,7 +221,7 @@ func analyses(ctx context.Context, snapshot Snapshot, reports map[VersionedFileI
 		// meant to provide diagnostics, but rather only suggested fixes.
 		// Skip these types of errors in diagnostics; we will use their
 		// suggested fixes when providing code actions.
-		if isConvenienceAnalyzer(e.Category) {
+		if isConvenienceAnalyzer(snapshot.View().Options(), e.Category) {
 			continue
 		}
 		// This is a bit of a hack, but clients > 3.15 will be able to grey out unnecessary code.
@@ -312,7 +312,7 @@ func hasUndeclaredErrors(pkg Package) bool {
 	return false
 }
 
-func isConvenienceAnalyzer(category string) bool {
+func isConvenienceAnalyzer(o *Options, category string) bool {
 	for _, a := range DefaultOptions().ConvenienceAnalyzers {
 		if category == a.Analyzer.Name {
 			return true

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/gc_annotations.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/gc_annotations.go
@@ -57,7 +57,7 @@ func GCOptimizationDetails(ctx context.Context, snapshot Snapshot, pkgDir span.U
 		if x == nil {
 			continue
 		}
-		v = filterDiagnostics(v, &opts)
+		v = filterDiagnostics(v, opts)
 		reports[x.VersionedFileIdentity()] = v
 	}
 	return reports, parseError

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
@@ -373,7 +373,7 @@ func formatVar(node ast.Spec, obj types.Object, decl *ast.GenDecl) *HoverInforma
 	return &HoverInformation{source: obj, comment: decl.Doc}
 }
 
-func FormatHover(h *HoverInformation, options Options) (string, error) {
+func FormatHover(h *HoverInformation, options *Options) (string, error) {
 	signature := h.Signature
 	if signature != "" && options.PreferredContentFormat == protocol.Markdown {
 		signature = fmt.Sprintf("```go\n%s\n```", signature)
@@ -403,7 +403,7 @@ func FormatHover(h *HoverInformation, options Options) (string, error) {
 	return "", errors.Errorf("no hover for %v", h.source)
 }
 
-func formatLink(h *HoverInformation, options Options) string {
+func formatLink(h *HoverInformation, options *Options) string {
 	if !options.LinksInHover || options.LinkTarget == "" || h.Link == "" {
 		return ""
 	}
@@ -418,14 +418,14 @@ func formatLink(h *HoverInformation, options Options) string {
 	}
 }
 
-func formatDoc(doc string, options Options) string {
+func formatDoc(doc string, options *Options) string {
 	if options.PreferredContentFormat == protocol.Markdown {
 		return CommentToMarkdown(doc)
 	}
 	return doc
 }
 
-func formatHover(options Options, x ...string) string {
+func formatHover(options *Options, x ...string) string {
 	var b strings.Builder
 	for i, el := range x {
 		if el != "" {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
+	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/asmdecl"
 	"golang.org/x/tools/go/analysis/passes/assign"
 	"golang.org/x/tools/go/analysis/passes/atomic"
@@ -52,79 +54,87 @@ import (
 	errors "golang.org/x/xerrors"
 )
 
+var (
+	optionsOnce    sync.Once
+	defaultOptions *Options
+)
+
 //go:generate go run golang.org/x/tools/cmd/stringer -output enums_string.go -type ImportShortcut,HoverKind,Matcher,SymbolMatcher,SymbolStyle
 //go:generate go run github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source/genopts -output options_json.go
 
 // DefaultOptions is the options that are used for Gopls execution independent
 // of any externally provided configuration (LSP initialization, command
 // invokation, etc.).
-func DefaultOptions() Options {
-	var commands []string
-	for _, c := range Commands {
-		commands = append(commands, c.Name)
-	}
-	return Options{
-		ClientOptions: ClientOptions{
-			InsertTextFormat:                  protocol.PlainTextTextFormat,
-			PreferredContentFormat:            protocol.Markdown,
-			ConfigurationSupported:            true,
-			DynamicConfigurationSupported:     true,
-			DynamicWatchedFilesSupported:      true,
-			LineFoldingOnly:                   false,
-			HierarchicalDocumentSymbolSupport: true,
-		},
-		ServerOptions: ServerOptions{
-			SupportedCodeActions: map[FileKind]map[protocol.CodeActionKind]bool{
-				Go: {
-					protocol.SourceFixAll:          true,
-					protocol.SourceOrganizeImports: true,
-					protocol.QuickFix:              true,
-					protocol.RefactorRewrite:       true,
-					protocol.RefactorExtract:       true,
-				},
-				Mod: {
-					protocol.SourceOrganizeImports: true,
-				},
-				Sum: {},
+func DefaultOptions() *Options {
+	optionsOnce.Do(func() {
+		var commands []string
+		for _, c := range Commands {
+			commands = append(commands, c.Name)
+		}
+		defaultOptions = &Options{
+			ClientOptions: ClientOptions{
+				InsertTextFormat:                  protocol.PlainTextTextFormat,
+				PreferredContentFormat:            protocol.Markdown,
+				ConfigurationSupported:            true,
+				DynamicConfigurationSupported:     true,
+				DynamicWatchedFilesSupported:      true,
+				LineFoldingOnly:                   false,
+				HierarchicalDocumentSymbolSupport: true,
 			},
-			SupportedCommands: commands,
-		},
-		UserOptions: UserOptions{
-			HoverKind:  FullDocumentation,
-			LinkTarget: "pkg.go.dev",
-		},
-		DebuggingOptions: DebuggingOptions{
-			CompletionBudget:   100 * time.Millisecond,
-			LiteralCompletions: true,
-		},
-		ExperimentalOptions: ExperimentalOptions{
-			TempModfile:             true,
-			ExpandWorkspaceToModule: true,
-			Codelens: map[string]bool{
-				CommandGenerate.Name:          true,
-				CommandRegenerateCgo.Name:     true,
-				CommandTidy.Name:              true,
-				CommandToggleDetails.Name:     false,
-				CommandUpgradeDependency.Name: true,
-				CommandVendor.Name:            true,
+			ServerOptions: ServerOptions{
+				SupportedCodeActions: map[FileKind]map[protocol.CodeActionKind]bool{
+					Go: {
+						protocol.SourceFixAll:          true,
+						protocol.SourceOrganizeImports: true,
+						protocol.QuickFix:              true,
+						protocol.RefactorRewrite:       true,
+						protocol.RefactorExtract:       true,
+					},
+					Mod: {
+						protocol.SourceOrganizeImports: true,
+					},
+					Sum: {},
+				},
+				SupportedCommands: commands,
 			},
-			LinksInHover:            true,
-			CompleteUnimported:      true,
-			CompletionDocumentation: true,
-			DeepCompletion:          true,
-			Matcher:                 Fuzzy,
-			SymbolMatcher:           SymbolFuzzy,
-		},
-		Hooks: Hooks{
-			ComputeEdits:         myers.ComputeEdits,
-			URLRegexp:            urlRegexp(),
-			DefaultAnalyzers:     defaultAnalyzers(),
-			TypeErrorAnalyzers:   typeErrorAnalyzers(),
-			ConvenienceAnalyzers: convenienceAnalyzers(),
-			StaticcheckAnalyzers: map[string]Analyzer{},
-			GoDiff:               true,
-		},
-	}
+			UserOptions: UserOptions{
+				HoverKind:  FullDocumentation,
+				LinkTarget: "pkg.go.dev",
+			},
+			DebuggingOptions: DebuggingOptions{
+				CompletionBudget:   100 * time.Millisecond,
+				LiteralCompletions: true,
+			},
+			ExperimentalOptions: ExperimentalOptions{
+				TempModfile:             true,
+				ExpandWorkspaceToModule: true,
+				Codelens: map[string]bool{
+					CommandGenerate.Name:          true,
+					CommandRegenerateCgo.Name:     true,
+					CommandTidy.Name:              true,
+					CommandToggleDetails.Name:     false,
+					CommandUpgradeDependency.Name: true,
+					CommandVendor.Name:            true,
+				},
+				LinksInHover:            true,
+				CompleteUnimported:      true,
+				CompletionDocumentation: true,
+				DeepCompletion:          true,
+				Matcher:                 Fuzzy,
+				SymbolMatcher:           SymbolFuzzy,
+			},
+			Hooks: Hooks{
+				ComputeEdits:         myers.ComputeEdits,
+				URLRegexp:            urlRegexp(),
+				DefaultAnalyzers:     defaultAnalyzers(),
+				TypeErrorAnalyzers:   typeErrorAnalyzers(),
+				ConvenienceAnalyzers: convenienceAnalyzers(),
+				StaticcheckAnalyzers: map[string]Analyzer{},
+				GoDiff:               true,
+			},
+		}
+	})
+	return defaultOptions
 }
 
 // Options holds various configuration that affects Gopls execution, organized
@@ -206,11 +216,11 @@ type Hooks struct {
 	GoDiff               bool
 	ComputeEdits         diff.ComputeEdits
 	URLRegexp            *regexp.Regexp
+	GofumptFormat        func(ctx context.Context, src []byte) ([]byte, error)
 	DefaultAnalyzers     map[string]Analyzer
 	TypeErrorAnalyzers   map[string]Analyzer
 	ConvenienceAnalyzers map[string]Analyzer
 	StaticcheckAnalyzers map[string]Analyzer
-	GofumptFormat        func(ctx context.Context, src []byte) ([]byte, error)
 }
 
 // ExperimentalOptions defines configuration for features under active
@@ -473,6 +483,59 @@ func (o *Options) ForClientCapabilities(caps protocol.ClientCapabilities) {
 	o.LineFoldingOnly = fr.LineFoldingOnly
 	// Check if the client supports hierarchical document symbols.
 	o.HierarchicalDocumentSymbolSupport = caps.TextDocument.DocumentSymbol.HierarchicalDocumentSymbolSupport
+}
+
+func (o *Options) Clone() *Options {
+	result := &Options{
+		ClientOptions:       o.ClientOptions,
+		DebuggingOptions:    o.DebuggingOptions,
+		ExperimentalOptions: o.ExperimentalOptions,
+		Hooks: Hooks{
+			GoDiff:        o.Hooks.GoDiff,
+			ComputeEdits:  o.Hooks.ComputeEdits,
+			GofumptFormat: o.GofumptFormat,
+			URLRegexp:     o.URLRegexp,
+		},
+		ServerOptions: o.ServerOptions,
+		UserOptions:   o.UserOptions,
+	}
+	// Fully clone any slice or map fields. Only Hooks, ExperimentalOptions,
+	// and UserOptions can be modified.
+	copyStringMap := func(src map[string]bool) map[string]bool {
+		dst := make(map[string]bool)
+		for k, v := range src {
+			dst[k] = v
+		}
+		return dst
+	}
+	result.Analyses = copyStringMap(o.Analyses)
+	result.Annotations = copyStringMap(o.Annotations)
+	result.Codelens = copyStringMap(o.Codelens)
+
+	copySlice := func(src []string) []string {
+		dst := make([]string, len(src))
+		copy(dst, src)
+		return dst
+	}
+	result.Env = copySlice(o.Env)
+	result.BuildFlags = copySlice(o.BuildFlags)
+
+	copyAnalyzerMap := func(src map[string]Analyzer) map[string]Analyzer {
+		dst := make(map[string]Analyzer)
+		for k, v := range src {
+			dst[k] = v
+		}
+		return dst
+	}
+	result.DefaultAnalyzers = copyAnalyzerMap(o.DefaultAnalyzers)
+	result.TypeErrorAnalyzers = copyAnalyzerMap(o.TypeErrorAnalyzers)
+	result.ConvenienceAnalyzers = copyAnalyzerMap(o.ConvenienceAnalyzers)
+	result.StaticcheckAnalyzers = copyAnalyzerMap(o.StaticcheckAnalyzers)
+	return result
+}
+
+func (options *Options) AddStaticcheckAnalyzer(a *analysis.Analyzer) {
+	options.StaticcheckAnalyzers[a.Name] = Analyzer{Analyzer: a, Enabled: true}
 }
 
 func (o *Options) set(name string, value interface{}) OptionResult {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -40,6 +40,9 @@ type Snapshot interface {
 	// if it is not already part of the snapshot.
 	GetFile(ctx context.Context, uri span.URI) (VersionedFileHandle, error)
 
+	// AwaitInitialized waits until the snapshot's view is initialized.
+	AwaitInitialized(ctx context.Context)
+
 	// IsOpen returns whether the editor currently has a file open.
 	IsOpen(uri span.URI) bool
 
@@ -142,9 +145,6 @@ type View interface {
 	// Shutdown closes this view, and detaches it from its session.
 	Shutdown(ctx context.Context)
 
-	// AwaitInitialized waits until a view is initialized
-	AwaitInitialized(ctx context.Context)
-
 	// WriteEnv writes the view-specific environment to the io.Writer.
 	WriteEnv(ctx context.Context, w io.Writer) error
 
@@ -153,13 +153,13 @@ type View interface {
 	RunProcessEnvFunc(ctx context.Context, fn func(*imports.Options) error) error
 
 	// Options returns a copy of the Options for this view.
-	Options() Options
+	Options() *Options
 
 	// SetOptions sets the options of this view to new values.
 	// Calling this may cause the view to be invalidated and a replacement view
 	// added to the session. If so the new view will be returned, otherwise the
 	// original one will be.
-	SetOptions(context.Context, Options) (View, error)
+	SetOptions(context.Context, *Options) (View, error)
 
 	// Snapshot returns the current snapshot for the view.
 	Snapshot(ctx context.Context) (Snapshot, func())
@@ -222,7 +222,7 @@ type TidiedModule struct {
 // A session may have many active views at any given time.
 type Session interface {
 	// NewView creates a new View, returning it and its first snapshot.
-	NewView(ctx context.Context, name string, folder span.URI, options Options) (View, Snapshot, func(), error)
+	NewView(ctx context.Context, name string, folder span.URI, options *Options) (View, Snapshot, func(), error)
 
 	// Cache returns the cache that created this session, for debugging only.
 	Cache() interface{}
@@ -250,10 +250,10 @@ type Session interface {
 	Overlays() []Overlay
 
 	// Options returns a copy of the SessionOptions for this session.
-	Options() Options
+	Options() *Options
 
 	// SetOptions sets the options of this session to new values.
-	SetOptions(Options)
+	SetOptions(*Options)
 }
 
 // Overlay is the type for a file held in memory on a session.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/workspace.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/workspace.go
@@ -33,9 +33,8 @@ func (s *Server) addView(ctx context.Context, name string, uri span.URI) (source
 	if state < serverInitialized {
 		return nil, nil, func() {}, errors.Errorf("addView called before server initialized")
 	}
-
-	options := s.session.Options()
-	if err := s.fetchConfig(ctx, name, uri, &options); err != nil {
+	options := s.session.Options().Clone()
+	if err := s.fetchConfig(ctx, name, uri, options); err != nil {
 		return nil, nil, func() {}, err
 	}
 	return s.session.NewView(ctx, name, uri, options)
@@ -44,8 +43,8 @@ func (s *Server) addView(ctx context.Context, name string, uri span.URI) (source
 func (s *Server) didChangeConfiguration(ctx context.Context, changed interface{}) error {
 	// go through all the views getting the config
 	for _, view := range s.session.Views() {
-		options := view.Options()
-		if err := s.fetchConfig(ctx, view.Name(), view.Folder(), &options); err != nil {
+		options := s.session.Options().Clone()
+		if err := s.fetchConfig(ctx, view.Name(), view.Folder(), options); err != nil {
 			return err
 		}
 		view, err := view.SetOptions(ctx, options)

--- a/cmd/govim/internal/golang_org_x_tools/memoize/memoize.go
+++ b/cmd/govim/internal/golang_org_x_tools/memoize/memoize.go
@@ -228,7 +228,7 @@ func (g *Generation) Inherit(h *Handle) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.state == stateDestroyed {
-		panic(fmt.Sprintf("inheriting destroyed handle %#v into generation %v", h.key, g.name))
+		panic(fmt.Sprintf("inheriting destroyed handle %#v (type %T) into generation %v", h.key, h.key, g.name))
 	}
 	h.generations[g] = struct{}{}
 }
@@ -280,7 +280,7 @@ func (h *Handle) Get(ctx context.Context, g *Generation, arg Arg) (interface{}, 
 		return h.value, nil
 	case stateDestroyed:
 		h.mu.Unlock()
-		err := fmt.Errorf("Get on destroyed entry %#v in generation %v", h.key, g.name)
+		err := fmt.Errorf("Get on destroyed entry %#v (type %T) in generation %v", h.key, h.key, g.name)
 		if *panicOnDestroyed {
 			panic(err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.6.2
 	golang.org/x/mod v0.3.0
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/tools v0.0.0-20200916122506-6ec2cde9631b
-	golang.org/x/tools/gopls v0.0.0-20200916122506-6ec2cde9631b
+	golang.org/x/tools v0.0.0-20200917132429-63098cc47d65
+	golang.org/x/tools/gopls v0.0.0-20200917132429-63098cc47d65
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -69,10 +69,10 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200828161849-5deb26317202/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200916122506-6ec2cde9631b h1:0Dg4Zh7bmF8ZxmLynSVH+U9+W84+APb1O4tkz/wfq4Y=
-golang.org/x/tools v0.0.0-20200916122506-6ec2cde9631b/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
-golang.org/x/tools/gopls v0.0.0-20200916122506-6ec2cde9631b h1:a9i7zMpW8g2fJC6oh1lklCL0eeYrPuR5rqqhXKgmBX0=
-golang.org/x/tools/gopls v0.0.0-20200916122506-6ec2cde9631b/go.mod h1:ZKEbBWLaHDNmr7igDh2FBZr7V0r1eonT0J5lLqVmCw0=
+golang.org/x/tools v0.0.0-20200917132429-63098cc47d65 h1:pSBfdsmz/LD4Z+CedEf2tYuhDR+/nb77SHI1Ap7+WDQ=
+golang.org/x/tools v0.0.0-20200917132429-63098cc47d65/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools/gopls v0.0.0-20200917132429-63098cc47d65 h1:zJ8fJlNGkSJtquEFe4Hc/UjYL8/maE6CjSceMZ0fkM4=
+golang.org/x/tools/gopls v0.0.0-20200917132429-63098cc47d65/go.mod h1:ZKEbBWLaHDNmr7igDh2FBZr7V0r1eonT0J5lLqVmCw0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/imports: don't set Context.WorkingDir, which was renamed 63098cc4
* internal/lsp: fix concurrency issues in view initialization 655488c8
* internal/lsp: pass options by reference instead of by value c537a342
* internal/lsp/cache: fix release tag parsing c9a70fc2
* internal/memoize: show key type in panics f128e626
* internal/lsp/mod: handle nil pointers in code lenses 587cf233
* cover: fix sorting of profile segment boundaries 56d9a0cd
* gopls/internal/regtest: simplify expectation return values c8d9e05b