### PR TITLE
deps: update x/tools and gopls to 598b068a

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/gocommand/invoke.go
+++ b/cmd/govim/internal/golang_org_x_tools/gocommand/invoke.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -133,6 +134,9 @@ type Invocation struct {
 	ModFlag    string
 	ModFile    string
 	Overlay    string
+	// If CleanEnv is set, the invocation will run only with the environment
+	// in Env, not starting with os.Environ.
+	CleanEnv   bool
 	Env        []string
 	WorkingDir string
 	Logf       func(format string, args ...interface{})
@@ -207,7 +211,10 @@ func (i *Invocation) run(ctx context.Context, stdout, stderr io.Writer) error {
 	// The Go stdlib has a special feature where if the cwd and the PWD are the
 	// same node then it trusts the PWD, so by setting it in the env for the child
 	// process we fix up all the paths returned by the go command.
-	cmd.Env = append(os.Environ(), i.Env...)
+	if !i.CleanEnv {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = append(cmd.Env, i.Env...)
 	if i.WorkingDir != "" {
 		cmd.Env = append(cmd.Env, "PWD="+i.WorkingDir)
 		cmd.Dir = i.WorkingDir
@@ -248,10 +255,19 @@ func runCmdContext(ctx context.Context, cmd *exec.Cmd) error {
 func cmdDebugStr(cmd *exec.Cmd) string {
 	env := make(map[string]string)
 	for _, kv := range cmd.Env {
-		split := strings.Split(kv, "=")
+		split := strings.SplitN(kv, "=", 2)
 		k, v := split[0], split[1]
 		env[k] = v
 	}
 
-	return fmt.Sprintf("GOROOT=%v GOPATH=%v GO111MODULE=%v GOPROXY=%v PWD=%v go %v", env["GOROOT"], env["GOPATH"], env["GO111MODULE"], env["GOPROXY"], env["PWD"], cmd.Args)
+	var args []string
+	for _, arg := range cmd.Args {
+		quoted := strconv.Quote(arg)
+		if quoted[1:len(quoted)-1] != arg || strings.Contains(arg, " ") {
+			args = append(args, quoted)
+		} else {
+			args = append(args, arg)
+		}
+	}
+	return fmt.Sprintf("GOROOT=%v GOPATH=%v GO111MODULE=%v GOPROXY=%v PWD=%v %v", env["GOROOT"], env["GOPATH"], env["GO111MODULE"], env["GOPROXY"], env["PWD"], strings.Join(args, " "))
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
@@ -433,6 +433,10 @@ func (v *View) shutdown(ctx context.Context) {
 	}
 }
 
+func (v *View) Session() *Session {
+	return v.session
+}
+
 func (v *View) BackgroundContext() context.Context {
 	v.mu.Lock()
 	defer v.mu.Unlock()

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command.go
@@ -373,7 +373,7 @@ func (s *Server) runGoGenerate(ctx context.Context, snapshot source.Snapshot, di
 
 	pattern := "."
 	if recursive {
-		pattern = "..."
+		pattern = "./..."
 	}
 
 	inv := &gocommand.Invocation{

--- a/cmd/govim/internal/golang_org_x_tools/lsp/debug/info.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/debug/info.go
@@ -99,6 +99,9 @@ func (i *Instance) PrintServerInfo(ctx context.Context, w io.Writer) {
 		fmt.Fprintf(w, "Debug address: %s\n", i.DebugAddress)
 	})
 	PrintVersionInfo(ctx, w, true, HTML)
+	section(w, HTML, "Command Line", func() {
+		fmt.Fprintf(w, "<a href=/debug/pprof/cmdline>cmdline</a>")
+	})
 }
 
 // PrintVersionInfo writes version information to w, using the output format

--- a/cmd/govim/internal/golang_org_x_tools/lsp/debug/serve.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/debug/serve.go
@@ -231,6 +231,36 @@ func (st *State) dropServer(id string) {
 	}
 }
 
+// an http.ResponseWriter that filters writes
+type filterResponse struct {
+	w    http.ResponseWriter
+	edit func([]byte) []byte
+}
+
+func (c filterResponse) Header() http.Header {
+	return c.w.Header()
+}
+
+func (c filterResponse) Write(buf []byte) (int, error) {
+	ans := c.edit(buf)
+	return c.w.Write(ans)
+}
+
+func (c filterResponse) WriteHeader(n int) {
+	c.w.WriteHeader(n)
+}
+
+// replace annoying nuls by spaces
+func cmdline(w http.ResponseWriter, r *http.Request) {
+	fake := filterResponse{
+		w: w,
+		edit: func(buf []byte) []byte {
+			return bytes.ReplaceAll(buf, []byte{0}, []byte{' '})
+		},
+	}
+	pprof.Cmdline(fake, r)
+}
+
 func (i *Instance) getCache(r *http.Request) interface{} {
 	return i.State.Cache(path.Base(r.URL.Path))
 }
@@ -354,6 +384,7 @@ func (i *Instance) SetLogFile(logfile string, isDaemon bool) (func(), error) {
 // It also logs the port the server starts on, to allow for :0 auto assigned
 // ports.
 func (i *Instance) Serve(ctx context.Context) error {
+	log.SetFlags(log.Lshortfile)
 	if i.DebugAddress == "" {
 		return nil
 	}
@@ -365,7 +396,7 @@ func (i *Instance) Serve(ctx context.Context) error {
 
 	port := listener.Addr().(*net.TCPAddr).Port
 	if strings.HasSuffix(i.DebugAddress, ":0") {
-		log.Printf("debug server listening on port %d", port)
+		log.Printf("debug server listening at http://localhost:%d", port)
 	}
 	event.Log(ctx, "Debug serving", tag.Port.Of(port))
 	go func() {
@@ -373,7 +404,7 @@ func (i *Instance) Serve(ctx context.Context) error {
 		mux.HandleFunc("/", render(mainTmpl, func(*http.Request) interface{} { return i }))
 		mux.HandleFunc("/debug/", render(debugTmpl, nil))
 		mux.HandleFunc("/debug/pprof/", pprof.Index)
-		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/cmdline", cmdline)
 		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
@@ -624,7 +655,7 @@ Unknown page
 {{define "serverlink"}}<a href="/server/{{.}}">Server {{.}}</a>{{end}}
 {{define "sessionlink"}}<a href="/session/{{.}}">Session {{.}}</a>{{end}}
 {{define "viewlink"}}<a href="/view/{{.}}">View {{.}}</a>{{end}}
-{{define "filelink"}}<a href="/file/{{.SessionID}}/{{.Identifier}}">{{.URI}}</a>{{end}}
+{{define "filelink"}}<a href="/file/{{.Session}}/{{.FileIdentity.Hash}}">{{.FileIdentity.URI}}</a>{{end}}
 `)).Funcs(template.FuncMap{
 	"fuint64":  fuint64,
 	"fuint32":  fuint32,
@@ -747,7 +778,7 @@ From: <b>{{template "cachelink" .Cache.ID}}</b><br>
 <h2>Views</h2>
 <ul>{{range .Views}}<li>{{.Name}} is {{template "viewlink" .ID}} in {{.Folder}}</li>{{end}}</ul>
 <h2>Overlays</h2>
-<ul>{{range .Overlays}}<li>{{template "filelink" .Identity}}</li>{{end}}</ul>
+<ul>{{range .Overlays}}<li>{{template "filelink" .}}</li>{{end}}</ul>
 {{end}}
 `))
 
@@ -763,16 +794,16 @@ From: <b>{{template "sessionlink" .Session.ID}}</b><br>
 `))
 
 var fileTmpl = template.Must(template.Must(baseTemplate.Clone()).Parse(`
-{{define "title"}}Overlay {{.Identity.Identifier}}{{end}}
+{{define "title"}}Overlay {{.FileIdentity.Hash}}{{end}}
 {{define "body"}}
-{{with .Identity}}
-	From: <b>{{template "sessionlink" .SessionID}}</b><br>
+{{with .}}
+	From: <b>{{template "sessionlink" .Session}}</b><br>
 	URI: <b>{{.URI}}</b><br>
-	Identifier: <b>{{.Identifier}}</b><br>
+	Identifier: <b>{{.FileIdentity.Hash}}</b><br>
 	Version: <b>{{.Version}}</b><br>
 	Kind: <b>{{.Kind}}</b><br>
 {{end}}
 <h3>Contents</h3>
-<pre>{{fcontent .Data}}</pre>
+<pre>{{fcontent .Read}}</pre>
 {{end}}
 `))

--- a/cmd/govim/internal/golang_org_x_tools/lsp/general.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/general.go
@@ -171,8 +171,7 @@ func (s *Server) initialized(ctx context.Context, params *protocol.InitializedPa
 			},
 		}
 		if options.SemanticTokens {
-			registrations = append(registrations, semanticTokenRegistrations()...)
-
+			registrations = append(registrations, semanticTokenRegistration())
 		}
 		if err := s.client.RegisterCapability(ctx, &protocol.RegistrationParams{
 			Registrations: registrations,
@@ -412,18 +411,14 @@ func (s *Server) fetchConfig(ctx context.Context, name string, folder span.URI, 
 	if !s.session.Options().ConfigurationSupported {
 		return nil
 	}
-	v := protocol.ParamConfiguration{
+	configs, err := s.client.Configuration(ctx, &protocol.ParamConfiguration{
 		ConfigurationParams: protocol.ConfigurationParams{
 			Items: []protocol.ConfigurationItem{{
 				ScopeURI: string(folder),
 				Section:  "gopls",
-			}, {
-				ScopeURI: string(folder),
-				Section:  fmt.Sprintf("gopls-%s", name),
 			}},
 		},
-	}
-	configs, err := s.client.Configuration(ctx, &v)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get workspace configuration from client (%s): %v", folder, err)
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/link.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/link.go
@@ -67,7 +67,7 @@ func modLinks(ctx context.Context, snapshot source.Snapshot, fh source.FileHandl
 		// Shift the start position to the location of the
 		// dependency within the require statement.
 		start, end := token.Pos(s+i), token.Pos(s+i+len(dep))
-		target := fmt.Sprintf("https://%s/mod/%s", snapshot.View().Options().LinkTarget, req.Mod.String())
+		target := source.BuildLink(snapshot.View().Options().LinkTarget, "mod/"+req.Mod.String(), "")
 		l, err := toProtocolLink(snapshot, pm.Mapper, target, start, end, source.Mod)
 		if err != nil {
 			return nil, err
@@ -143,7 +143,7 @@ func goLinks(ctx context.Context, snapshot source.Snapshot, fh source.FileHandle
 			// Account for the quotation marks in the positions.
 			start := imp.Path.Pos() + 1
 			end := imp.Path.End() - 1
-			target = fmt.Sprintf("https://%s/%s", view.Options().LinkTarget, target)
+			target = source.BuildLink(view.Options().LinkTarget, target, "")
 			l, err := toProtocolLink(snapshot, pgf.Mapper, target, start, end, source.Go)
 			if err != nil {
 				return nil, err

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/hover.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/hover.go
@@ -140,7 +140,7 @@ func formatExplanation(text string, req *modfile.Require, options *source.Option
 		if strings.ToLower(options.LinkTarget) == "pkg.go.dev" {
 			target = strings.Replace(target, req.Mod.Path, req.Mod.String(), 1)
 		}
-		reference = fmt.Sprintf("[%s](https://%s/%s)", imp, options.LinkTarget, target)
+		reference = fmt.Sprintf("[%s](%s)", imp, source.BuildLink(options.LinkTarget, target, ""))
 	}
 	b.WriteString("This module is necessary because " + reference + " is imported in")
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/server.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/server.go
@@ -96,13 +96,19 @@ type Server struct {
 	gcOptimizationDetailsMu sync.Mutex
 	gcOptimizationDetails   map[span.URI]struct{}
 
-	// diagnosticsSema limits the concurrency of diagnostics runs, which can be expensive.
+	// diagnosticsSema limits the concurrency of diagnostics runs, which can be
+	// expensive.
 	diagnosticsSema chan struct{}
 
 	progress *progressTracker
 
 	// debouncer is used for debouncing diagnostics.
 	debouncer *debouncer
+
+	// When the workspace fails to load, we show its status through a progress
+	// report with an error message.
+	criticalErrorStatusMu sync.Mutex
+	criticalErrorStatus   *workDone
 }
 
 // sentDiagnostics is used to cache diagnostics that have been sent for a given file.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
@@ -1522,6 +1522,7 @@ func (c *completer) structLiteralFieldName(ctx context.Context) error {
 		}
 	}
 
+	deltaScore := 0.0001
 	switch t := clInfo.clType.(type) {
 	case *types.Struct:
 		for i := 0; i < t.NumFields(); i++ {
@@ -1529,7 +1530,7 @@ func (c *completer) structLiteralFieldName(ctx context.Context) error {
 			if !addedFields[field] {
 				c.deepState.enqueue(candidate{
 					obj:   field,
-					score: highScore,
+					score: highScore - float64(i)*deltaScore,
 				})
 			}
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/deep_completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/deep_completion.go
@@ -121,12 +121,16 @@ outer:
 		cand := c.deepState.dequeue()
 		obj := cand.obj
 
+		if obj == nil {
+			continue
+		}
+
 		// At the top level, dedupe by object.
 		if len(cand.path) == 0 {
-			if c.seen[cand.obj] {
+			if c.seen[obj] {
 				continue
 			}
-			c.seen[cand.obj] = true
+			c.seen[obj] = true
 		}
 
 		// If obj is not accessible because it lives in another package and is

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/format.go
@@ -14,6 +14,7 @@ import (
 	"go/parser"
 	"go/token"
 	"strings"
+	"text/scanner"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/imports"
@@ -228,12 +229,17 @@ func importPrefix(src []byte) string {
 	}
 	for _, c := range f.Comments {
 		if end := tok.Offset(c.End()); end > importEnd {
-			// Work-around golang/go#41197: For multi-line comments add +2 to
-			// the offset. The end position does not account for the */ at the
-			// end.
+			startLine := tok.Position(c.Pos()).Line
 			endLine := tok.Position(c.End()).Line
-			if end+2 <= tok.Size() && tok.Position(tok.Pos(end+2)).Line == endLine {
-				end += 2
+
+			// Work around golang/go#41197 by checking if the comment might
+			// contain "\r", and if so, find the actual end position of the
+			// comment by scanning the content of the file.
+			startOffset := tok.Offset(c.Pos())
+			if startLine != endLine && bytes.Contains(src[startOffset:], []byte("\r")) {
+				if commentEnd := scanForCommentEnd(tok, src[startOffset:]); commentEnd > 0 {
+					end = startOffset + commentEnd
+				}
 			}
 			importEnd = maybeAdjustToLineEnd(tok.Pos(end), true)
 		}
@@ -242,6 +248,20 @@ func importPrefix(src []byte) string {
 		importEnd = len(src)
 	}
 	return string(src[:importEnd])
+}
+
+// scanForCommentEnd returns the offset of the end of the multi-line comment
+// at the start of the given byte slice.
+func scanForCommentEnd(tok *token.File, src []byte) int {
+	var s scanner.Scanner
+	s.Init(bytes.NewReader(src))
+	s.Mode ^= scanner.SkipComments
+
+	t := s.Scan()
+	if t == scanner.Comment {
+		return s.Pos().Offset
+	}
+	return 0
 }
 
 func computeTextEdits(ctx context.Context, snapshot Snapshot, pgf *ParsedGoFile, formatted string) ([]protocol.TextEdit, error) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
@@ -443,8 +443,6 @@ func isDirective(c string) bool {
 }
 
 // InDir checks whether path is in the file tree rooted at dir.
-// If so, InDir returns an equivalent path relative to dir.
-// If not, InDir returns an empty string.
 // InDir makes some effort to succeed even in the presence of symbolic links.
 //
 // Copied and slightly adjusted from go/src/cmd/go/internal/search/search.go.

--- a/cmd/govim/testdata/scenario_default/quickfix_new_files.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_new_files.txt
@@ -132,7 +132,7 @@ func TestDoIt(t *testing.T) {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "cannot use 5 (untyped int constant) as string value in argument to p.DoIt: cannot convert 5 (untyped int constant) to string",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to p.DoIt",
     "type": "",
     "valid": 1,
     "vcol": 0
@@ -144,7 +144,7 @@ func TestDoIt(t *testing.T) {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "cannot use 5 (untyped int constant) as string value in argument to DoIt: cannot convert 5 (untyped int constant) to string",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to DoIt",
     "type": "",
     "valid": 1,
     "vcol": 0
@@ -156,7 +156,7 @@ func TestDoIt(t *testing.T) {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "cannot use 5 (untyped int constant) as string value in argument to p.DoIt: cannot convert 5 (untyped int constant) to string",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to p.DoIt",
     "type": "",
     "valid": 1,
     "vcol": 0

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.6.2
 	golang.org/x/mod v0.3.0
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/tools v0.0.0-20201111213328-5794f8bd7a57
-	golang.org/x/tools/gopls v0.0.0-20201111213328-5794f8bd7a57
+	golang.org/x/tools v0.0.0-20201118030313-598b068a9102
+	golang.org/x/tools/gopls v0.0.0-20201118030313-598b068a9102
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -76,10 +76,10 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201021214918-23787c007979/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
-golang.org/x/tools v0.0.0-20201111213328-5794f8bd7a57 h1:YB601acXebAxKnp1qDGHXmNMS8D2Qp4IVdqbtQ7wLJk=
-golang.org/x/tools v0.0.0-20201111213328-5794f8bd7a57/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools/gopls v0.0.0-20201111213328-5794f8bd7a57 h1:1mginX6kP7HVvTTcVP6R1puRvkBdyURrjohNHQVm+yQ=
-golang.org/x/tools/gopls v0.0.0-20201111213328-5794f8bd7a57/go.mod h1:lxOXGvXni0OC5X6jaBADTiPd+YCtcFl0ZPLjYdpEK7Y=
+golang.org/x/tools v0.0.0-20201118030313-598b068a9102 h1:kr6Ik/EJgxdTSLX+rSiDounHdHWMBu9Ks/ghr2hWNpo=
+golang.org/x/tools v0.0.0-20201118030313-598b068a9102/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools/gopls v0.0.0-20201118030313-598b068a9102 h1:oUd0xt4IBd1qwggbOK9Bsg4/J/DCgI+dIsFjrs5QwXI=
+golang.org/x/tools/gopls v0.0.0-20201118030313-598b068a9102/go.mod h1:lxOXGvXni0OC5X6jaBADTiPd+YCtcFl0ZPLjYdpEK7Y=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/lsp: fix end positions for multi-line comments with CRLF lines 598b068a
* internal/lsp: use a marker test for struct field ranking test bd56c0ad
* internal/lsp: order struct fields completions by definition 74a3905d
* gopls/internal/regtest: eliminate log duplication f544f6cb
* Revert "internal/lsp: explicitly watch all known directories" 9036a0f9
* internal/lsp: explicitly watch all known directories 3c3a8120
* internal/lsp: show critical error pop-ups as progress reports 74f2986d
* go/packages: handle variation an an error message 1d699438
* internal/lsp: fix capability registration for semantic tokens 6f6c72ae
* internal/gocommand: improve debug string d68bbb54
* go/packages: start with empty environment 247bdb27
* internal/lsp: get debug pages limping along again 1a2739ce
* gopls/internal/regtest: update TestEditFile to use a modified buffer ac45abd4
* internal/lsp: add ?utm_source=gopls to links to pkg.go.dev 9712d02b
* internal/lsp/source: handle nil pointer exception in completion 61ea331e
* internal/regtest: refactor diagnostic expectation implementation 1643af14
* internal/lsp: make log message for debug server clickable 559c4acc
* internal/lsp: remove gopls-<name> configuration eeaa07dd
* internal/lsp/cache: fix InDir error comment b3895597
* internal/lsp: fix recursive go generate pattern 41a3a589

Includes a slight tweak for error messages as they will appear in go1.16