### PR TITLE
ci: use explicit version of Ubuntu on GitHub actions for now

### DIFF
--- a/.github/workflows/docker-based_tests.yml
+++ b/.github/workflows/docker-based_tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         go_version: ["go1.14.9", "go1.15.2"]
         vim_flavor: ["vim", "gvim"]
         vim_version: ["v8.1.1711", "v8.1.2056", "v8.2.1690"]

--- a/.github/workflows/vim_main.yml
+++ b/.github/workflows/vim_main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         go-version: ["1.15.2"]
     runs-on: ${{ matrix.os }}
     env:

--- a/internal/cmd/genconfig/genconfig.go
+++ b/internal/cmd/genconfig/genconfig.go
@@ -312,7 +312,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         go_version: {{{ .GoVersions }}}
         vim_flavor: {{{ .VimFlavors }}}
         vim_version: {{{ .VimVersions }}}
@@ -351,7 +351,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         go-version: ["{{{.MaxRealGoVersion}}}"]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
To be defensive ahead of the upcoming switch of latest