### PR TITLE
deps: update x/tools and gopls to ae774e97

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/mod_tidy.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/mod_tidy.go
@@ -209,6 +209,7 @@ See https://github.com/golang/go/issues/39164 for more detail on this issue.`,
 				Message: `go.sum is out of sync with go.mod. Please update it or run "go mod tidy".`,
 				SuggestedFixes: []source.SuggestedFix{
 					{
+						Title: source.CommandTidy.Title,
 						Command: &protocol.Command{
 							Command:   source.CommandTidy.ID(),
 							Title:     source.CommandTidy.Title,
@@ -216,6 +217,7 @@ See https://github.com/golang/go/issues/39164 for more detail on this issue.`,
 						},
 					},
 					{
+						Title: source.CommandUpdateGoSum.Title,
 						Command: &protocol.Command{
 							Command:   source.CommandUpdateGoSum.ID(),
 							Title:     source.CommandUpdateGoSum.Title,
@@ -509,7 +511,10 @@ func switchDirectness(req *modfile.Require, m *protocol.ColumnMapper, computeEdi
 		return nil, err
 	}
 	// Calculate the edits to be made due to the change.
-	diff := computeEdits(m.URI, string(m.Content), string(newContent))
+	diff, err := computeEdits(m.URI, string(m.Content), string(newContent))
+	if err != nil {
+		return nil, err
+	}
 	return source.ToProtocolEdits(m, diff)
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/workspace.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/workspace.go
@@ -271,7 +271,8 @@ func (w *workspace) invalidate(ctx context.Context, changes map[span.URI]*fileCh
 		gmURI := goplsModURI(w.root)
 		if change, ok := changes[gmURI]; ok {
 			if change.exists {
-				// Only invalidate if the gopls.mod actually parses. Otherwise, stick with the current gopls.mod
+				// Only invalidate if the gopls.mod actually parses.
+				// Otherwise, stick with the current gopls.mod.
 				parsedFile, parsedModules, err := parseGoplsMod(w.root, gmURI, change.content)
 				if err == nil {
 					modFile = parsedFile

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/definition.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/definition.go
@@ -51,7 +51,10 @@ func (r *runner) Definition(t *testing.T, spn span.Span, d tests.Definition) {
 			return []byte(got), nil
 		})))
 		if expect != "" && !strings.HasPrefix(got, expect) {
-			d := myers.ComputeEdits("", expect, got)
+			d, err := myers.ComputeEdits("", expect, got)
+			if err != nil {
+				t.Fatal(err)
+			}
 			t.Errorf("definition %v failed with %#v\n%s", tag, args, diff.ToUnified("expect", "got", expect, d))
 		}
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/imports.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/imports.go
@@ -20,7 +20,10 @@ func (r *runner) Import(t *testing.T, spn span.Span) {
 		return []byte(got), nil
 	}))
 	if want != got {
-		d := myers.ComputeEdits(uri, want, got)
+		d, err := myers.ComputeEdits(uri, want, got)
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Errorf("imports failed for %s, expected:\n%s", filename, diff.ToUnified("want", "got", want, d))
 	}
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/suggested_fix.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/suggested_fix.go
@@ -30,6 +30,6 @@ func (r *runner) SuggestedFix(t *testing.T, spn span.Span, actionKinds []string,
 		return []byte(got), nil
 	}))
 	if want != got {
-		t.Errorf("suggested fixes failed for %s:\n%s", filename, tests.Diff(want, got))
+		t.Errorf("suggested fixes failed for %s:\n%s", filename, tests.Diff(t, want, got))
 	}
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/workspace_symbol.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/workspace_symbol.go
@@ -48,6 +48,6 @@ func (r *runner) runWorkspaceSymbols(t *testing.T, uri span.URI, matcher, query 
 	}))
 
 	if expect != got {
-		t.Errorf("workspace_symbol failed for %s:\n%s", query, tests.Diff(expect, got))
+		t.Errorf("workspace_symbol failed for %s:\n%s", query, tests.Diff(t, expect, got))
 	}
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
@@ -369,7 +369,7 @@ func (s *Server) showCriticalErrorStatus(ctx context.Context, snapshot source.Sn
 
 		// Some error messages can also be displayed as diagnostics.
 		if criticalErr := (*source.CriticalError)(nil); errors.As(err, &criticalErr) {
-			s.storeErrorDiagnostics(ctx, snapshot, typeCheckSource, criticalErr.ErrorList)
+			s.storeErrorDiagnostics(ctx, snapshot, modSource, criticalErr.ErrorList)
 		}
 		errMsg = strings.Replace(err.Error(), "\n", " ", -1)
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/diff/diff.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/diff/diff.go
@@ -21,7 +21,7 @@ type TextEdit struct {
 
 // ComputeEdits is the type for a function that produces a set of edits that
 // convert from the before content to the after content.
-type ComputeEdits func(uri span.URI, before, after string) []TextEdit
+type ComputeEdits func(uri span.URI, before, after string) ([]TextEdit, error)
 
 // SortTextEdits attempts to order all edits by their starting points.
 // The sort is stable so that edits with the same starting point will not

--- a/cmd/govim/internal/golang_org_x_tools/lsp/diff/difftest/difftest.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/diff/difftest/difftest.go
@@ -222,7 +222,10 @@ func DiffTest(t *testing.T, compute diff.ComputeEdits) {
 	for _, test := range TestCases {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Helper()
-			edits := compute(span.URIFromPath("/"+test.Name), test.In, test.Out)
+			edits, err := compute(span.URIFromPath("/"+test.Name), test.In, test.Out)
+			if err != nil {
+				t.Fatal(err)
+			}
 			got := diff.ApplyEdits(test.In, edits)
 			unified := fmt.Sprint(diff.ToUnified(FileA, FileB, test.In, edits))
 			if got != test.Out {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/diff/myers/diff.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/diff/myers/diff.go
@@ -16,7 +16,7 @@ import (
 // https://blog.jcoglan.com/2017/02/17/the-myers-diff-algorithm-part-3/
 // https://www.codeproject.com/Articles/42279/%2FArticles%2F42279%2FInvestigating-Myers-diff-algorithm-Part-1-of-2
 
-func ComputeEdits(uri span.URI, before, after string) []diff.TextEdit {
+func ComputeEdits(uri span.URI, before, after string) ([]diff.TextEdit, error) {
 	ops := operations(splitLines(before), splitLines(after))
 	edits := make([]diff.TextEdit, 0, len(ops))
 	for _, op := range ops {
@@ -32,7 +32,7 @@ func ComputeEdits(uri span.URI, before, after string) []diff.TextEdit {
 			}
 		}
 	}
-	return edits
+	return edits, nil
 }
 
 type operation struct {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/format.go
@@ -21,6 +21,9 @@ func Format(ctx context.Context, snapshot source.Snapshot, fh source.FileHandle)
 		return nil, err
 	}
 	// Calculate the edits to be made due to the change.
-	diff := snapshot.View().Options().ComputeEdits(fh.URI(), string(pm.Mapper.Content), string(formatted))
+	diff, err := snapshot.View().Options().ComputeEdits(fh.URI(), string(pm.Mapper.Content), string(formatted))
+	if err != nil {
+		return nil, err
+	}
 	return source.ToProtocolEdits(pm.Mapper, diff)
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/code_lens.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/code_lens.go
@@ -71,27 +71,29 @@ func runTestCodeLens(ctx context.Context, snapshot Snapshot, fh FileHandle) ([]p
 		})
 	}
 
-	_, pgf, err := GetParsedFile(ctx, snapshot, fh, WidestPackage)
-	if err != nil {
-		return nil, err
+	if len(fns.Benchmarks) > 0 {
+		_, pgf, err := GetParsedFile(ctx, snapshot, fh, WidestPackage)
+		if err != nil {
+			return nil, err
+		}
+		// add a code lens to the top of the file which runs all benchmarks in the file
+		rng, err := NewMappedRange(snapshot.FileSet(), pgf.Mapper, pgf.File.Package, pgf.File.Package).Range()
+		if err != nil {
+			return nil, err
+		}
+		args, err := MarshalArgs(fh.URI(), []string{}, fns.Benchmarks)
+		if err != nil {
+			return nil, err
+		}
+		codeLens = append(codeLens, protocol.CodeLens{
+			Range: rng,
+			Command: protocol.Command{
+				Title:     "run file benchmarks",
+				Command:   CommandTest.ID(),
+				Arguments: args,
+			},
+		})
 	}
-	// add a code lens to the top of the file which runs all benchmarks in the file
-	rng, err := NewMappedRange(snapshot.FileSet(), pgf.Mapper, pgf.File.Package, pgf.File.Package).Range()
-	if err != nil {
-		return nil, err
-	}
-	args, err := MarshalArgs(fh.URI(), []string{}, fns.Benchmarks)
-	if err != nil {
-		return nil, err
-	}
-	codeLens = append(codeLens, protocol.CodeLens{
-		Range: rng,
-		Command: protocol.Command{
-			Title:     "run file benchmarks",
-			Command:   CommandTest.ID(),
-			Arguments: args,
-		},
-	})
 	return codeLens, nil
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/format.go
@@ -173,7 +173,10 @@ func computeFixEdits(snapshot Snapshot, pgf *ParsedGoFile, options *imports.Opti
 	if fixedData == nil || fixedData[len(fixedData)-1] != '\n' {
 		fixedData = append(fixedData, '\n') // ApplyFixes may miss the newline, go figure.
 	}
-	edits := snapshot.View().Options().ComputeEdits(pgf.URI, left, string(fixedData))
+	edits, err := snapshot.View().Options().ComputeEdits(pgf.URI, left, string(fixedData))
+	if err != nil {
+		return nil, err
+	}
 	return ToProtocolEdits(pgf.Mapper, edits)
 }
 
@@ -270,7 +273,10 @@ func computeTextEdits(ctx context.Context, snapshot Snapshot, pgf *ParsedGoFile,
 	_, done := event.Start(ctx, "source.computeTextEdits")
 	defer done()
 
-	edits := snapshot.View().Options().ComputeEdits(pgf.URI, string(pgf.Src), formatted)
+	edits, err := snapshot.View().Options().ComputeEdits(pgf.URI, string(pgf.Src), formatted)
+	if err != nil {
+		return nil, err
+	}
 	return ToProtocolEdits(pgf.Mapper, edits)
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/tests/tests.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/tests/tests.go
@@ -880,7 +880,7 @@ func checkData(t *testing.T, data *Data) {
 	}))
 	got := buf.String()
 	if want != got {
-		t.Errorf("test summary does not match:\n%s", Diff(want, got))
+		t.Errorf("test summary does not match:\n%s", Diff(t, want, got))
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rogpeppe/go-internal v1.6.2
 	golang.org/x/mod v0.3.0
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/tools v0.0.0-20201215192005-fa10ef0b8743
-	golang.org/x/tools/gopls v0.0.0-20201215192005-fa10ef0b8743
+	golang.org/x/tools v0.0.0-20201218024724-ae774e9781d2
+	golang.org/x/tools/gopls v0.0.0-20201218024724-ae774e9781d2
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -80,10 +80,10 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201021214918-23787c007979/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
-golang.org/x/tools v0.0.0-20201215192005-fa10ef0b8743 h1:SLHKXsC4wI4NdEGVGe/yxcTBkF/mPUS7agW3Qt5smVg=
-golang.org/x/tools v0.0.0-20201215192005-fa10ef0b8743/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools/gopls v0.0.0-20201215192005-fa10ef0b8743 h1:pLG6A3++lBtPx/MOvyTsX/OnnSVu0ZUUBNguR/Pznrc=
-golang.org/x/tools/gopls v0.0.0-20201215192005-fa10ef0b8743/go.mod h1:dX4r01tsFuvQkDBSUrhuPQtUNJgbKBje5tyWxNhT0NI=
+golang.org/x/tools v0.0.0-20201218024724-ae774e9781d2 h1:lHDhNNs7asPT3p01mm8EP3B+bNyyVfg0bcYjhJUYgxw=
+golang.org/x/tools v0.0.0-20201218024724-ae774e9781d2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools/gopls v0.0.0-20201218024724-ae774e9781d2 h1:vgNiT/DVBx0Bf80IRe0SL1hmoOiqFeCmzvj4QGhqhRQ=
+golang.org/x/tools/gopls v0.0.0-20201218024724-ae774e9781d2/go.mod h1:dX4r01tsFuvQkDBSUrhuPQtUNJgbKBje5tyWxNhT0NI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/lsp: don't show duplicate diagnostics for go.mod errors ae774e97
* internal/lsp/source: only show "run file benchmarks" if available 5b06639e
* gopls/internal/regtest: test metadata validation only on save for go.mod 11a5667e
* go/analysis/passes/fieldalignment: filter comments from suggested fix 5b43ef93
* gopls/internal/regtest: test that accepting fix removes diagnostics 4b31ac34
* internal/lsp, gopls: recover from go-diff panics 008e4774
* internal/lsp: add titles to `go mod tidy` and update go.sum fixes 48e5bd11