### PR TITLE
cmd/govim: add support for testing via gopls GOVIMGoTest

### DIFF
--- a/cmd/govim/code_action.go
+++ b/cmd/govim/code_action.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	"github.com/govim/govim"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/types"
+)
+
+func (v *vimstate) runGoTest(flags govim.CommandFlags, args ...string) error {
+	if c := v.config.ExperimentalProgressPopups; c == nil || !*c {
+		opts := make(map[string]interface{})
+		opts["mousemoved"] = "any"
+		opts["moved"] = "any"
+		opts["padding"] = []int{0, 1, 0, 1}
+		opts["wrap"] = true
+		opts["border"] = []int{}
+		opts["highlight"] = "ErrorMsg"
+		opts["line"] = 1
+		opts["close"] = "click"
+		v.ChannelCall("popup_create", []string{"GOVIMGoTest requires progress popups. Add this to your .vimrc:",
+			" call govim#config#Set(\"ExperimentalProgressPopups\", 1)"}, opts)
+		return nil
+	}
+	b, _, err := v.bufCursorPos()
+	if err != nil {
+		return fmt.Errorf("failed to get cursor position: %v", err)
+	}
+	start, end, err := v.rangeFromFlags(b, flags)
+	if err != nil {
+		return err
+	}
+
+	ca, err := v.server.CodeAction(context.Background(), &protocol.CodeActionParams{
+		TextDocument: b.ToTextDocumentIdentifier(),
+		Range: protocol.Range{
+			Start: start.ToPosition(),
+			End:   end.ToPosition(),
+		},
+		Context: protocol.CodeActionContext{
+			Only: []protocol.CodeActionKind{protocol.GoTest},
+		},
+		WorkDoneProgressParams: protocol.WorkDoneProgressParams{},
+	})
+	if err != nil || len(ca) == 0 {
+		return err
+	}
+	if len(ca) > 1 {
+		return fmt.Errorf("got %d CodeActions, expected no more than 1", len(ca))
+	}
+
+	c := ca[0]
+
+	token := protocol.ProgressToken(fmt.Sprintf("govim%d", rand.Uint64()))
+	if _, ok := v.progressPopups[token]; ok {
+		return fmt.Errorf("failed to init progress, duplicate token")
+	}
+	v.progressPopups[token] = &types.ProgressPopup{}
+
+	_, err = v.server.ExecuteCommand(context.Background(), &protocol.ExecuteCommandParams{
+		Command:   c.Command.Command,
+		Arguments: c.Command.Arguments,
+		WorkDoneProgressParams: protocol.WorkDoneProgressParams{
+			WorkDoneToken: token,
+		},
+	})
+
+	return err
+}

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -341,6 +341,19 @@ const (
 	//
 	// Note that this feature is experimental in gopls.
 	CommandGCDetails Command = "GCDetails"
+
+	// CommandGoTest executes the test / benchmark under the cursor. It also
+	// supports ranged requests, e.g. calling ":'<,'>GOVIMGoTest" will execute
+	// all tests selected in visual mode.
+	//
+	// Calling "%GOVIMGoTest" will execute all tests in the current file.
+	//
+	// Enable progress popups to see the test progress.
+	CommandGoTest Command = "GoTest"
+
+	// Open a new buffer that contain the current output from the most recently
+	// created progress popup. Useful for looking at a failed test for example.
+	CommandLastProgress Command = "LastProgress"
 )
 
 type Function string

--- a/cmd/govim/internal/types/popup.go
+++ b/cmd/govim/internal/types/popup.go
@@ -1,5 +1,7 @@
 package types
 
+import "strings"
+
 // PopupLine is the internal representation of a single text line with text
 // propertiesin a vim popup. When creating popups using popup_create, the
 // first arg can be either a buffer number, a string, a list of strings or
