### PR TITLE
cmd/govim: Log ShowMessage callbacks in a consistent way

### DIFF
--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -38,7 +38,7 @@ var _ protocol.Client = (*govimplugin)(nil)
 
 func (g *govimplugin) ShowMessage(ctxt context.Context, params *protocol.ShowMessageParams) error {
 	defer absorbShutdownErr()
-	g.logGoplsClientf("ShowMessage callback: %v", params.Message)
+	g.logGoplsClientf("ShowMessage callback: %v", pretty.Sprint(params))
 
 	var hl string
 	switch params.Type {

--- a/cmd/govim/testdata/scenario_default/show_message.txt
+++ b/cmd/govim/testdata/scenario_default/show_message.txt
@@ -4,7 +4,7 @@
 
 vim expr 'GOVIM_internal_ShowMessagePopup()'
 
-errlogmatch 'ShowMessage callback: Something went wrong'
+errlogmatch 'ShowMessage callback: &protocol.ShowMessageParams{Type:1, Message:"Something went wrong"}'
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout popup.golden
 


### PR DESCRIPTION
The other callbacks from gopls logs the entire param structure.
ShowMessage is updated to be consistent and do the same.