### PR TITLE
cmd/govim: fix overlap and formating issues in progress popups

### DIFF
--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"unicode"
 
 	"github.com/govim/govim"
 	"github.com/govim/govim/cmd/govim/config"
@@ -272,7 +273,7 @@ func (g *govimplugin) Progress(ctxt context.Context, params *protocol.ProgressPa
 		return fmt.Errorf("expected required field 'kind' in progress callback")
 	}
 	message, _ := raw["message"].(string) // optional
-	message = strings.TrimSpace(message)
+	message = strings.TrimRightFunc(message, unicode.IsSpace)
 
 	var title string
 	if title, ok = raw["title"].(string); !ok && kind == "begin" { // required for "begin"

--- a/cmd/govim/progress.go
+++ b/cmd/govim/progress.go
@@ -75,7 +75,7 @@ func (v *vimstate) rearrangeProgressPopups() {
 				map[string]interface{}{"line": popups[i].LinePos},
 			)
 		}
-		line += len(popups[i].Text) + 1 // title + lines
+		line += len(popups[i].Text) + 2 // lines + top & bottom border
 	}
 	v.MustBatchEnd()
 }


### PR DESCRIPTION
Two small fixes for progress I caught while experimenting with "go
test":

- Multiple progress popups did overlap
- The progress message could intentionally start with space, we
  shouldn't trim those