### PR TITLE
cmd/govim: add "go test" popup highlighting

### DIFF
--- a/cmd/govim/code_action.go
+++ b/cmd/govim/code_action.go
@@ -58,7 +58,7 @@ func (v *vimstate) runGoTest(flags govim.CommandFlags, args ...string) error {
 	if _, ok := v.progressPopups[token]; ok {
 		return fmt.Errorf("failed to init progress, duplicate token")
 	}
-	v.progressPopups[token] = &types.ProgressPopup{}
+	v.progressPopups[token] = &types.ProgressPopup{Initiator: types.GoTest}
 
 	_, err = v.server.ExecuteCommand(context.Background(), &protocol.ExecuteCommandParams{
 		Command:   c.Command.Command,

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -526,4 +526,9 @@ const (
 	HighlightSignature Highlight = "GOVIMSignature"
 	// HighlightSignatureParam is the group used to add text properties to the signature active parameter
 	HighlightSignatureParam Highlight = "GOVIMSignatureParam"
+
+	// HighlightGoTestPass
+	HighlightGoTestPass Highlight = "GOVIMGoTestPass"
+	//  HighlightGoTestFail
+	HighlightGoTestFail Highlight = "GOVIMGoTestFail"
 )

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -309,7 +309,7 @@ func (g *govimplugin) WorkDoneProgressCreate(ctxt context.Context, params *proto
 		if _, ok := v.progressPopups[params.Token]; ok {
 			return fmt.Errorf("WorkDoneProgressCreate received for an ongoing progress token")
 		}
-		v.progressPopups[params.Token] = &types.ProgressPopup{}
+		v.progressPopups[params.Token] = &types.ProgressPopup{Initiator: types.WorkDoneProgressCreate}
 		return nil
 	})
 	return nil

--- a/cmd/govim/internal/types/popup.go
+++ b/cmd/govim/internal/types/popup.go
@@ -21,11 +21,22 @@ type PopupProp struct {
 	Len  int    `json:"length"`
 }
 
+type ProgressInitiator string
+
+const (
+	GoTest                 ProgressInitiator = "GoTest"
+	WorkDoneProgressCreate ProgressInitiator = "WorkDoneProgressCreate"
+)
+
 // ProgressPopup represents a vim popup placed in the upper right corner used
 // to show LSP progress. LinePos is used to stack multiple visible progress
-// popups.
+// popups. Initiator is a optional field used to describe who initiated this
+// progress (if known), e.g. "GoTest" when running GOVIMGoTest. This allow
+// us to handle text from different commands to be handled differently (or
+// even suppressed).
 type ProgressPopup struct {
-	ID      int
-	Text    strings.Builder
-	LinePos int
+	ID        int
+	Text      strings.Builder
+	LinePos   int
+	Initiator ProgressInitiator
 }

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -421,6 +421,9 @@ func (g *govimplugin) defineHighlights() {
 
 		fmt.Sprintf("highlight default link %s PMenu", config.HighlightSignature),
 		fmt.Sprintf("highlight default %s term=bold cterm=bold gui=bold", config.HighlightSignatureParam),
+
+		fmt.Sprintf("highlight default %s ctermfg=2 guifg=Green", config.HighlightGoTestPass),
+		fmt.Sprintf("highlight default %s ctermfg=1 guifg=Red ", config.HighlightGoTestFail),
 	} {
 		g.vimstate.BatchChannelCall("execute", hi)
 	}


### PR DESCRIPTION
When running `:GOVIMGoTest` the popup dialog will be styled according to
two new highlight definitions:
```
  GOVIMGoTestPass
  GOVIMGoTestFail
```

If one or more test fail, the popup will turn red. If all tests pass it
will turn green.

Redefine a highlight in your .vimrc to override default colors, e.g.
white on red when test fail:

```
highlight GOVIMGoTestFail ctermfg=15 ctermbg=1
```