### PR TITLE
cmd/govim: fix line-wise visual selection in GOVIMStingFn

### DIFF
--- a/cmd/govim/testdata/scenario_default/stringfn.txt
+++ b/cmd/govim/testdata/scenario_default/stringfn.txt
@@ -3,15 +3,17 @@
 # No range in .go file
 vim ex 'e main.go'
 vim ex 'call cursor(7,1) | GOVIMStringFn crypto/sha256.Sum256 encoding/hex.EncodeToString'
-vim ex 'call cursor(12,1) | GOVIMStringFn regexp.QuoteMeta'
+
+# Multi-line selection
+vim ex 'call cursor(11,1)'
+vim ex 'normal Vjj:'
+vim ex '''<,''>GOVIMStringFn encoding/hex.EncodeToString'
+
+vim ex 'call cursor(15,1) | GOVIMStringFn regexp.QuoteMeta'
 vim ex 'w'
 cmp main.go main.go.golden
 
-# With a visual selection
-
 skip 'Pending work to fix up Vim commands in test'
-
-# TODO: add a test based on a visual selection
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -31,6 +33,11 @@ func main() {
 test
 `)
 	fmt.Println("test")
+	multiline := `
+Lorem ipsum dolor sit amet,
+    consectetur adipiscing elit, sed
+         do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+`
 }
 
 // Here is an (end-of-file) line
@@ -44,6 +51,9 @@ func main() {
 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
 `)
 	fmt.Println("test")
+	multiline := `
+4c6f72656d20697073756d20646f6c6f722073697420616d65742c0a20202020636f6e73656374657475722061646970697363696e6720656c69742c207365640a202020202020202020646f20656975736d6f642074656d706f7220696e6369646964756e74207574206c61626f726520657420646f6c6f7265206d61676e6120616c697175612e
+`
 }
 
 // Here is an \(end-of-file\) line


### PR DESCRIPTION
The line-wise mode always used two lines regardless of how many lines
that was selected. It is now possible to use GOVIMStringFn on more
lines.