@@ -24,6 +26,6 @@ type PopupProp struct {
 // popups.
 type ProgressPopup struct {
 	ID      int
-	Text    []string
+	Text    strings.Builder
 	LinePos int
 }

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -313,7 +313,9 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineCommand(string(config.CommandExperimentalSignatureHelp), g.vimstate.signatureHelp)
 	g.DefineCommand(string(config.CommandFillStruct), g.vimstate.fillStruct)
 	g.DefineCommand(string(config.CommandGCDetails), g.vimstate.toggleGCDetails)
+	g.DefineCommand(string(config.CommandGoTest), g.vimstate.runGoTest, govim.RangeLine)
 	g.DefineFunction(string(config.FunctionProgressClosed), []string{"id", "selected"}, g.vimstate.progressClosed)
+	g.DefineCommand(string(config.CommandLastProgress), g.vimstate.openLastProgress)
 	g.defineHighlights()
 	if err := g.vimstate.signDefine(); err != nil {
 		return fmt.Errorf("failed to define signs: %v", err)

--- a/cmd/govim/stringfns.go
+++ b/cmd/govim/stringfns.go
@@ -1,18 +1,14 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/govim/govim"
-	"github.com/govim/govim/cmd/govim/config"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/stringfns"
-	"github.com/govim/govim/cmd/govim/internal/types"
 )
 
 func (v *vimstate) stringfns(flags govim.CommandFlags, args ...string) error {
@@ -23,86 +19,15 @@ func (v *vimstate) stringfns(flags govim.CommandFlags, args ...string) error {
 		}
 		transFns = append(transFns, fp)
 	}
-	var err error
-	var start, end types.Point
-	var b *types.Buffer
-	switch *flags.Range {
-	case 2:
-		// we have a range
-		var pos struct {
-			BuffNr int    `json:"buffnr"`
-			Mode   string `json:"mode"`
-			Start  []int  `json:"start"` // [bufnr, line, col, off]
-			End    []int  `json:"end"`   // [bufnr, line, col, off]
-		}
-		v.Parse(v.ChannelExpr(`{"buffnr": bufnr(""), "mode": visualmode(), "start": getpos("'<"), "end": getpos("'>")}`), &pos)
 
-		if pos.Mode == "\x16" { // <CTRL-V>, block-wise
-			return fmt.Errorf("cannot use %v in visual block mode", config.CommandStringFn)
-		}
+	b, _, err := v.bufCursorPos()
+	if err != nil {
+		return err
+	}
 
-		var ok bool
-		b, ok = v.buffers[pos.BuffNr]
-		if !ok {
-			return fmt.Errorf("failed to derive buffer")
-		}
-
-		if pos.Mode == "V" || pos.Mode == "" {
-			// There are a couple of different ways to execute range command,
-			// for example :%GOVIMFooBar that doesn't set any markers (<','>).
-			// Use Line1/Line2 over pos.Start/pos.End to support them.
-			start, err = types.PointFromVim(b, *flags.Line1, 1)
-			if err != nil {
-				return fmt.Errorf("failed to get start position of range: %v", err)
-			}
-			// Since the end col will be "a large value" we need to evaluate
-			// the real col by getting the offset for the first column on the
-			// "next line" and subtract 1 (the newline).
-			var nl types.Point
-			nl, err = types.PointFromVim(b, *flags.Line2+1, 1)
-			if err != nil {
-				return fmt.Errorf("failed to get point from line after end line: %v", err)
-			}
-			end, err = types.PointFromOffset(b, nl.Offset()-1)
-			if err != nil {
-				return fmt.Errorf("failed to get end position of range: %v", err)
-			}
-		} else if pos.Mode == "v" {
-			start, err = types.PointFromVim(b, pos.Start[1], pos.Start[2])
-			if err != nil {
-				return fmt.Errorf("failed to get start position of range: %v", err)
-			}
-			end, err = types.PointFromVim(b, pos.End[1], pos.End[2])
-			if err != nil {
-				return fmt.Errorf("failed to get end position of range: %v", err)
-			}
-			// we need to move past the end of the selection
-			rem := b.Contents()[end.Offset():]
-			if len(rem) > 0 {
-				_, adj := utf8.DecodeRune(rem)
-				end, err = types.PointFromVim(b, pos.End[1], pos.End[2]+adj)
-				if err != nil {
-					return fmt.Errorf("failed to get adjusted end position: %v", err)
-				}
-			}
-		}
-	case 0:
-		// current line
-		b, _, err = v.bufCursorPos()
-		if err != nil {
-			return fmt.Errorf("failed to get cursor position for line range")
-		}
-		start, err = types.PointFromVim(b, *flags.Line1, 1)
-		if err != nil {
-			return fmt.Errorf("failed to derive start position from cursor position on line %v: %v", *flags.Line1, err)
-		}
-		lines := bytes.Split(b.Contents(), []byte("\n"))
-		end, err = types.PointFromVim(b, *flags.Line1, len(lines[*flags.Line1-1])+1)
-		if err != nil {
-			return fmt.Errorf("failed to derive end position from cursor position on line %v: %v", *flags.Line1, err)
-		}
-	default:
-		return fmt.Errorf("unknown range indicator %v", *flags.Range)
+	start, end, err := v.rangeFromFlags(b, flags)
+	if err != nil {
+		return err
 	}
 
 	newText := string(b.Contents()[start.Offset():end.Offset()])

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/govim/govim/cmd/govim/config"
@@ -84,6 +85,10 @@ type vimstate struct {
 	// ProgressClosed function as callback to ensure that entities are removed
 	// from this map when the popup closes.
 	progressPopups map[protocol.ProgressToken]*types.ProgressPopup
+
+	// lastProgressText points to the text in the most recently created progress
+	// popup.
+	lastProgressText *strings.Builder
 }
 
 func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {


### PR DESCRIPTION
Add command GOVIMGoTest that, via gopls, execute test and benchmark
functions.

It will execute the test func under the cursor, and also support
executing multiple test functions via visual mode or ranged command.

E.g.

Select range via visual mode and call `":'<,'>GOVIMGoTest"` to test all
functions that intersect with the selection.

`":%GOVIMGoTest"` tests the entire file
`":20,$GOVIMGoTest"` tests all functions from line 20 to the end

Also fixes a offset error when there are multiple progress popups open
at the same time.

Updates #441