### PR TITLE
Support "goimports-gofmt" value for FormatOnSave

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -35,7 +35,7 @@ function! s:pushConfig()
 endfunction
 
 function! s:validFormatOnSave(v)
-  let valid = ["", "gofmt", "goimports"]
+  let valid = ["", "gofmt", "goimports", "goimports-gofmt"]
   if index(valid, a:v) < 0
     return [v:false, "must be one of: ".string(valid)]
   endif


### PR DESCRIPTION
As stated in godoc `FormatOnSave` accepts `goimports-gofmt` const. But this value has not been added to validation function thus after adding line to `vimrc`:

```
call govim#config#Set("FormatOnSave", "goimports-gofmt")
```
exception occures:

```
E605: Exception not caught: Tried to set invalid value for key FormatOnSave: must be one of: ['', 'gofmt', 'goimports']
```

This PR fixes above mentioned issue.