### PR TITLE
cmd/govim: add new config that changes how last progress is opened

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -148,6 +148,9 @@ function! s:validAnalyses(v)
   return [v:true, ""]
 endfunction
 
+function! s:openLastProgressWith(v)
+  return s:validString(a:v)
+endfunction
 
 function! s:validExperimentalAutoreadLoadedBuffers(v)
   return s:validBool(a:v)
@@ -197,6 +200,7 @@ let s:validators = {
       \ "TempModfile": function("s:validTempModfile"),
       \ "GoplsEnv": function("s:validGoplsEnv"),
       \ "Analyses": function("s:validAnalyses"),
+      \ "OpenLastProgressWith": function("s:openLastProgressWith"),
       \ "ExperimentalAutoreadLoadedBuffers": function("s:validExperimentalAutoreadLoadedBuffers"),
       \ "ExperimentalMouseTriggeredHoverPopupOptions": function("s:validExperimentalMouseTriggeredHoverPopupOptions"),
       \ "ExperimentalCursorTriggeredHoverPopupOptions": function("s:validExperimentalCursorTriggeredHoverPopupOptions"),

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -175,6 +175,20 @@ type Config struct {
 	// Default: nil
 	Analyses *map[string]bool `json:",omitempty"`
 
+	// OpenLastProgressWith configures how vim should open the buffer created
+	// when calling :GOVIMLastProgress.
+	// Valid values are any vim command that takes a buffer number as argument.
+	//
+	// Examples: (note that options as "eadirection" alters default behaviour)
+	//    ""             - The buffer is only created
+	//    "e"            - Open the buffer in the current window
+	//    "split"        - Split into two windows with the buffer in one of them
+	//    "7vsplit"      - Split vertically 7 columns wide
+	//    "above 5split" - Split into 5 lines above (left)
+	//
+	// Default: "below 10split"
+	OpenLastProgressWith *string `json:",omitempty"`
+
 	// ExperimentalAutoreadLoadedBuffers is used to reload buffers that are
 	// changed outside vim even when they are loaded (e.g. running two vim
 	// sessions in the same workspace). This is achieved by running "checktime"

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -52,6 +52,9 @@ func (r *Config) Apply(v *Config) {
 	if v.Analyses != nil {
 		r.Analyses = v.Analyses
 	}
+	if v.OpenLastProgressWith != nil {
+		r.OpenLastProgressWith = v.OpenLastProgressWith
+	}
 	if v.ExperimentalAutoreadLoadedBuffers != nil {
 		r.ExperimentalAutoreadLoadedBuffers = v.ExperimentalAutoreadLoadedBuffers
 	}

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -24,6 +24,7 @@ type VimConfig struct {
 	TempModfile                                  *int
 	GoplsEnv                                     *map[string]string
 	Analyses                                     *map[string]int
+	OpenLastProgressWith                         *string
 	ExperimentalAutoreadLoadedBuffers            *int
 	ExperimentalMouseTriggeredHoverPopupOptions  *map[string]interface{}
 	ExperimentalCursorTriggeredHoverPopupOptions *map[string]interface{}
@@ -50,6 +51,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		TempModfile:                       boolVal(c.TempModfile, d.TempModfile),
 		GoplsEnv:                          copyStringValMap(c.GoplsEnv, d.GoplsEnv),
 		Analyses:                          mergeBoolValMap(c.Analyses, d.Analyses),
+		OpenLastProgressWith:              stringVal(c.OpenLastProgressWith, d.OpenLastProgressWith),
 		ExperimentalAutoreadLoadedBuffers: boolVal(c.ExperimentalAutoreadLoadedBuffers, d.ExperimentalAutoreadLoadedBuffers),
 		ExperimentalMouseTriggeredHoverPopupOptions:  copyMap(c.ExperimentalMouseTriggeredHoverPopupOptions, d.ExperimentalMouseTriggeredHoverPopupOptions),
 		ExperimentalCursorTriggeredHoverPopupOptions: copyMap(c.ExperimentalCursorTriggeredHoverPopupOptions, d.ExperimentalCursorTriggeredHoverPopupOptions),
@@ -152,6 +154,10 @@ func BoolVal(v bool) *bool {
 }
 
 func MapVal(v map[string]interface{}) *map[string]interface{} {
+	return &v
+}
+
+func StringVal(v string) *string {
 	return &v
 }
 

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -240,6 +240,7 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 			ExperimentalAutoreadLoadedBuffers: vimconfig.BoolVal(false),
 			SymbolMatcher:                     vimconfig.SymbolMatcherVal(config.SymbolMatcherFuzzy),
 			SymbolStyle:                       vimconfig.SymbolStyleVal(config.SymbolStyleFull),
+			OpenLastProgressWith:              vimconfig.StringVal("below 10split"),
 		}
 	}
 	// Overlay the initial user values on the defaults

--- a/cmd/govim/progress.go
+++ b/cmd/govim/progress.go
@@ -119,6 +119,8 @@ func (v *vimstate) openLastProgress(flags govim.CommandFlags, args ...string) er
 	v.BatchChannelCall("setbufvar", bufNr, "&buflisted", 1)
 	v.BatchChannelCall("setbufline", bufNr, 1, strings.Split(v.lastProgressText.String(), "\n"))
 	v.MustBatchEnd()
-	v.ChannelExf("e %s", bufName)
+	if open := v.config.OpenLastProgressWith; open != nil && *open != "" {
+		v.ChannelExf("%s %s", *open, bufName)
+	}
 	return nil
 }


### PR DESCRIPTION
When calling :GOVIMLastProgress govim creates a new vim buffer. This
change adds the possibility to change how the new buffer is opened.

It also changes the default from "e" to "below 10split".

Change by setting OpenLastProgressWith to a string value, e.g:
   "" - Do not open the new buffer
   "e" - Open in same window
   "split" - Open in split window
   "belowright 15vsplit" - Open in vertical split, right side, 15 columns