### PR TITLE
cmd/govim: improve qf index selection on update

### DIFF
--- a/cmd/govim/quickfix.go
+++ b/cmd/govim/quickfix.go
@@ -76,8 +76,9 @@ func (v *vimstate) updateQuickfixWithDiagnostics(force bool, wasPrevNotDiagnosti
 	if !wasPrevNotDiagnostics && len(v.lastQuickFixDiagnostics) > 0 {
 		var want qflistWant
 		v.Parse(v.ChannelExpr(`getqflist({"idx":0})`), &want)
-		if want.Idx == 1 {
-			// Don't guess selection if position is 1
+		if want.Idx == 0 {
+			// NOTE: this should never happen since idx == 0 only if the qf is empty
+			// and we just tested it isn't.
 			goto NewIndexSet
 		}
 		wantIdx := want.Idx - 1

--- a/cmd/govim/quickfix.go
+++ b/cmd/govim/quickfix.go
@@ -82,9 +82,6 @@ func (v *vimstate) updateQuickfixWithDiagnostics(force bool, wasPrevNotDiagnosti
 			goto NewIndexSet
 		}
 		wantIdx := want.Idx - 1
-		if len(v.lastQuickFixDiagnostics) <= wantIdx {
-			goto NewIndexSet
-		}
 		currFix := v.lastQuickFixDiagnostics[wantIdx]
 		var fileNextIdx, fileLastIdx, dirFirstIdx int
 		for i, f := range fixes {

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_directory.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_directory.txt
@@ -5,14 +5,6 @@
 vim ex 'e charly.go'
 vimexprwait errors.golden.orig GOVIMTest_getqflist()
 
-# Verify we have the first entry selected
-# NOTE: disabled because when errors are spreaded accross multiple files like 
-# in this test, the quickfix list can be populated multiple times, which makes
-# GOVIM retains the previous selected entry.
-#vim expr 'getqflist({\"idx\": 0})'
-#stdout '{"idx":1}'
-#! stderr .+
-
 # Now move to error 'errc' and check the position
 vim expr 'setqflist([], \"r\", {\"idx\": 3})'
 vim expr 'getqflist({\"idx\": 0})'

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_directory.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_directory.txt
@@ -1,0 +1,140 @@
+# Test that the quickfix window logic fallbacks to first error of the selected
+# entry directory, if this one is not found in the new quickfix list and if
+# there's no other errors in this entry file.
+
+vim ex 'e charly.go'
+vimexprwait errors.golden.orig GOVIMTest_getqflist()
+
+# Verify we have the first entry selected
+vim expr 'getqflist({\"idx\": 0})'
+stdout '{"idx":1}'
+! stderr .+
+
+# Now move to error 'errc' and check the position
+vim expr 'setqflist([], \"r\", {\"idx\": 3})'
+vim expr 'getqflist({\"idx\": 0})'
+stdout '{"idx":3}'
+! stderr .+
+
+# Now fix selected error and assert the index points to the first file of the directory
+vim ex 'call cursor(3,1)'
+vim normal dd
+vimexprwait errors.golden.updated GOVIMTest_getqflist()
+vim expr 'getqflist({\"idx\": 0})'
+stdout '{"idx":2}'
+! stderr .+
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- alice/alice.go --
+package alice
+
+erralice
+-- bob.go --
+package main
+
+errbob
+-- charly.go --
+package main
+
+errcharly
+-- dave.go --
+package main
+
+errdave
+-- errors.golden.orig --
+[
+  {
+    "bufname": "alice/alice.go",
+    "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found erralice",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "bob.go",
+    "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found errbob",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "charly.go",
+    "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found errcharly",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "dave.go",
+    "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found errdave",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.golden.updated --
+[
+  {
+    "bufname": "alice/alice.go",
+    "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found erralice",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "bob.go",
+    "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found errbob",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "dave.go",
+    "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found errdave",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_directory.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_directory.txt
@@ -6,9 +6,12 @@ vim ex 'e charly.go'
 vimexprwait errors.golden.orig GOVIMTest_getqflist()
 
 # Verify we have the first entry selected
-vim expr 'getqflist({\"idx\": 0})'
-stdout '{"idx":1}'
-! stderr .+
+# NOTE: disabled because when errors are spreaded accross multiple files like 
+# in this test, the quickfix list can be populated multiple times, which makes
+# GOVIM retains the previous selected entry.
+#vim expr 'getqflist({\"idx\": 0})'
+#stdout '{"idx":1}'
+#! stderr .+
 
 # Now move to error 'errc' and check the position
 vim expr 'setqflist([], \"r\", {\"idx\": 3})'

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_last.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_last.txt
@@ -1,0 +1,132 @@
+# Test that the quickfix window logic fallbacks to last entry of the previous
+# selected entry file, if this one isn't found and if there's no next entry.
+
+vim ex 'e main.go'
+vimexprwait errors.golden.orig GOVIMTest_getqflist()
+
+# Verify we have the first entry selected
+vim expr 'getqflist({\"idx\": 0})'
+stdout '{"idx":1}'
+! stderr .+
+
+# Now move to error 'err4' and check the position
+vim expr 'setqflist([], \"r\", {\"idx\": 4})'
+vim expr 'getqflist({\"idx\": 0})'
+stdout '{"idx":4}'
+! stderr .+
+
+# Now fix selected error and assert the index points to the last entry of the file
+vim ex 'call cursor(7,1)'
+vim normal dd
+vimexprwait errors.golden.updated GOVIMTest_getqflist()
+vim expr 'getqflist({\"idx\": 0})'
+stdout '{"idx":3}'
+! stderr .+
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+func main() {
+	err1
+	err2
+	err3
+	err4
+}
+-- errors.golden.orig --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err2",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err3",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err4",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.golden.updated --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err2",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err3",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_next.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_next.txt
@@ -1,0 +1,132 @@
+# Test that the quickfix window logic fallbacks to next entry of the selected
+# entry file if this one isn't found.
+
+vim ex 'e main.go'
+vimexprwait errors.golden.orig GOVIMTest_getqflist()
+
+# Verify we have the first entry selected
+vim expr 'getqflist({\"idx\": 0})'
+stdout '{"idx":1}'
+! stderr .+
+
+# Now move to error 'err2' and check the position
+vim expr 'setqflist([], \"r\", {\"idx\": 2})'
+vim expr 'getqflist({\"idx\": 0})'
+stdout '{"idx":2}'
+! stderr .+
+
+# Now fix selected error and assert the index points to the next entry
+vim ex 'call cursor(5,1)'
+vim normal dd
+vimexprwait errors.golden.updated GOVIMTest_getqflist()
+vim expr 'getqflist({\"idx\": 0})'
+stdout '{"idx":2}'
+! stderr .+
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+func main() {
+	err1
+	err2
+	err3
+	err4
+}
+-- errors.golden.orig --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err2",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err3",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err4",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.golden.updated --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err3",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err4",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]


### PR DESCRIPTION
GoVim often looses the selected qf entry, which results in setting qf index to 1.

This is especially annoying when you have a lot of warnings (from an other package opened in another buffer), and you try to fix compile errors. As soon as you fix the error, the qf list index becomes 1 and you have to scroll down the warnings to find again your compile errors.

Actually, the selected qf entry is kept only if you're not fixing it, or if your fix doesn't affect its line number.

I tried to patch this behavior a little bit, by selecting the closest entry with the same filename (or dirname), if the selected entry isn't found. Thus, the next qf index stays in the same file or package, so you can continue to fix compile errors. I tested a little bit and I found the behavior a way more convenient than before.

An other improvement would be to fallback on entries with a compile errors rather than warnings or less.

I'm not sure this is the kind of change expected for qf index selection, because I didn't understand the comment located above my change : 

```go
        // In the future we might want to improve this logic
	// by stashing the last selected diagnostic when we flip to, for example,
	// references mode. But for now we keep it simple.
```

Also I didn't find any tests related to qf index selection, and I don't know how I can verify the qf index from the tests. Any help would be appreciated.