### PR TITLE
cmd/govim: allow signature help for anonymous functions

### DIFF
--- a/cmd/govim/signature_help.go
+++ b/cmd/govim/signature_help.go
@@ -90,7 +90,7 @@ FindCall:
 	// hence we need to adjust accordingly
 	var placePos token.Pos
 	switch f := callExpr.Fun.(type) {
-	case *ast.Ident:
+	case *ast.Ident, *ast.FuncLit:
 		placePos = callExpr.Pos()
 	case *ast.SelectorExpr:
 		placePos = f.Sel.Pos()

--- a/cmd/govim/testdata/scenario_default/signature_help_anon.txt
+++ b/cmd/govim/testdata/scenario_default/signature_help_anon.txt
@@ -1,0 +1,29 @@
+# Test case that verifies signature help in anonymous functions
+
+# Open main.go
+vim ex 'e main.go'
+
+# Move cursor to anonymous function
+vim ex 'call cursor(5,3)'
+
+# Trigger signature help
+vim ex ':GOVIMExperimentalSignatureHelp'
+
+# Trivial check to see if a popup is created
+errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\{.*\"text\":\"func\(foo bool\)\"'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+func main() {
+	go func(foo bool) {
+	}(true)
+}


### PR DESCRIPTION
This change enables experimental signature help for anonymous functions
such as:

```
go func() {
}()  // cursor inside ()
```

Fixes #957