### PR TITLE
cmd/govim: rename "vimstate.popupWinId" to please staticcheck

### DIFF
--- a/cmd/govim/hover.go
+++ b/cmd/govim/hover.go
@@ -45,9 +45,9 @@ func (v *vimstate) hoverMsgAt(pos types.Point, tdi protocol.TextDocumentIdentifi
 }
 
 func (v *vimstate) showHover(posExpr string, opts map[string]interface{}, userOpts *map[string]interface{}) (interface{}, error) {
-	if v.popupWinId > 0 {
-		v.ChannelCall("popup_close", v.popupWinId)
-		v.popupWinId = 0
+	if v.popupWinID > 0 {
+		v.ChannelCall("popup_close", v.popupWinID)
+		v.popupWinID = 0
 		v.ChannelRedraw(false)
 	}
 	var vpos struct {
@@ -136,7 +136,7 @@ func (v *vimstate) showHover(posExpr string, opts map[string]interface{}, userOp
 		opts["wrap"] = false
 		opts["close"] = "click"
 	}
-	v.popupWinId = v.ParseInt(v.ChannelCall("popup_create", lines, opts))
+	v.popupWinID = v.ParseInt(v.ChannelCall("popup_create", lines, opts))
 	v.ChannelRedraw(false)
 	return "", nil
 }

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -46,8 +46,8 @@ type vimstate struct {
 	// calls GOVIMQuickfixDiagnostics, which sets the flag to true.
 	quickfixIsDiagnostics bool
 
-	// popupWinId is the id of the window currently being used for a hover-based popup
-	popupWinId int
+	// popupWinID is the id of the window currently being used for a hover-based popup
+	popupWinID int
 
 	// currBatch represents the batch we are collecting
 	currBatch *batch


### PR DESCRIPTION
This change renames the field "popupWinId" in vimstate to "popupWinID"
to avoid getting diagnostics about it when running with staticcheck
enabled.