### PR TITLE
deps: update x/tools and gopls to fa10ef0b

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/imports/mod.go
+++ b/cmd/govim/internal/golang_org_x_tools/imports/mod.go
@@ -88,7 +88,11 @@ func (r *ModuleResolver) init() error {
 	if gmc := r.env.Env["GOMODCACHE"]; gmc != "" {
 		r.moduleCacheDir = gmc
 	} else {
-		r.moduleCacheDir = filepath.Join(filepath.SplitList(goenv["GOPATH"])[0], "/pkg/mod")
+		gopaths := filepath.SplitList(goenv["GOPATH"])
+		if len(gopaths) == 0 {
+			return fmt.Errorf("empty GOPATH")
+		}
+		r.moduleCacheDir = filepath.Join(gopaths[0], "/pkg/mod")
 	}
 
 	sort.Slice(r.modsByModPath, func(i, j int) bool {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/errors.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/errors.go
@@ -22,6 +22,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/typesinternal"
 	errors "golang.org/x/xerrors"
 )
 
@@ -31,6 +32,7 @@ func sourceError(ctx context.Context, snapshot *snapshot, pkg *pkg, e interface{
 		spn           span.Span
 		err           error
 		msg, category string
+		code          typesinternal.ErrorCode
 		kind          source.ErrorKind
 		fixes         []source.SuggestedFix
 		related       []source.RelatedInformation
@@ -90,7 +92,7 @@ func sourceError(ctx context.Context, snapshot *snapshot, pkg *pkg, e interface{
 		if !e.Pos.IsValid() {
 			return nil, fmt.Errorf("invalid position for type error %v", e)
 		}
-		spn, err = typeErrorRange(snapshot, fset, pkg, e.Pos)
+		code, spn, err = typeErrorData(fset, pkg, e)
 		if err != nil {
 			return nil, err
 		}
@@ -101,14 +103,14 @@ func sourceError(ctx context.Context, snapshot *snapshot, pkg *pkg, e interface{
 		if !perr.Pos.IsValid() {
 			return nil, fmt.Errorf("invalid position for type error %v", e)
 		}
-		spn, err = typeErrorRange(snapshot, fset, pkg, perr.Pos)
+		code, spn, err = typeErrorData(fset, pkg, e.primary)
 		if err != nil {
 			return nil, err
 		}
 		for _, s := range e.secondaries {
 			var x source.RelatedInformation
 			x.Message = s.Msg
-			xspn, err := typeErrorRange(snapshot, fset, pkg, s.Pos)
+			_, xspn, err := typeErrorData(fset, pkg, s)
 			if err != nil {
 				return nil, fmt.Errorf("invalid position for type error %v", s)
 			}
@@ -143,7 +145,7 @@ func sourceError(ctx context.Context, snapshot *snapshot, pkg *pkg, e interface{
 	if err != nil {
 		return nil, err
 	}
-	return &source.Error{
+	se := &source.Error{
 		URI:            spn.URI(),
 		Range:          rng,
 		Message:        msg,
@@ -151,7 +153,17 @@ func sourceError(ctx context.Context, snapshot *snapshot, pkg *pkg, e interface{
 		Category:       category,
 		SuggestedFixes: fixes,
 		Related:        related,
-	}, nil
+	}
+	if code != 0 {
+		se.Code = code.String()
+		se.CodeHref = typesCodeHref(snapshot, code)
+	}
+	return se, nil
+}
+
+func typesCodeHref(snapshot *snapshot, code typesinternal.ErrorCode) string {
+	target := snapshot.View().Options().LinkTarget
+	return fmt.Sprintf("%s/github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/typesinternal#%s", target, code.String())
 }
 
 func suggestedAnalysisFixes(snapshot *snapshot, pkg *pkg, diag *analysis.Diagnostic) ([]source.SuggestedFix, error) {
@@ -213,18 +225,29 @@ func toSourceErrorKind(kind packages.ErrorKind) source.ErrorKind {
 	}
 }
 
-func typeErrorRange(snapshot *snapshot, fset *token.FileSet, pkg *pkg, pos token.Pos) (span.Span, error) {
-	posn := fset.Position(pos)
+func typeErrorData(fset *token.FileSet, pkg *pkg, terr types.Error) (typesinternal.ErrorCode, span.Span, error) {
+	ecode, start, end, ok := typesinternal.ReadGo116ErrorData(terr)
+	if !ok {
+		start, end = terr.Pos, terr.Pos
+		ecode = 0
+	}
+	posn := fset.Position(start)
 	pgf, err := pkg.File(span.URIFromPath(posn.Filename))
 	if err != nil {
-		return span.Span{}, err
+		return 0, span.Span{}, err
 	}
-	return span.Range{
-		FileSet:   fset,
-		Start:     pos,
-		End:       analysisinternal.TypeErrorEndPos(fset, pgf.Src, pos),
-		Converter: pgf.Mapper.Converter,
-	}.Span()
+	if !end.IsValid() || end == start {
+		end = analysisinternal.TypeErrorEndPos(fset, pgf.Src, start)
+	}
+	spn, err := parsedGoSpan(pgf, start, end)
+	if err != nil {
+		return 0, span.Span{}, err
+	}
+	return ecode, spn, nil
+}
+
+func parsedGoSpan(pgf *source.ParsedGoFile, start, end token.Pos) (span.Span, error) {
+	return span.FileSpan(pgf.Tok, pgf.Mapper.Converter, start, end)
 }
 
 func scannerErrorRange(snapshot *snapshot, pkg *pkg, posn token.Position) (span.Span, error) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
@@ -117,9 +117,20 @@ func (p *pkg) GetImport(pkgPath string) (source.Package, error) {
 }
 
 func (p *pkg) MissingDependencies() []string {
+	// We don't invalidate metadata for import deletions, so check the package
+	// imports via the *types.Package. Only use metadata if p.types is nil.
+	if p.types == nil {
+		var md []string
+		for i := range p.m.missingDeps {
+			md = append(md, string(i))
+		}
+		return md
+	}
 	var md []string
-	for i := range p.m.missingDeps {
-		md = append(md, string(i))
+	for _, pkg := range p.types.Imports() {
+		if _, ok := p.m.missingDeps[packagePath(pkg.Path())]; ok {
+			md = append(md, pkg.Path())
+		}
 	}
 	return md
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -175,14 +174,14 @@ func (s *Session) createView(ctx context.Context, name string, folder, tempWorks
 	}
 	root := folder
 	if options.ExpandWorkspaceToModule {
-		root, err = findWorkspaceRoot(ctx, root, s, options.ExperimentalWorkspaceModule)
+		root, err = findWorkspaceRoot(ctx, root, s, pathExcludedByFilterFunc(options), options.ExperimentalWorkspaceModule)
 		if err != nil {
 			return nil, nil, func() {}, err
 		}
 	}
 
 	// Build the gopls workspace, collecting active modules in the view.
-	workspace, err := newWorkspace(ctx, root, s, ws.userGo111Module == off, options.ExperimentalWorkspaceModule)
+	workspace, err := newWorkspace(ctx, root, s, pathExcludedByFilterFunc(options), ws.userGo111Module == off, options.ExperimentalWorkspaceModule)
 	if err != nil {
 		return nil, nil, func() {}, err
 	}
@@ -288,12 +287,11 @@ func (s *Session) viewOf(uri span.URI) (*View, error) {
 		return v, nil
 	}
 	// Pick the best view for this file and memoize the result.
-	v, err := s.bestView(uri)
-	if err != nil {
-		return nil, err
+	if len(s.views) == 0 {
+		return nil, fmt.Errorf("no views in session")
 	}
-	s.viewMap[uri] = v
-	return v, nil
+	s.viewMap[uri] = bestViewForURI(uri, s.views)
+	return s.viewMap[uri], nil
 }
 
 func (s *Session) viewsOf(uri span.URI) []*View {
@@ -302,7 +300,7 @@ func (s *Session) viewsOf(uri span.URI) []*View {
 
 	var views []*View
 	for _, view := range s.views {
-		if strings.HasPrefix(string(uri), string(view.Folder())) {
+		if source.InDir(view.folder.Filename(), uri.Filename()) {
 			views = append(views, view)
 		}
 	}
@@ -319,15 +317,12 @@ func (s *Session) Views() []source.View {
 	return result
 }
 
-// bestView finds the best view to associate a given URI with.
-// viewMu must be held when calling this method.
-func (s *Session) bestView(uri span.URI) (*View, error) {
-	if len(s.views) == 0 {
-		return nil, errors.Errorf("no views in the session")
-	}
+// bestViewForURI returns the most closely matching view for the given URI
+// out of the given set of views.
+func bestViewForURI(uri span.URI, views []*View) *View {
 	// we need to find the best view for this file
 	var longest *View
-	for _, view := range s.views {
+	for _, view := range views {
 		if longest != nil && len(longest.Folder()) > len(view.Folder()) {
 			continue
 		}
@@ -336,16 +331,16 @@ func (s *Session) bestView(uri span.URI) (*View, error) {
 		}
 	}
 	if longest != nil {
-		return longest, nil
+		return longest
 	}
 	// Try our best to return a view that knows the file.
-	for _, view := range s.views {
+	for _, view := range views {
 		if view.knownFile(uri) {
-			return view, nil
+			return view
 		}
 	}
 	// TODO: are there any more heuristics we can use?
-	return s.views[0], nil
+	return views[0]
 }
 
 func (s *Session) removeView(ctx context.Context, view *View) error {
@@ -405,7 +400,7 @@ func (s *Session) dropView(ctx context.Context, v *View) (int, error) {
 }
 
 func (s *Session) ModifyFiles(ctx context.Context, changes []source.FileModification) error {
-	_, _, releases, err := s.DidModifyFiles(ctx, changes)
+	_, releases, err := s.DidModifyFiles(ctx, changes)
 	for _, release := range releases {
 		release()
 	}
@@ -418,13 +413,13 @@ type fileChange struct {
 	fileHandle source.VersionedFileHandle
 }
 
-func (s *Session) DidModifyFiles(ctx context.Context, changes []source.FileModification) (map[span.URI]source.View, map[source.View]source.Snapshot, []func(), error) {
+func (s *Session) DidModifyFiles(ctx context.Context, changes []source.FileModification) (map[source.Snapshot][]span.URI, []func(), error) {
 	views := make(map[*View]map[span.URI]*fileChange)
-	bestViews := map[span.URI]source.View{}
+	affectedViews := map[span.URI][]*View{}
 
 	overlays, err := s.updateOverlays(ctx, changes)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 	var forceReloadMetadata bool
 	for _, c := range changes {
@@ -433,12 +428,6 @@ func (s *Session) DidModifyFiles(ctx context.Context, changes []source.FileModif
 		}
 
 		// Build the list of affected views.
-		bestView, err := s.viewOf(c.URI)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		bestViews[c.URI] = bestView
-
 		var changedViews []*View
 		for _, view := range s.views {
 			// Don't propagate changes that are outside of the view's scope
@@ -448,16 +437,25 @@ func (s *Session) DidModifyFiles(ctx context.Context, changes []source.FileModif
 			}
 			changedViews = append(changedViews, view)
 		}
-		// If no view matched the change, assign it to the best view.
+		// If the change is not relevant to any view, but the change is
+		// happening in the editor, assign it the most closely matching view.
 		if len(changedViews) == 0 {
+			if c.OnDisk {
+				continue
+			}
+			bestView, err := s.viewOf(c.URI)
+			if err != nil {
+				return nil, nil, err
+			}
 			changedViews = append(changedViews, bestView)
 		}
+		affectedViews[c.URI] = changedViews
 
 		// Apply the changes to all affected views.
 		for _, view := range changedViews {
 			// Make sure that the file is added to the view.
 			if _, err := view.getFile(c.URI); err != nil {
-				return nil, nil, nil, err
+				return nil, nil, err
 			}
 			if _, ok := views[view]; !ok {
 				views[view] = make(map[span.URI]*fileChange)
@@ -471,7 +469,7 @@ func (s *Session) DidModifyFiles(ctx context.Context, changes []source.FileModif
 			} else {
 				fsFile, err := s.cache.getFile(ctx, c.URI)
 				if err != nil {
-					return nil, nil, nil, err
+					return nil, nil, err
 				}
 				content, err := fsFile.Read()
 				fh := &closedFile{fsFile}
@@ -484,14 +482,32 @@ func (s *Session) DidModifyFiles(ctx context.Context, changes []source.FileModif
 		}
 	}
 
-	snapshots := map[source.View]source.Snapshot{}
 	var releases []func()
+	viewToSnapshot := map[*View]*snapshot{}
 	for view, changed := range views {
 		snapshot, release := view.invalidateContent(ctx, changed, forceReloadMetadata)
-		snapshots[view] = snapshot
 		releases = append(releases, release)
+		viewToSnapshot[view] = snapshot
 	}
-	return bestViews, snapshots, releases, nil
+
+	// We only want to diagnose each changed file once, in the view to which
+	// it "most" belongs. We do this by picking the best view for each URI,
+	// and then aggregating the set of snapshots and their URIs (to avoid
+	// diagnosing the same snapshot multiple times).
+	snapshotURIs := map[source.Snapshot][]span.URI{}
+	for _, mod := range changes {
+		viewSlice, ok := affectedViews[mod.URI]
+		if !ok || len(viewSlice) == 0 {
+			continue
+		}
+		view := bestViewForURI(mod.URI, viewSlice)
+		snapshot, ok := viewToSnapshot[view]
+		if !ok {
+			panic(fmt.Sprintf("no snapshot for view %s", view.Folder()))
+		}
+		snapshotURIs[snapshot] = append(snapshotURIs[snapshot], mod.URI)
+	}
+	return snapshotURIs, releases, nil
 }
 
 func (s *Session) ExpandModificationsToDirectories(ctx context.Context, changes []source.FileModification) []source.FileModification {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/workspace.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/workspace.go
@@ -54,6 +54,7 @@ func (s workspaceSource) String() string {
 // across multiple snapshots.
 type workspace struct {
 	root         span.URI
+	excludePath  func(string) bool
 	moduleSource workspaceSource
 
 	// activeModFiles holds the active go.mod files.
@@ -76,11 +77,12 @@ type workspace struct {
 	buildMu  sync.Mutex
 	built    bool
 	buildErr error
-	file     *modfile.File
+	mod      *modfile.File
+	sum      []byte
 	wsDirs   map[span.URI]struct{}
 }
 
-func newWorkspace(ctx context.Context, root span.URI, fs source.FileSource, go111moduleOff bool, experimental bool) (*workspace, error) {
+func newWorkspace(ctx context.Context, root span.URI, fs source.FileSource, excludePath func(string) bool, go111moduleOff bool, experimental bool) (*workspace, error) {
 	// In experimental mode, the user may have a gopls.mod file that defines
 	// their workspace.
 	if experimental {
@@ -96,16 +98,17 @@ func newWorkspace(ctx context.Context, root span.URI, fs source.FileSource, go11
 			}
 			return &workspace{
 				root:           root,
+				excludePath:    excludePath,
 				activeModFiles: activeModFiles,
 				knownModFiles:  activeModFiles,
-				file:           file,
+				mod:            file,
 				moduleSource:   goplsModWorkspace,
 			}, nil
 		}
 	}
 	// Otherwise, in all other modes, search for all of the go.mod files in the
 	// workspace.
-	knownModFiles, err := findModules(ctx, root, 0)
+	knownModFiles, err := findModules(ctx, root, excludePath, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -113,6 +116,7 @@ func newWorkspace(ctx context.Context, root span.URI, fs source.FileSource, go11
 	if go111moduleOff {
 		return &workspace{
 			root:           root,
+			excludePath:    excludePath,
 			moduleSource:   legacyWorkspace,
 			knownModFiles:  knownModFiles,
 			go111moduleOff: true,
@@ -126,6 +130,7 @@ func newWorkspace(ctx context.Context, root span.URI, fs source.FileSource, go11
 		}
 		return &workspace{
 			root:           root,
+			excludePath:    excludePath,
 			activeModFiles: activeModFiles,
 			knownModFiles:  knownModFiles,
 			moduleSource:   legacyWorkspace,
@@ -133,18 +138,19 @@ func newWorkspace(ctx context.Context, root span.URI, fs source.FileSource, go11
 	}
 	return &workspace{
 		root:           root,
+		excludePath:    excludePath,
 		activeModFiles: knownModFiles,
 		knownModFiles:  knownModFiles,
 		moduleSource:   fileSystemWorkspace,
 	}, nil
 }
 
-func (wm *workspace) getKnownModFiles() map[span.URI]struct{} {
-	return wm.knownModFiles
+func (w *workspace) getKnownModFiles() map[span.URI]struct{} {
+	return w.knownModFiles
 }
 
-func (wm *workspace) getActiveModFiles() map[span.URI]struct{} {
-	return wm.activeModFiles
+func (w *workspace) getActiveModFiles() map[span.URI]struct{} {
+	return w.activeModFiles
 }
 
 // modFile gets the workspace modfile associated with this workspace,
@@ -154,16 +160,21 @@ func (wm *workspace) getActiveModFiles() map[span.URI]struct{} {
 // correct to pass in the snapshot file source to newWorkspace when
 // invalidating, because at the time these are called the snapshot is locked.
 // So we must pass it in later on when actually using the modFile.
-func (wm *workspace) modFile(ctx context.Context, fs source.FileSource) (*modfile.File, error) {
-	wm.build(ctx, fs)
-	return wm.file, wm.buildErr
+func (w *workspace) modFile(ctx context.Context, fs source.FileSource) (*modfile.File, error) {
+	w.build(ctx, fs)
+	return w.mod, w.buildErr
 }
 
-func (wm *workspace) build(ctx context.Context, fs source.FileSource) {
-	wm.buildMu.Lock()
-	defer wm.buildMu.Unlock()
+func (w *workspace) sumFile(ctx context.Context, fs source.FileSource) ([]byte, error) {
+	w.build(ctx, fs)
+	return w.sum, w.buildErr
+}
 
-	if wm.built {
+func (w *workspace) build(ctx context.Context, fs source.FileSource) {
+	w.buildMu.Lock()
+	defer w.buildMu.Unlock()
+
+	if w.built {
 		return
 	}
 	// Building should never be cancelled. Since the workspace module is shared
@@ -173,46 +184,52 @@ func (wm *workspace) build(ctx context.Context, fs source.FileSource) {
 
 	// If our module source is not gopls.mod, try to build the workspace module
 	// from modules. Fall back on the pre-existing mod file if parsing fails.
-	if wm.moduleSource != goplsModWorkspace {
-		file, err := buildWorkspaceModFile(ctx, wm.activeModFiles, fs)
+	if w.moduleSource != goplsModWorkspace {
+		file, err := buildWorkspaceModFile(ctx, w.activeModFiles, fs)
 		switch {
 		case err == nil:
-			wm.file = file
-		case wm.file != nil:
+			w.mod = file
+		case w.mod != nil:
 			// Parsing failed, but we have a previous file version.
 			event.Error(ctx, "building workspace mod file", err)
 		default:
 			// No file to fall back on.
-			wm.buildErr = err
+			w.buildErr = err
 		}
 	}
-	if wm.file != nil {
-		wm.wsDirs = map[span.URI]struct{}{
-			wm.root: {},
+	if w.mod != nil {
+		w.wsDirs = map[span.URI]struct{}{
+			w.root: {},
 		}
-		for _, r := range wm.file.Replace {
+		for _, r := range w.mod.Replace {
 			// We may be replacing a module with a different version, not a path
 			// on disk.
 			if r.New.Version != "" {
 				continue
 			}
-			wm.wsDirs[span.URIFromPath(r.New.Path)] = struct{}{}
+			w.wsDirs[span.URIFromPath(r.New.Path)] = struct{}{}
 		}
 	}
 	// Ensure that there is always at least the root dir.
-	if len(wm.wsDirs) == 0 {
-		wm.wsDirs = map[span.URI]struct{}{
-			wm.root: {},
+	if len(w.wsDirs) == 0 {
+		w.wsDirs = map[span.URI]struct{}{
+			w.root: {},
 		}
 	}
-	wm.built = true
+	sum, err := buildWorkspaceSumFile(ctx, w.activeModFiles, fs)
+	if err == nil {
+		w.sum = sum
+	} else {
+		event.Error(ctx, "building workspace sum file", err)
+	}
+	w.built = true
 }
 
 // dirs returns the workspace directories for the loaded modules.
-func (wm *workspace) dirs(ctx context.Context, fs source.FileSource) []span.URI {
-	wm.build(ctx, fs)
+func (w *workspace) dirs(ctx context.Context, fs source.FileSource) []span.URI {
+	w.build(ctx, fs)
 	var dirs []span.URI
-	for d := range wm.wsDirs {
+	for d := range w.wsDirs {
 		dirs = append(dirs, d)
 	}
 	sort.Slice(dirs, func(i, j int) bool {
@@ -224,11 +241,11 @@ func (wm *workspace) dirs(ctx context.Context, fs source.FileSource) []span.URI 
 // invalidate returns a (possibly) new workspaceModule after invalidating
 // changedURIs. If wm is still valid in the presence of changedURIs, it returns
 // itself unmodified.
-func (wm *workspace) invalidate(ctx context.Context, changes map[span.URI]*fileChange) (*workspace, bool) {
+func (w *workspace) invalidate(ctx context.Context, changes map[span.URI]*fileChange) (*workspace, bool) {
 	// Prevent races to wm.modFile or wm.wsDirs below, if wm has not yet been
 	// built.
-	wm.buildMu.Lock()
-	defer wm.buildMu.Unlock()
+	w.buildMu.Lock()
+	defer w.buildMu.Unlock()
 
 	// Any gopls.mod change is processed first, followed by go.mod changes, as
 	// changes to gopls.mod may affect the set of active go.mod files.
@@ -236,25 +253,26 @@ func (wm *workspace) invalidate(ctx context.Context, changes map[span.URI]*fileC
 		// New values. We return a new workspace module if and only if
 		// knownModFiles is non-nil.
 		knownModFiles map[span.URI]struct{}
-		moduleSource  = wm.moduleSource
-		modFile       = wm.file
+		moduleSource  = w.moduleSource
+		modFile       = w.mod
+		sumData       = w.sum
 		err           error
 	)
-	if wm.moduleSource == goplsModWorkspace {
+	if w.moduleSource == goplsModWorkspace {
 		// If we are currently reading the modfile from gopls.mod, we default to
 		// preserving it even if module metadata changes (which may be the case if
 		// a go.sum file changes).
-		modFile = wm.file
+		modFile = w.mod
 	}
 	// First handle changes to the gopls.mod file.
-	if wm.moduleSource != legacyWorkspace {
+	if w.moduleSource != legacyWorkspace {
 		// If gopls.mod has changed we need to either re-read it if it exists or
 		// walk the filesystem if it doesn't exist.
-		gmURI := goplsModURI(wm.root)
+		gmURI := goplsModURI(w.root)
 		if change, ok := changes[gmURI]; ok {
 			if change.exists {
 				// Only invalidate if the gopls.mod actually parses. Otherwise, stick with the current gopls.mod
-				parsedFile, parsedModules, err := parseGoplsMod(wm.root, gmURI, change.content)
+				parsedFile, parsedModules, err := parseGoplsMod(w.root, gmURI, change.content)
 				if err == nil {
 					modFile = parsedFile
 					moduleSource = goplsModWorkspace
@@ -266,7 +284,7 @@ func (wm *workspace) invalidate(ctx context.Context, changes map[span.URI]*fileC
 			} else {
 				// gopls.mod is deleted. search for modules again.
 				moduleSource = fileSystemWorkspace
-				knownModFiles, err = findModules(ctx, wm.root, 0)
+				knownModFiles, err = findModules(ctx, w.root, w.excludePath, 0)
 				// the modFile is no longer valid.
 				if err != nil {
 					event.Error(ctx, "finding file system modules", err)
@@ -279,20 +297,20 @@ func (wm *workspace) invalidate(ctx context.Context, changes map[span.URI]*fileC
 	// Next, handle go.mod changes that could affect our set of tracked modules.
 	// If we're reading our tracked modules from the gopls.mod, there's nothing
 	// to do here.
-	if wm.moduleSource != goplsModWorkspace {
+	if w.moduleSource != goplsModWorkspace {
 		for uri, change := range changes {
 			// If a go.mod file has changed, we may need to update the set of active
 			// modules.
 			if !isGoMod(uri) {
 				continue
 			}
-			if !source.InDir(wm.root.Filename(), uri.Filename()) {
+			if !source.InDir(w.root.Filename(), uri.Filename()) {
 				// Otherwise, the module must be contained within the workspace root.
 				continue
 			}
 			if knownModFiles == nil {
 				knownModFiles = make(map[span.URI]struct{})
-				for k := range wm.knownModFiles {
+				for k := range w.knownModFiles {
 					knownModFiles[k] = struct{}{}
 				}
 			}
@@ -305,15 +323,15 @@ func (wm *workspace) invalidate(ctx context.Context, changes map[span.URI]*fileC
 	}
 	if knownModFiles != nil {
 		var activeModFiles map[span.URI]struct{}
-		if wm.go111moduleOff {
+		if w.go111moduleOff {
 			// If GO111MODULE=off, the set of active go.mod files is unchanged.
-			activeModFiles = wm.activeModFiles
+			activeModFiles = w.activeModFiles
 		} else {
 			activeModFiles = make(map[span.URI]struct{})
 			for uri := range knownModFiles {
 				// Legacy mode only considers a module a workspace root, so don't
 				// update the active go.mod files map.
-				if wm.moduleSource == legacyWorkspace && source.CompareURI(modURI(wm.root), uri) != 0 {
+				if w.moduleSource == legacyWorkspace && source.CompareURI(modURI(w.root), uri) != 0 {
 					continue
 				}
 				activeModFiles[uri] = struct{}{}
@@ -321,16 +339,18 @@ func (wm *workspace) invalidate(ctx context.Context, changes map[span.URI]*fileC
 		}
 		// Any change to modules triggers a new version.
 		return &workspace{
-			root:           wm.root,
+			root:           w.root,
+			excludePath:    w.excludePath,
 			moduleSource:   moduleSource,
 			activeModFiles: activeModFiles,
 			knownModFiles:  knownModFiles,
-			file:           modFile,
-			wsDirs:         wm.wsDirs,
+			mod:            modFile,
+			sum:            sumData,
+			wsDirs:         w.wsDirs,
 		}, true
 	}
 	// No change. Just return wm, since it is immutable.
-	return wm, false
+	return w, false
 }
 
 // goplsModURI returns the URI for the gopls.mod file contained in root.
@@ -424,7 +444,7 @@ const fileLimit = 1000000
 // searching stops once modLimit modules have been found.
 //
 // TODO(rfindley): consider overlays.
-func findModules(ctx context.Context, root span.URI, modLimit int) (map[span.URI]struct{}, error) {
+func findModules(ctx context.Context, root span.URI, excludePath func(string) bool, modLimit int) (map[span.URI]struct{}, error) {
 	// Walk the view's folder to find all modules in the view.
 	modFiles := make(map[span.URI]struct{})
 	searched := 0
@@ -441,7 +461,8 @@ func findModules(ctx context.Context, root span.URI, modLimit int) (map[span.URI
 			suffix := strings.TrimPrefix(path, root.Filename())
 			switch {
 			case checkIgnored(suffix),
-				strings.Contains(filepath.ToSlash(suffix), "/vendor/"):
+				strings.Contains(filepath.ToSlash(suffix), "/vendor/"),
+				excludePath(suffix):
 				return filepath.SkipDir
 			}
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/code_action.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/code_action.go
@@ -363,7 +363,7 @@ func diagnosticToAnalyzer(snapshot source.Snapshot, src, msg string) (analyzer *
 var importErrorRe = regexp.MustCompile(`could not import ([^\s]+)`)
 
 func goGetFixes(ctx context.Context, snapshot source.Snapshot, uri span.URI, diagnostics []protocol.Diagnostic) ([]protocol.CodeAction, error) {
-	if snapshot.GoModForFile(ctx, uri) == "" {
+	if snapshot.GoModForFile(uri) == "" {
 		// Go get only supports module mode for now.
 		return nil, nil
 	}
@@ -510,7 +510,7 @@ func moduleQuickFixes(ctx context.Context, snapshot source.Snapshot, fh source.V
 	case source.Mod:
 		modFH = fh
 	case source.Go:
-		modURI := snapshot.GoModForFile(ctx, fh.URI())
+		modURI := snapshot.GoModForFile(fh.URI())
 		if modURI == "" {
 			return nil, nil
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/debug/info.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/debug/info.go
@@ -9,8 +9,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"runtime/debug"
+	"sort"
 	"strings"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 )
 
 type PrintMode int
@@ -155,4 +159,98 @@ func printModuleInfo(w io.Writer, m *Module, mode PrintMode) {
 		fmt.Fprintf(w, " => %v", m.Replace.Path)
 	}
 	fmt.Fprintf(w, "\n")
+}
+
+type field struct {
+	index []int
+}
+
+var fields []field
+
+// find all the options. The presumption is that the Options are nested structs
+// and that pointers don't need to be dereferenced
+func swalk(t reflect.Type, ix []int, indent string) {
+	switch t.Kind() {
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			fld := t.Field(i)
+			ixx := append(append([]int{}, ix...), i)
+			swalk(fld.Type, ixx, indent+". ")
+		}
+	default:
+		// everything is either a struct or a field (that's an assumption about Options)
+		fields = append(fields, field{ix})
+	}
+}
+
+func showOptions(o *source.Options) []string {
+	// non-breaking spaces for indenting current and defaults when they are on a separate line
+	const indent = "\u00a0\u00a0\u00a0\u00a0\u00a0"
+	var ans strings.Builder
+	t := reflect.TypeOf(*o)
+	swalk(t, []int{}, "")
+	v := reflect.ValueOf(*o)
+	do := reflect.ValueOf(*source.DefaultOptions())
+	for _, f := range fields {
+		val := v.FieldByIndex(f.index)
+		def := do.FieldByIndex(f.index)
+		tx := t.FieldByIndex(f.index)
+		prefix := fmt.Sprintf("%s (type is %s): ", tx.Name, tx.Type)
+		is := strVal(val)
+		was := strVal(def)
+		if len(is) < 30 && len(was) < 30 {
+			fmt.Fprintf(&ans, "%s current:%s, default:%s\n", prefix, is, was)
+		} else {
+			fmt.Fprintf(&ans, "%s\n%scurrent:%s\n%sdefault:%s\n", prefix, indent, is, indent, was)
+		}
+	}
+	return strings.Split(ans.String(), "\n")
+}
+func strVal(val reflect.Value) string {
+	switch val.Kind() {
+	case reflect.Bool:
+		return fmt.Sprintf("%v", val.Interface())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return fmt.Sprintf("%v", val.Interface())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return fmt.Sprintf("%v", val.Interface())
+	case reflect.Uintptr, reflect.UnsafePointer:
+		return fmt.Sprintf("0x%x", val.Pointer())
+	case reflect.Complex64, reflect.Complex128:
+		return fmt.Sprintf("%v", val.Complex())
+	case reflect.Array, reflect.Slice:
+		ans := []string{}
+		for i := 0; i < val.Len(); i++ {
+			ans = append(ans, strVal(val.Index(i)))
+		}
+		sort.Strings(ans)
+		return fmt.Sprintf("%v", ans)
+	case reflect.Chan, reflect.Func, reflect.Ptr:
+		return val.Kind().String()
+	case reflect.Struct:
+		var x source.Analyzer
+		if val.Type() != reflect.TypeOf(x) {
+			return val.Kind().String()
+		}
+		// this is sort of ugly, but usable
+		str := val.FieldByName("Analyzer").Elem().FieldByName("Doc").String()
+		ix := strings.Index(str, "\n")
+		if ix == -1 {
+			ix = len(str)
+		}
+		return str[:ix]
+	case reflect.String:
+		return fmt.Sprintf("%q", val.Interface())
+	case reflect.Map:
+		ans := []string{}
+		iter := val.MapRange()
+		for iter.Next() {
+			k := iter.Key()
+			v := iter.Value()
+			ans = append(ans, fmt.Sprintf("%s:%s, ", strVal(k), strVal(v)))
+		}
+		sort.Strings(ans)
+		return fmt.Sprintf("%v", ans)
+	}
+	return fmt.Sprintf("??%s??", val.Type())
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/debug/log/log.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/debug/log/log.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package log provides helper methods for exporting log events to the
+// internal/event package.
+package log
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event/label"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag"
+)
+
+// Level parameterizes log severity.
+type Level int
+
+const (
+	_ Level = iota
+	Error
+	Warning
+	Info
+	Debug
+	Trace
+)
+
+// Log exports a log event labeled with level l.
+func (l Level) Log(ctx context.Context, msg string) {
+	event.Log(ctx, msg, tag.Level.Of(int(l)))
+}
+
+// Logf formats and exports a log event labeled with level l.
+func (l Level) Logf(ctx context.Context, format string, args ...interface{}) {
+	l.Log(ctx, fmt.Sprintf(format, args...))
+}
+
+// LabeledLevel extracts the labeled log l
+func LabeledLevel(lm label.Map) Level {
+	return Level(tag.Level.Get(lm))
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/debug/serve.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/debug/serve.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	stdlog "log"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -34,15 +34,19 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event/keys"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event/label"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/cache"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/log"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	errors "golang.org/x/xerrors"
 )
 
-type instanceKeyType int
+type contextKeyType int
 
-const instanceKey = instanceKeyType(0)
+const (
+	instanceKey contextKeyType = iota
+	traceKey
+)
 
 // An Instance holds all debug information associated with a gopls instance.
 type Instance struct {
@@ -373,7 +377,7 @@ func (i *Instance) SetLogFile(logfile string, isDaemon bool) (func(), error) {
 		closeLog = func() {
 			defer f.Close()
 		}
-		log.SetOutput(io.MultiWriter(os.Stderr, f))
+		stdlog.SetOutput(io.MultiWriter(os.Stderr, f))
 		i.LogWriter = f
 	}
 	i.Logfile = logfile
@@ -384,7 +388,7 @@ func (i *Instance) SetLogFile(logfile string, isDaemon bool) (func(), error) {
 // It also logs the port the server starts on, to allow for :0 auto assigned
 // ports.
 func (i *Instance) Serve(ctx context.Context) error {
-	log.SetFlags(log.Lshortfile)
+	stdlog.SetFlags(stdlog.Lshortfile)
 	if i.DebugAddress == "" {
 		return nil
 	}
@@ -396,7 +400,7 @@ func (i *Instance) Serve(ctx context.Context) error {
 
 	port := listener.Addr().(*net.TCPAddr).Port
 	if strings.HasSuffix(i.DebugAddress, ":0") {
-		log.Printf("debug server listening at http://localhost:%d", port)
+		stdlog.Printf("debug server listening at http://localhost:%d", port)
 	}
 	event.Log(ctx, "Debug serving", tag.Port.Of(port))
 	go func() {
@@ -520,13 +524,29 @@ func makeGlobalExporter(stderr io.Writer) event.Exporter {
 				p.WriteEvent(stderr, ev, lm)
 				pMu.Unlock()
 			}
+			level := log.LabeledLevel(lm)
+			// Exclude trace logs from LSP logs.
+			if level < log.Trace {
+				ctx = protocol.LogEvent(ctx, ev, lm, messageType(level))
+			}
 		}
-		ctx = protocol.LogEvent(ctx, ev, lm)
 		if i == nil {
 			return ctx
 		}
 		return i.exporter(ctx, ev, lm)
 	}
+}
+
+func messageType(l log.Level) protocol.MessageType {
+	switch l {
+	case log.Error:
+		return protocol.Error
+	case log.Warning:
+		return protocol.Warning
+	case log.Debug:
+		return protocol.Log
+	}
+	return protocol.Info
 }
 
 func makeInstanceExporter(i *Instance) event.Exporter {
@@ -573,6 +593,9 @@ func makeInstanceExporter(i *Instance) event.Exporter {
 		}
 		return ctx
 	}
+	// StdTrace must be above export.Spans below (by convention, export
+	// middleware applies its wrapped exporter last).
+	exporter = StdTrace(exporter)
 	metrics := metric.Config{}
 	registerMetrics(&metrics)
 	exporter = metrics.Exporter(exporter)
@@ -680,6 +703,9 @@ Unknown page
 		}
 		return s
 	},
+	"options": func(s *cache.Session) []string {
+		return showOptions(s.Options())
+	},
 })
 
 var mainTmpl = template.Must(template.Must(baseTemplate.Clone()).Parse(`
@@ -779,6 +805,8 @@ From: <b>{{template "cachelink" .Cache.ID}}</b><br>
 <ul>{{range .Views}}<li>{{.Name}} is {{template "viewlink" .ID}} in {{.Folder}}</li>{{end}}</ul>
 <h2>Overlays</h2>
 <ul>{{range .Overlays}}<li>{{template "filelink" .}}</li>{{end}}</ul>
+<h2>Options</h2>
+{{range options .}}<p>{{.}}{{end}}
 {{end}}
 `))
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag/tag.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag/tag.go
@@ -41,6 +41,8 @@ var (
 	DebugAddress = keys.NewString("debug_address", "")
 	GoplsPath    = keys.NewString("gopls_path", "")
 	ClientID     = keys.NewString("client_id", "")
+
+	Level = keys.NewInt("level", "The logging level")
 )
 
 var (

--- a/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/log"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/mod"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
@@ -68,19 +69,14 @@ func hashDiagnostics(diags ...*source.Diagnostic) string {
 func (s *Server) diagnoseDetached(snapshot source.Snapshot) {
 	ctx := snapshot.BackgroundContext()
 	ctx = xcontext.Detach(ctx)
-	showWarning := s.diagnose(ctx, snapshot, false)
-	if showWarning {
-		// If a view has been created or the configuration changed, warn the user.
-		s.client.ShowMessage(ctx, &protocol.ShowMessageParams{
-			Type:    protocol.Warning,
-			Message: `You are neither in a module nor in your GOPATH. If you are using modules, please open your editor to a directory in your module. If you believe this warning is incorrect, please file an issue: https://github.com/golang/go/issues/new.`,
-		})
-	}
+	s.diagnose(ctx, snapshot, false)
 	s.publishDiagnostics(ctx, true, snapshot)
 }
 
 func (s *Server) diagnoseSnapshot(snapshot source.Snapshot, changedURIs []span.URI, onDisk bool) {
 	ctx := snapshot.BackgroundContext()
+	ctx, done := event.Start(ctx, "Server.diagnoseSnapshot", tag.Snapshot.Of(snapshot.ID()))
+	defer done()
 
 	delay := snapshot.View().Options().ExperimentalDiagnosticsDelay
 	if delay > 0 {
@@ -106,7 +102,7 @@ func (s *Server) diagnoseSnapshot(snapshot source.Snapshot, changedURIs []span.U
 }
 
 func (s *Server) diagnoseChangedFiles(ctx context.Context, snapshot source.Snapshot, uris []span.URI, onDisk bool) {
-	ctx, done := event.Start(ctx, "Server.diagnoseChangedFiles")
+	ctx, done := event.Start(ctx, "Server.diagnoseChangedFiles", tag.Snapshot.Of(snapshot.ID()))
 	defer done()
 	packages := make(map[source.Package]struct{})
 	for _, uri := range uris {
@@ -138,7 +134,7 @@ func (s *Server) diagnoseChangedFiles(ctx context.Context, snapshot source.Snaps
 		go func(pkg source.Package) {
 			defer wg.Done()
 
-			_ = s.diagnosePkg(ctx, snapshot, pkg, false)
+			s.diagnosePkg(ctx, snapshot, pkg, false)
 		}(pkg)
 	}
 	wg.Wait()
@@ -146,14 +142,14 @@ func (s *Server) diagnoseChangedFiles(ctx context.Context, snapshot source.Snaps
 
 // diagnose is a helper function for running diagnostics with a given context.
 // Do not call it directly. forceAnalysis is only true for testing purposes.
-func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, forceAnalysis bool) bool {
-	ctx, done := event.Start(ctx, "Server.diagnose")
+func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, forceAnalysis bool) {
+	ctx, done := event.Start(ctx, "Server.diagnose", tag.Snapshot.Of(snapshot.ID()))
 	defer done()
 
 	// Wait for a free diagnostics slot.
 	select {
 	case <-ctx.Done():
-		return false
+		return
 	case s.diagnosticsSema <- struct{}{}:
 	}
 	defer func() {
@@ -163,7 +159,8 @@ func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, forceAn
 	// First, diagnose the go.mod file.
 	modReports, modErr := mod.Diagnostics(ctx, snapshot)
 	if ctx.Err() != nil {
-		return false
+		log.Trace.Log(ctx, "diagnose cancelled")
+		return
 	}
 	if modErr != nil {
 		event.Error(ctx, "warning: diagnose go.mod", modErr, tag.Directory.Of(snapshot.View().Folder().Filename()), tag.Snapshot.Of(snapshot.ID()))
@@ -179,7 +176,24 @@ func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, forceAn
 	// Diagnose all of the packages in the workspace.
 	wsPkgs, err := snapshot.WorkspacePackages(ctx)
 	if s.shouldIgnoreError(ctx, snapshot, err) {
-		return false
+		return
+	}
+	// Even if packages didn't fail to load, we still may want to show
+	// additional warnings.
+	if err == nil {
+		if msg := shouldShowAdHocPackagesWarning(snapshot, wsPkgs); msg != "" {
+			err = fmt.Errorf(msg)
+		}
+	}
+
+	// Even if workspace packages were returned, there still may be an error
+	// with the user's workspace layout. Workspace packages that only have the
+	// ID "command-line-arguments" are usually a symptom of a bad workspace
+	// configuration.
+	if containsCommandLineArguments(wsPkgs) {
+		if criticalErr := snapshot.WorkspaceLayoutError(ctx); criticalErr != nil {
+			err = criticalErr
+		}
 	}
 
 	// Show the error as a progress error report so that it appears in the
@@ -188,16 +202,15 @@ func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, forceAn
 	// error progress reports will be closed.
 	s.showCriticalErrorStatus(ctx, snapshot, err)
 
-	if err != nil {
-		event.Error(ctx, "errors diagnosing workspace", err, tag.Snapshot.Of(snapshot.ID()), tag.Directory.Of(snapshot.View().Folder()))
-		return false
+	// If there are no workspace packages, there is nothing to diagnose and
+	// there are no orphaned files.
+	if len(wsPkgs) == 0 {
+		return
 	}
 
 	var (
-		wg              sync.WaitGroup
-		shouldShowMsgMu sync.Mutex
-		shouldShowMsg   bool
-		seen            = map[span.URI]struct{}{}
+		wg   sync.WaitGroup
+		seen = map[span.URI]struct{}{}
 	)
 	for _, pkg := range wsPkgs {
 		wg.Add(1)
@@ -209,33 +222,28 @@ func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, forceAn
 		go func(pkg source.Package) {
 			defer wg.Done()
 
-			show := s.diagnosePkg(ctx, snapshot, pkg, forceAnalysis)
-			if show {
-				shouldShowMsgMu.Lock()
-				shouldShowMsg = true
-				shouldShowMsgMu.Unlock()
-			}
+			s.diagnosePkg(ctx, snapshot, pkg, forceAnalysis)
 		}(pkg)
 	}
 	wg.Wait()
+
 	// Confirm that every opened file belongs to a package (if any exist in
 	// the workspace). Otherwise, add a diagnostic to the file.
-	if len(wsPkgs) > 0 {
-		for _, o := range s.session.Overlays() {
-			if _, ok := seen[o.URI()]; ok {
-				continue
-			}
-			diagnostic := s.checkForOrphanedFile(ctx, snapshot, o)
-			if diagnostic == nil {
-				continue
-			}
-			s.storeDiagnostics(snapshot, o.URI(), orphanedSource, []*source.Diagnostic{diagnostic})
+	for _, o := range s.session.Overlays() {
+		if _, ok := seen[o.URI()]; ok {
+			continue
 		}
+		diagnostic := s.checkForOrphanedFile(ctx, snapshot, o)
+		if diagnostic == nil {
+			continue
+		}
+		s.storeDiagnostics(snapshot, o.URI(), orphanedSource, []*source.Diagnostic{diagnostic})
 	}
-	return shouldShowMsg
 }
 
-func (s *Server) diagnosePkg(ctx context.Context, snapshot source.Snapshot, pkg source.Package, alwaysAnalyze bool) bool {
+func (s *Server) diagnosePkg(ctx context.Context, snapshot source.Snapshot, pkg source.Package, alwaysAnalyze bool) {
+	ctx, done := event.Start(ctx, "Server.diagnosePkg", tag.Snapshot.Of(snapshot.ID()), tag.Package.Of(pkg.ID()))
+	defer done()
 	includeAnalysis := alwaysAnalyze // only run analyses for packages with open files
 	var gcDetailsDir span.URI        // find the package's optimization details, if available
 	for _, pgf := range pkg.CompiledGoFiles() {
@@ -261,7 +269,7 @@ func (s *Server) diagnosePkg(ctx context.Context, snapshot source.Snapshot, pkg 
 		reports, err := source.Analyze(ctx, snapshot, pkg, typeCheckResults)
 		if err != nil {
 			event.Error(ctx, "warning: diagnose package", err, tag.Snapshot.Of(snapshot.ID()), tag.Package.Of(pkg.ID()))
-			return false
+			return
 		}
 		for uri, diags := range reports {
 			s.storeDiagnostics(snapshot, uri, analysisSource, diags)
@@ -284,7 +292,6 @@ func (s *Server) diagnosePkg(ctx context.Context, snapshot source.Snapshot, pkg 
 			s.storeDiagnostics(snapshot, id.URI, gcDetailsSource, diags)
 		}
 	}
-	return shouldWarn(snapshot, pkg)
 }
 
 // storeDiagnostics stores results from a single diagnostic source. If merge is
@@ -319,21 +326,6 @@ func (s *Server) storeDiagnostics(snapshot source.Snapshot, uri span.URI, dsourc
 	s.diagnostics[uri].reports[dsource] = report
 }
 
-// shouldWarn reports whether we should warn the user about their build
-// configuration.
-func shouldWarn(snapshot source.Snapshot, pkg source.Package) bool {
-	if snapshot.ValidBuildConfiguration() {
-		return false
-	}
-	if len(pkg.MissingDependencies()) > 0 {
-		return true
-	}
-	if len(pkg.CompiledGoFiles()) == 1 && hasUndeclaredErrors(pkg) {
-		return true // The user likely opened a single file.
-	}
-	return false
-}
-
 // clearDiagnosticSource clears all diagnostics for a given source type. It is
 // necessary for cases where diagnostics have been invalidated by something
 // other than a snapshot change, for example when gc_details is toggled.
@@ -345,21 +337,23 @@ func (s *Server) clearDiagnosticSource(dsource diagnosticSource) {
 	}
 }
 
-// hasUndeclaredErrors returns true if a package has a type error
-// about an undeclared symbol.
-//
-// TODO(findleyr): switch to using error codes in 1.16
-func hasUndeclaredErrors(pkg source.Package) bool {
-	for _, err := range pkg.GetErrors() {
-		if err.Kind != source.TypeError {
-			continue
-		}
-		if strings.Contains(err.Message, "undeclared name:") {
-			return true
+const adHocPackagesWarning = `You are outside of a module and outside of $GOPATH/src.
+If you are using modules, please open your editor to a directory in your module.
+If you believe this warning is incorrect, please file an issue: https://github.com/golang/go/issues/new.`
+
+func shouldShowAdHocPackagesWarning(snapshot source.Snapshot, pkgs []source.Package) string {
+	if snapshot.ValidBuildConfiguration() {
+		return ""
+	}
+	for _, pkg := range pkgs {
+		if len(pkg.MissingDependencies()) > 0 {
+			return adHocPackagesWarning
 		}
 	}
-	return false
+	return ""
 }
+
+const WorkspaceLoadFailure = "Error loading workspace"
 
 // showCriticalErrorStatus shows the error as a progress report.
 // If the error is nil, it clears any existing error progress report.
@@ -371,21 +365,18 @@ func (s *Server) showCriticalErrorStatus(ctx context.Context, snapshot source.Sn
 	// status bar.
 	var errMsg string
 	if err != nil {
-		// Some error messages can also be displayed as diagnostics. But don't
-		// show source.ErrorLists as critical errors--only CriticalErrors
-		// should be shown.
+		event.Error(ctx, "errors loading workspace", err, tag.Snapshot.Of(snapshot.ID()), tag.Directory.Of(snapshot.View().Folder()))
+
+		// Some error messages can also be displayed as diagnostics.
 		if criticalErr := (*source.CriticalError)(nil); errors.As(err, &criticalErr) {
 			s.storeErrorDiagnostics(ctx, snapshot, typeCheckSource, criticalErr.ErrorList)
-		} else if srcErrList := (source.ErrorList)(nil); errors.As(err, &srcErrList) {
-			s.storeErrorDiagnostics(ctx, snapshot, typeCheckSource, srcErrList)
-			return
 		}
 		errMsg = strings.Replace(err.Error(), "\n", " ", -1)
 	}
 
 	if s.criticalErrorStatus == nil {
 		if errMsg != "" {
-			s.criticalErrorStatus = s.progress.start(ctx, "Error loading workspace", errMsg, nil, nil)
+			s.criticalErrorStatus = s.progress.start(ctx, WorkspaceLoadFailure, errMsg, nil, nil)
 		}
 		return
 	}
@@ -445,6 +436,8 @@ func (s *Server) storeErrorDiagnostics(ctx context.Context, snapshot source.Snap
 			Related:  e.Related,
 			Severity: protocol.SeverityError,
 			Source:   e.Category,
+			Code:     e.Code,
+			CodeHref: e.CodeHref,
 		}
 		s.storeDiagnostics(snapshot, e.URI, dsource, []*source.Diagnostic{diagnostic})
 	}
@@ -452,8 +445,16 @@ func (s *Server) storeErrorDiagnostics(ctx context.Context, snapshot source.Snap
 
 // publishDiagnostics collects and publishes any unpublished diagnostic reports.
 func (s *Server) publishDiagnostics(ctx context.Context, final bool, snapshot source.Snapshot) {
+	ctx, done := event.Start(ctx, "Server.publishDiagnostics", tag.Snapshot.Of(snapshot.ID()))
+	defer done()
 	s.diagnosticsMu.Lock()
 	defer s.diagnosticsMu.Unlock()
+
+	published := 0
+	defer func() {
+		log.Trace.Logf(ctx, "published %d diagnostics", published)
+	}()
+
 	for uri, r := range s.diagnostics {
 		// Snapshot IDs are always increasing, so we use them instead of file
 		// versions to create the correct order for diagnostics.
@@ -504,6 +505,7 @@ func (s *Server) publishDiagnostics(ctx context.Context, final bool, snapshot so
 			URI:         protocol.URIFromSpanURI(uri),
 			Version:     version,
 		}); err == nil {
+			published++
 			r.publishedHash = hash
 			r.snapshotID = snapshot.ID()
 			for dsource, hash := range reportHashes {
@@ -514,6 +516,7 @@ func (s *Server) publishDiagnostics(ctx context.Context, final bool, snapshot so
 		} else {
 			if ctx.Err() != nil {
 				// Publish may have failed due to a cancelled context.
+				log.Trace.Log(ctx, "publish cancelled")
 				return
 			}
 			event.Error(ctx, "publishReports: failed to deliver diagnostic", err, tag.URI.Of(uri))
@@ -534,7 +537,7 @@ func toProtocolDiagnostics(diagnostics []*source.Diagnostic) []protocol.Diagnost
 				Message: rel.Message,
 			})
 		}
-		reports = append(reports, protocol.Diagnostic{
+		pdiag := protocol.Diagnostic{
 			// diag.Message might start with \n or \t
 			Message:            strings.TrimSpace(diag.Message),
 			Range:              diag.Range,
@@ -542,7 +545,14 @@ func toProtocolDiagnostics(diagnostics []*source.Diagnostic) []protocol.Diagnost
 			Source:             diag.Source,
 			Tags:               diag.Tags,
 			RelatedInformation: related,
-		})
+		}
+		if diag.Code != "" {
+			pdiag.Code = diag.Code
+		}
+		if diag.CodeHref != "" {
+			pdiag.CodeDescription = &protocol.CodeDescription{Href: diag.CodeHref}
+		}
+		reports = append(reports, pdiag)
 	}
 	return reports
 }
@@ -567,4 +577,13 @@ func (s *Server) shouldIgnoreError(ctx context.Context, snapshot source.Snapshot
 		return errors.New("done")
 	})
 	return !hasGo
+}
+
+func containsCommandLineArguments(pkgs []source.Package) bool {
+	for _, pkg := range pkgs {
+		if strings.Contains(pkg.ID(), "command-line-arguments") {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
@@ -96,6 +96,8 @@ type EditorConfig struct {
 	// the PID. This can only be set by one test.
 	SendPID bool
 
+	DirectoryFilters []string
+
 	VerboseOutput bool
 }
 
@@ -197,7 +199,9 @@ func (e *Editor) configuration() map[string]interface{} {
 	if e.Config.BuildFlags != nil {
 		config["buildFlags"] = e.Config.BuildFlags
 	}
-
+	if e.Config.DirectoryFilters != nil {
+		config["directoryFilters"] = e.Config.DirectoryFilters
+	}
 	if e.Config.CodeLenses != nil {
 		config["codelenses"] = e.Config.CodeLenses
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/sandbox.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/sandbox.go
@@ -239,9 +239,9 @@ func (sb *Sandbox) RunGoCommand(ctx context.Context, dir, verb string, args []st
 		inv.WorkingDir = string(sb.Workdir.RelativeTo)
 	}
 	gocmdRunner := &gocommand.Runner{}
-	_, _, _, err := gocmdRunner.RunRaw(ctx, inv)
+	stdout, stderr, _, err := gocmdRunner.RunRaw(ctx, inv)
 	if err != nil {
-		return err
+		return errors.Errorf("go command failed (stdout: %s) (stderr: %s): %v", stdout.String(), stderr.String(), err)
 	}
 	// Since running a go command may result in changes to workspace files,
 	// check if we need to send any any "watched" file events.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/code_lens.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/code_lens.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"golang.org/x/mod/modfile"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
@@ -14,13 +15,13 @@ import (
 // LensFuncs returns the supported lensFuncs for go.mod files.
 func LensFuncs() map[string]source.LensFunc {
 	return map[string]source.LensFunc{
-		source.CommandUpgradeDependency.Name: upgradeLens,
+		source.CommandUpgradeDependency.Name: upgradeLenses,
 		source.CommandTidy.Name:              tidyLens,
 		source.CommandVendor.Name:            vendorLens,
 	}
 }
 
-func upgradeLens(ctx context.Context, snapshot source.Snapshot, fh source.FileHandle) ([]protocol.CodeLens, error) {
+func upgradeLenses(ctx context.Context, snapshot source.Snapshot, fh source.FileHandle) ([]protocol.CodeLens, error) {
 	pm, err := snapshot.ParseMod(ctx, fh)
 	if err != nil || pm.File == nil {
 		return nil, err
@@ -29,22 +30,41 @@ func upgradeLens(ctx context.Context, snapshot source.Snapshot, fh source.FileHa
 		// Nothing to upgrade.
 		return nil, nil
 	}
-	upgradeDepArgs, err := source.MarshalArgs(fh.URI(), false, []string{"-u", "all"})
+	upgradeTransitiveArgs, err := source.MarshalArgs(fh.URI(), false, []string{"-u", "all"})
 	if err != nil {
 		return nil, err
 	}
-	rng, err := moduleStmtRange(fh, pm)
+	var requires []string
+	for _, req := range pm.File.Require {
+		requires = append(requires, req.Mod.Path)
+	}
+	upgradeDirectArgs, err := source.MarshalArgs(fh.URI(), false, requires)
 	if err != nil {
 		return nil, err
 	}
-	return []protocol.CodeLens{{
-		Range: rng,
-		Command: protocol.Command{
-			Title:     "Upgrade all dependencies",
-			Command:   source.CommandUpgradeDependency.ID(),
-			Arguments: upgradeDepArgs,
+	// Put the upgrade code lenses above the first require block or statement.
+	rng, err := firstRequireRange(fh, pm)
+	if err != nil {
+		return nil, err
+	}
+	return []protocol.CodeLens{
+		{
+			Range: rng,
+			Command: protocol.Command{
+				Title:     "Upgrade transitive dependencies",
+				Command:   source.CommandUpgradeDependency.ID(),
+				Arguments: upgradeTransitiveArgs,
+			},
 		},
-	}}, nil
+		{
+			Range: rng,
+			Command: protocol.Command{
+				Title:     "Upgrade direct dependencies",
+				Command:   source.CommandUpgradeDependency.ID(),
+				Arguments: upgradeDirectArgs,
+			},
+		},
+	}, nil
 
 }
 
@@ -110,19 +130,40 @@ func moduleStmtRange(fh source.FileHandle, pm *source.ParsedModule) (protocol.Ra
 		return protocol.Range{}, fmt.Errorf("no module statement in %s", fh.URI())
 	}
 	syntax := pm.File.Module.Syntax
-	line, col, err := pm.Mapper.Converter.ToPosition(syntax.Start.Byte)
+	return lineToRange(pm.Mapper, fh.URI(), syntax.Start, syntax.End)
+}
+
+// firstRequireRange returns the range for the first "require" in the given
+// go.mod file. This is either a require block or an individual require line.
+func firstRequireRange(fh source.FileHandle, pm *source.ParsedModule) (protocol.Range, error) {
+	if len(pm.File.Require) == 0 {
+		return protocol.Range{}, fmt.Errorf("no requires in the file %s", fh.URI())
+	}
+	var start, end modfile.Position
+	for _, stmt := range pm.File.Syntax.Stmt {
+		if b, ok := stmt.(*modfile.LineBlock); ok && len(b.Token) == 1 && b.Token[0] == "require" {
+			start, end = b.Span()
+			break
+		}
+	}
+
+	firstRequire := pm.File.Require[0].Syntax
+	if firstRequire.Start.Byte < start.Byte {
+		start, end = firstRequire.Start, firstRequire.End
+	}
+	return lineToRange(pm.Mapper, fh.URI(), start, end)
+}
+
+func lineToRange(m *protocol.ColumnMapper, uri span.URI, start, end modfile.Position) (protocol.Range, error) {
+	line, col, err := m.Converter.ToPosition(start.Byte)
 	if err != nil {
 		return protocol.Range{}, err
 	}
-	start := span.NewPoint(line, col, syntax.Start.Byte)
-	line, col, err = pm.Mapper.Converter.ToPosition(syntax.End.Byte)
+	s := span.NewPoint(line, col, start.Byte)
+	line, col, err = m.Converter.ToPosition(end.Byte)
 	if err != nil {
 		return protocol.Range{}, err
 	}
-	end := span.NewPoint(line, col, syntax.End.Byte)
-	rng, err := pm.Mapper.Range(span.New(fh.URI(), start, end))
-	if err != nil {
-		return protocol.Range{}, err
-	}
-	return rng, err
+	e := span.NewPoint(line, col, end.Byte)
+	return m.Range(span.New(uri, s, e))
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/diagnostics.go
@@ -69,8 +69,6 @@ func ErrorsForMod(ctx context.Context, snapshot source.Snapshot, fh source.FileH
 		// Some error messages can also be displayed as diagnostics.
 		if criticalErr := (*source.CriticalError)(nil); errors.As(err, &criticalErr) {
 			return criticalErr.ErrorList, nil
-		} else if srcErrList := (source.ErrorList)(nil); errors.As(err, &srcErrList) {
-			return srcErrList, nil
 		}
 		return nil, err
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/context.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/context.go
@@ -21,18 +21,16 @@ func WithClient(ctx context.Context, client Client) context.Context {
 	return context.WithValue(ctx, clientKey, client)
 }
 
-func LogEvent(ctx context.Context, ev core.Event, tags label.Map) context.Context {
-	if !event.IsLog(ev) {
-		return ctx
-	}
+func LogEvent(ctx context.Context, ev core.Event, lm label.Map, mt MessageType) context.Context {
 	client, ok := ctx.Value(clientKey).(Client)
 	if !ok {
 		return ctx
 	}
 	buf := &bytes.Buffer{}
 	p := export.Printer{}
-	p.WriteEvent(buf, ev, tags)
-	msg := &LogMessageParams{Type: Info, Message: buf.String()}
+	p.WriteEvent(buf, ev, lm)
+	msg := &LogMessageParams{Type: mt, Message: buf.String()}
+	// Handle messages generated via event.Error, which won't have a level Label.
 	if event.IsError(ev) {
 		msg.Type = Error
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -166,7 +166,7 @@ var GeneratedAPIJSON = &APIJSON{
 			{
 				Name:       "codelenses",
 				Type:       "map[string]bool",
-				Doc:        "codelenses overrides the enabled/disabled state of code lenses. See the \"Code Lenses\"\nsection of settings.md for the list of supported lenses.\n\nExample Usage:\n```json5\n\"gopls\": {\n...\n  \"codelens\": {\n    \"generate\": false,  // Don't show the `go generate` lens.\n    \"gc_details\": true  // Show a code lens toggling the display of gc's choices.\n  }\n...\n}\n```\n",
+				Doc:        "codelenses overrides the enabled/disabled state of code lenses. See the \"Code Lenses\"\nsection of settings.md for the list of supported lenses.\n\nExample Usage:\n```json5\n\"gopls\": {\n...\n  \"codelenses\": {\n    \"generate\": false,  // Don't show the `go generate` lens.\n    \"gc_details\": true  // Show a code lens toggling the display of gc's choices.\n  }\n...\n}\n```\n",
 				EnumValues: nil,
 				Default:    "{\"gc_details\":false,\"generate\":true,\"regenerate_cgo\":true,\"tidy\":true,\"upgrade_dependency\":true,\"vendor\":true}",
 			},
@@ -256,6 +256,13 @@ var GeneratedAPIJSON = &APIJSON{
 					},
 				},
 				Default: "\"Dynamic\"",
+			},
+			{
+				Name:       "directoryFilters",
+				Type:       "[]string",
+				Doc:        "directoryFilters can be used to exclude unwanted directories from the\nworkspace. By default, all directories are included. Filters are an\noperator, `+` to include and `-` to exclude, followed by a path prefix\nrelative to the workspace folder. They are evaluated in order, and\nthe last filter that applies to a path controls whether it is included.\nThe path prefix can be empty, so an initial `-` excludes everything.\n\nExamples:\nExclude node_modules: `-node_modules`\nInclude only project_a: `-` (exclude everything), `+project_a`\nInclude only project_a, but not node_modules inside it: `-`, `+project_a`, `-project_a/node_modules`\n",
+				EnumValues: nil,
+				Default:    "[]",
 			},
 		},
 	},

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
@@ -1284,12 +1284,10 @@ func (c *completer) lexical(ctx context.Context) error {
 				}
 			}
 
-			// Don't use LHS of value spec in RHS.
-			if vs := enclosingValueSpec(c.path); vs != nil {
-				for _, ident := range vs.Names {
-					if obj.Pos() == ident.Pos() {
-						continue Names
-					}
+			// Don't use LHS of decl in RHS.
+			for _, ident := range enclosingDeclLHS(c.path) {
+				if obj.Pos() == ident.Pos() {
+					continue Names
 				}
 			}
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/util.go
@@ -195,10 +195,21 @@ func enclosingSelector(path []ast.Node, pos token.Pos) *ast.SelectorExpr {
 	return nil
 }
 
-func enclosingValueSpec(path []ast.Node) *ast.ValueSpec {
+// enclosingDeclLHS returns LHS idents from containing value spec or
+// assign statement.
+func enclosingDeclLHS(path []ast.Node) []*ast.Ident {
 	for _, n := range path {
-		if vs, ok := n.(*ast.ValueSpec); ok {
-			return vs
+		switch n := n.(type) {
+		case *ast.ValueSpec:
+			return n.Names
+		case *ast.AssignStmt:
+			ids := make([]*ast.Ident, 0, len(n.Lhs))
+			for _, e := range n.Lhs {
+				if id, ok := e.(*ast.Ident); ok {
+					ids = append(ids, id)
+				}
+			}
+			return ids
 		}
 	}
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/diagnostics.go
@@ -18,6 +18,8 @@ type Diagnostic struct {
 	Range    protocol.Range
 	Message  string
 	Source   string
+	Code     string
+	CodeHref string
 	Severity protocol.DiagnosticSeverity
 	Tags     []protocol.DiagnosticTag
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
@@ -7,6 +7,7 @@ package source
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -234,7 +235,7 @@ type UserOptions struct {
 	// ```json5
 	// "gopls": {
 	// ...
-	//   "codelens": {
+	//   "codelenses": {
 	//     "generate": false,  // Don't show the `go generate` lens.
 	//     "gc_details": true  // Show a code lens toggling the display of gc's choices.
 	//   }
@@ -267,6 +268,19 @@ type UserOptions struct {
 	// }
 	// ```
 	SymbolStyle SymbolStyle
+
+	// DirectoryFilters can be used to exclude unwanted directories from the
+	// workspace. By default, all directories are included. Filters are an
+	// operator, `+` to include and `-` to exclude, followed by a path prefix
+	// relative to the workspace folder. They are evaluated in order, and
+	// the last filter that applies to a path controls whether it is included.
+	// The path prefix can be empty, so an initial `-` excludes everything.
+	//
+	// Examples:
+	// Exclude node_modules: `-node_modules`
+	// Include only project_a: `-` (exclude everything), `+project_a`
+	// Include only project_a, but not node_modules inside it: `-`, `+project_a`, `-project_a/node_modules`
+	DirectoryFilters []string
 }
 
 // EnvSlice returns Env as a slice of k=v strings.
@@ -606,6 +620,7 @@ func (o *Options) Clone() *Options {
 	}
 	result.SetEnvSlice(o.EnvSlice())
 	result.BuildFlags = copySlice(o.BuildFlags)
+	result.DirectoryFilters = copySlice(o.DirectoryFilters)
 
 	copyAnalyzerMap := func(src map[string]Analyzer) map[string]Analyzer {
 		dst := make(map[string]Analyzer)
@@ -665,7 +680,22 @@ func (o *Options) set(name string, value interface{}) OptionResult {
 			flags = append(flags, fmt.Sprintf("%s", flag))
 		}
 		o.BuildFlags = flags
-
+	case "directoryFilters":
+		ifilters, ok := value.([]interface{})
+		if !ok {
+			result.errorf("invalid type %T, expect list", value)
+			break
+		}
+		var filters []string
+		for _, ifilter := range ifilters {
+			filter := fmt.Sprint(ifilter)
+			if filter[0] != '+' && filter[0] != '-' {
+				result.errorf("invalid filter %q, must start with + or -", filter)
+				return result
+			}
+			filters = append(filters, filepath.FromSlash(filter))
+		}
+		o.DirectoryFilters = filters
 	case "completionDocumentation":
 		result.setBool(&o.CompletionDocumentation)
 	case "usePlaceholders":

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/types_format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/types_format.go
@@ -282,10 +282,7 @@ func qualifyExpr(expr ast.Expr, srcpkg, pkg Package, clonedInfo map[token.Pos]*t
 			if !ok {
 				return false
 			}
-			pkgName := qf(obj.Imported())
-			if pkgName != "" {
-				x.Name = pkgName
-			}
+			x.Name = qf(obj.Imported())
 			return false
 		case *ast.Ident:
 			if srcpkg == pkg {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/text_synchronization.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/text_synchronization.go
@@ -221,21 +221,12 @@ func (s *Server) didModifyFiles(ctx context.Context, modifications []source.File
 	// to their files.
 	modifications = s.session.ExpandModificationsToDirectories(ctx, modifications)
 
-	views, snapshots, releases, err := s.session.DidModifyFiles(ctx, modifications)
+	snapshots, releases, err := s.session.DidModifyFiles(ctx, modifications)
 	if err != nil {
 		return err
 	}
 
-	// Group files by best view and diagnose them.
-	viewURIs := map[source.View][]span.URI{}
-	for uri, view := range views {
-		viewURIs[view] = append(viewURIs[view], uri)
-	}
-	for view, uris := range viewURIs {
-		snapshot := snapshots[view]
-		if snapshot == nil {
-			panic(fmt.Sprintf("no snapshot assigned for files %v", uris))
-		}
+	for snapshot, uris := range snapshots {
 		diagnosticWG.Add(1)
 		go func(snapshot source.Snapshot, uris []span.URI) {
 			defer diagnosticWG.Done()

--- a/cmd/govim/internal/golang_org_x_tools/typesinternal/types.go
+++ b/cmd/govim/internal/golang_org_x_tools/typesinternal/types.go
@@ -2,9 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Package typesinternal provides access to internal go/types APIs that are not
+// yet exported.
 package typesinternal
 
 import (
+	"go/token"
 	"go/types"
 	"reflect"
 	"unsafe"
@@ -25,4 +28,18 @@ func SetUsesCgo(conf *types.Config) bool {
 	*(*bool)(addr) = true
 
 	return true
+}
+
+func ReadGo116ErrorData(terr types.Error) (ErrorCode, token.Pos, token.Pos, bool) {
+	var data [3]int
+	// By coincidence all of these fields are ints, which simplifies things.
+	v := reflect.ValueOf(terr)
+	for i, name := range []string{"go116code", "go116start", "go116end"} {
+		f := v.FieldByName(name)
+		if !f.IsValid() {
+			return 0, 0, 0, false
+		}
+		data[i] = int(f.Int())
+	}
+	return ErrorCode(data[0]), token.Pos(data[1]), token.Pos(data[2]), true
 }

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.6.2
 	golang.org/x/mod v0.3.0
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/tools v0.0.0-20201206230334-368bee879bfd
-	golang.org/x/tools/gopls v0.0.0-20201206230334-368bee879bfd
+	golang.org/x/tools v0.0.0-20201215192005-fa10ef0b8743
+	golang.org/x/tools/gopls v0.0.0-20201215192005-fa10ef0b8743
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -80,10 +80,10 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201021214918-23787c007979/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
-golang.org/x/tools v0.0.0-20201206230334-368bee879bfd h1:EqFvKLTxjH6gEy2baWxX2AgJwZkBIDIcZFYcoYlI9RA=
-golang.org/x/tools v0.0.0-20201206230334-368bee879bfd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools/gopls v0.0.0-20201206230334-368bee879bfd h1:GW+bz0wKmXeWOz3+dFfaF3j7Qqrzvl8Q01Z0qUBTvaw=
-golang.org/x/tools/gopls v0.0.0-20201206230334-368bee879bfd/go.mod h1:dX4r01tsFuvQkDBSUrhuPQtUNJgbKBje5tyWxNhT0NI=
+golang.org/x/tools v0.0.0-20201215192005-fa10ef0b8743 h1:SLHKXsC4wI4NdEGVGe/yxcTBkF/mPUS7agW3Qt5smVg=
+golang.org/x/tools v0.0.0-20201215192005-fa10ef0b8743/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools/gopls v0.0.0-20201215192005-fa10ef0b8743 h1:pLG6A3++lBtPx/MOvyTsX/OnnSVu0ZUUBNguR/Pznrc=
+golang.org/x/tools/gopls v0.0.0-20201215192005-fa10ef0b8743/go.mod h1:dX4r01tsFuvQkDBSUrhuPQtUNJgbKBje5tyWxNhT0NI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/lsp/source: update codelenses example fa10ef0b
* go/analysis/passes/fieldalignment: support fields without name 6307297f
* internal/lsp/debug: hook runtime/trace into event spans d93e913c
* go/analysis/passes/structtag: recognize multiple keys per tag abf6a1d8
* gopls/internal/regtest: remove redundant 'With' from run options 6d345e82
* internal/lsp: add an orphaned file diagnostic for nested modules f31efc5a
* internal/lsp/debug: show Options in gopls debug server b71f123c
* internal/lsp: only diagnose views affected by a change a543418b
* internal/lsp: remove the last diagnostics pop-up warning 5cdc2744
* gopls/internal/regtest: skip builders on which regtests time out ef0c6350
* go/analysis/passes/framepointer: don't report on runtime package de58e7c0
* internal/lsp/mod: add an "Upgrade direct dependencies" code lens 5737becd
* internal/lsp: support directory inclusion/exclusion filters cc330816
* internal/lsp: show multiple modules error message with GO111MODULE=auto e652b2f4
* internal/lsp: delete workspace package IDs after package name change 66f93157
* internal/lsp/source: omit assign stmt LHS in RHS completion a835c872
* internal/lsp/source: fix default param name generation 7bb39e4c
* internal/imports: prevent panic in imports GOMODCACHE logic 1dfd70e0
* internal/lsp/source: simplify workspace symbol package collection 627cb6d6
* internal/lsp/cache: build a go.sum file for multi-module workspaces 9a3a6c5f
* internal/lsp/cache: remove test variants from workspace packages 56794389
* internal/typesinternal: use Go 1.16 metadata for go/types errors 6d2eea54
* godoc: change godoc.org links to pkg.go.dev 05664e2e