### PR TITLE
ci: drop use of set-env and add-path

### DIFF
--- a/_scripts/common.bash
+++ b/_scripts/common.bash
@@ -39,6 +39,6 @@ function doBranchCheck {
 		return
 	fi
 	echo "Skipping build for ${VIM_FLAVOR}_${VIM_VERSION}_${GO_VERSION}"
-	echo "::set-env name=CI_SKIP_JOB::true"
+	echo "CI_SKIP_JOB=true" >> $GITHUB_ENV
 	exit 0
 }

--- a/_scripts/postRun.sh
+++ b/_scripts/postRun.sh
@@ -16,4 +16,4 @@ tidyUp $ARTEFACTS
 # step in CI only runs after tidyUp, since it isn't
 # possible (at least currently) to check the status
 # of this job step alone.
-echo "::set-env name=CI_UPLOAD_ARTIFACTS::true"
+echo "CI_UPLOAD_ARTIFACTS=true" >> $GITHUB_ENV


### PR DESCRIPTION
Per https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/