### PR TITLE
cmd/govim: add support for gofumpt as formatter

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -152,6 +152,10 @@ function! s:openLastProgressWith(v)
   return s:validString(a:v)
 endfunction
 
+function! s:validGofumpt(v)
+  return s:validBool(a:v)
+endfunction
+
 function! s:validExperimentalAutoreadLoadedBuffers(v)
   return s:validBool(a:v)
 endfunction
@@ -201,6 +205,7 @@ let s:validators = {
       \ "GoplsEnv": function("s:validGoplsEnv"),
       \ "Analyses": function("s:validAnalyses"),
       \ "OpenLastProgressWith": function("s:openLastProgressWith"),
+      \ "Gofumpt": function("s:validGofumpt"),
       \ "ExperimentalAutoreadLoadedBuffers": function("s:validExperimentalAutoreadLoadedBuffers"),
       \ "ExperimentalMouseTriggeredHoverPopupOptions": function("s:validExperimentalMouseTriggeredHoverPopupOptions"),
       \ "ExperimentalCursorTriggeredHoverPopupOptions": function("s:validExperimentalCursorTriggeredHoverPopupOptions"),

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -189,6 +189,17 @@ type Config struct {
 	// Default: "below 10split"
 	OpenLastProgressWith *string `json:",omitempty"`
 
+	// Gofumpt configures gopls to use gofumpt as formatter.
+	// It is a stricter formatter than gofmt, while being backwards compatible.
+	// Read more at: https://github.com/mvdan/gofumpt
+	//
+	// Note that the way gopls uses gofumpt is still evaluated and might change
+	// in the future (to be default with suggested fixes instead for example).
+	// See https://github.com/golang/go/issues/39805.
+	//
+	// Default: false
+	Gofumpt *bool `json:",omitempty"`
+
 	// ExperimentalAutoreadLoadedBuffers is used to reload buffers that are
 	// changed outside vim even when they are loaded (e.g. running two vim
 	// sessions in the same workspace). This is achieved by running "checktime"

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -55,6 +55,9 @@ func (r *Config) Apply(v *Config) {
 	if v.OpenLastProgressWith != nil {
 		r.OpenLastProgressWith = v.OpenLastProgressWith
 	}
+	if v.Gofumpt != nil {
+		r.Gofumpt = v.Gofumpt
+	}
 	if v.ExperimentalAutoreadLoadedBuffers != nil {
 		r.ExperimentalAutoreadLoadedBuffers = v.ExperimentalAutoreadLoadedBuffers
 	}

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -33,6 +33,7 @@ const (
 	goplsCodeLenses           = "codelenses"
 	goplsSymbolMatcher        = "symbolMatcher"
 	goplsSymbolStyle          = "symbolStyle"
+	goplsGofumpt              = "gofumpt"
 )
 
 var _ protocol.Client = (*govimplugin)(nil)
@@ -164,6 +165,9 @@ func (g *govimplugin) Configuration(ctxt context.Context, params *protocol.Param
 	}
 	if g.vimstate.config.TempModfile != nil {
 		goplsConfig[goplsTempModfile] = *conf.TempModfile
+	}
+	if g.vimstate.config.Gofumpt != nil {
+		goplsConfig[goplsGofumpt] = *conf.Gofumpt
 	}
 	if os.Getenv(string(config.EnvVarGoplsVerbose)) == "true" {
 		goplsConfig[goplsVerboseOutput] = true

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -25,6 +25,7 @@ type VimConfig struct {
 	GoplsEnv                                     *map[string]string
 	Analyses                                     *map[string]int
 	OpenLastProgressWith                         *string
+	Gofumpt                                      *int
 	ExperimentalAutoreadLoadedBuffers            *int
 	ExperimentalMouseTriggeredHoverPopupOptions  *map[string]interface{}
 	ExperimentalCursorTriggeredHoverPopupOptions *map[string]interface{}
@@ -52,6 +53,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		GoplsEnv:                          copyStringValMap(c.GoplsEnv, d.GoplsEnv),
 		Analyses:                          mergeBoolValMap(c.Analyses, d.Analyses),
 		OpenLastProgressWith:              stringVal(c.OpenLastProgressWith, d.OpenLastProgressWith),
+		Gofumpt:                           boolVal(c.Gofumpt, d.Gofumpt),
 		ExperimentalAutoreadLoadedBuffers: boolVal(c.ExperimentalAutoreadLoadedBuffers, d.ExperimentalAutoreadLoadedBuffers),
 		ExperimentalMouseTriggeredHoverPopupOptions:  copyMap(c.ExperimentalMouseTriggeredHoverPopupOptions, d.ExperimentalMouseTriggeredHoverPopupOptions),
 		ExperimentalCursorTriggeredHoverPopupOptions: copyMap(c.ExperimentalCursorTriggeredHoverPopupOptions, d.ExperimentalCursorTriggeredHoverPopupOptions),

--- a/cmd/govim/testdata/scenario_gofumpt/gofumpt.txt
+++ b/cmd/govim/testdata/scenario_gofumpt/gofumpt.txt
@@ -1,0 +1,64 @@
+# Verify that gofumpt can be enabled and works
+
+vim ex 'e main.go'
+vim ex 'w'
+cmp main.go main.golden
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+import "fmt"
+
+func fn() (int, error) {
+
+	return 0, nil
+
+}
+func main() {
+
+	var (
+		s string = ""
+	)
+	fmt.Println(s)
+
+	i, err := fn()
+
+	if err != nil {
+		panic(err)
+	}
+
+	switch i {
+	case 0, 1, 2,
+		3, 4:
+	}
+}
+-- main.golden --
+package main
+
+import "fmt"
+
+func fn() (int, error) {
+	return 0, nil
+}
+
+func main() {
+	var s string = ""
+	fmt.Println(s)
+
+	i, err := fn()
+	if err != nil {
+		panic(err)
+	}
+
+	switch i {
+	case 0, 1, 2, 3, 4:
+	}
+}

--- a/cmd/govim/testdata/scenario_gofumpt/user_config.json
+++ b/cmd/govim/testdata/scenario_gofumpt/user_config.json
@@ -1,0 +1,3 @@
+{
+	"Gofumpt": true
+}


### PR DESCRIPTION
Gopls do support changing formatter to gofumpt but the setting wasn't
exposed by govim. This change adds a new config that can be enabled by
adding a line to your .vimrc:

```vim
call govim#config#Set("Gofumpt", 1)
```

Closes #1004 