### PR TITLE
Support DirectoryFilters config option for gopls

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -136,6 +136,18 @@ function! s:validGoplsEnv(v)
   return [v:true, ""]
 endfunction
 
+function! s:validGoplsDirectoryFilters(v)
+  if type(a:v) != 3
+    return [v:false, "value must be a list"]
+  endif
+  for item in a:v
+    if type(item) != 1
+      return [v:false, "value must be a string"]
+    endif
+  endfor
+  return [v:true, ""]
+endfunction
+
 function! s:validAnalyses(v)
   if type(a:v) != 4
     return [v:false, "must be of type dict"]
@@ -211,6 +223,7 @@ let s:validators = {
       \ "CompletionBudget": function("s:validCompletionBudget"),
       \ "TempModfile": function("s:validTempModfile"),
       \ "GoplsEnv": function("s:validGoplsEnv"),
+      \ "GoplsDirectoryFilters": function("s:validGoplsDirectoryFilters"),
       \ "Analyses": function("s:validAnalyses"),
       \ "OpenLastProgressWith": function("s:openLastProgressWith"),
       \ "Gofumpt": function("s:validGofumpt"),

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -175,6 +175,18 @@ type Config struct {
 	// GOFLAGS=-modfile=go.local.mod in order to use an alternative go.mod file.
 	GoplsEnv *map[string]string `json:",omitempty"`
 
+	// GoplsDirectoryFilters can be used to exclude unwanted directories from the
+	// workspace. By default, all directories are included. Filters are an
+	// operator, `+` to include and `-` to exclude, followed by a path prefix
+	// relative to the workspace folder. They are evaluated in order, and
+	// the last filter that applies to a path controls whether it is included.
+	// The path prefix can be empty, so an initial `-` excludes everything.
+	//
+	// For more details and examples see:
+	//
+	// https://github.com/golang/tools/blob/master/gopls/doc/settings.md#directoryfilters-string
+	GoplsDirectoryFilters *[]string `json:",omitempty"`
+
 	// Analyses is a map of booleans (0 or 1 in VimScript) used to enable/disable
 	// specific analyses in gopls. Entries in the map are used to override
 	// defaults specified by gopls. A list of analyzers with their default value

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -49,6 +49,9 @@ func (r *Config) Apply(v *Config) {
 	if v.GoplsEnv != nil {
 		r.GoplsEnv = v.GoplsEnv
 	}
+	if v.GoplsDirectoryFilters != nil {
+		r.GoplsDirectoryFilters = v.GoplsDirectoryFilters
+	}
 	if v.Analyses != nil {
 		r.Analyses = v.Analyses
 	}

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -35,6 +35,7 @@ const (
 	goplsSymbolStyle                 = "symbolStyle"
 	goplsGofumpt                     = "gofumpt"
 	goplsExperimentalWorkspaceModule = "experimentalWorkspaceModule"
+	goplsDirectoryFilters            = "directoryFilters"
 )
 
 var _ protocol.Client = (*govimplugin)(nil)
@@ -186,6 +187,9 @@ func (g *govimplugin) Configuration(ctxt context.Context, params *protocol.Param
 		// It is safe not to copy the map here because a new config setting from
 		// Vim creates a new map.
 		goplsConfig[goplsEnv] = *conf.GoplsEnv
+	}
+	if g.vimstate.config.GoplsDirectoryFilters != nil {
+		goplsConfig[goplsDirectoryFilters] = *conf.GoplsDirectoryFilters
 	}
 	res[0] = goplsConfig
 

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -23,6 +23,7 @@ type VimConfig struct {
 	CompletionBudget                             *string
 	TempModfile                                  *int
 	GoplsEnv                                     *map[string]string
+	GoplsDirectoryFilters                        *[]string
 	Analyses                                     *map[string]int
 	OpenLastProgressWith                         *string
 	Gofumpt                                      *int
@@ -53,6 +54,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		CompletionBudget:                  stringVal(c.CompletionBudget, d.CompletionBudget),
 		TempModfile:                       boolVal(c.TempModfile, d.TempModfile),
 		GoplsEnv:                          copyStringValMap(c.GoplsEnv, d.GoplsEnv),
+		GoplsDirectoryFilters:             copyStringValSlice(c.GoplsDirectoryFilters, d.GoplsDirectoryFilters),
 		Analyses:                          mergeBoolValMap(c.Analyses, d.Analyses),
 		OpenLastProgressWith:              stringVal(c.OpenLastProgressWith, d.OpenLastProgressWith),
 		Gofumpt:                           boolVal(c.Gofumpt, d.Gofumpt),
@@ -105,6 +107,21 @@ func copyStringValMap(i, j *map[string]string) *map[string]string {
 	res := make(map[string]string)
 	for ck, cv := range *toCopy {
 		res[ck] = cv
+	}
+	return &res
+}
+
+func copyStringValSlice(i, j *[]string) *[]string {
+	toCopy := i
+	if i == nil {
+		toCopy = j
+		if j == nil {
+			return nil
+		}
+	}
+	res := make([]string, len(*toCopy))
+	for i, cv := range *toCopy {
+		res[i] = cv
 	}
 	return &res
 }

--- a/cmd/govim/testdata/scenario_directoryfilter/directory_filter.txt
+++ b/cmd/govim/testdata/scenario_directoryfilter/directory_filter.txt
@@ -1,0 +1,27 @@
+# Verify that directory filters work. In this setup, we should not
+# see diagnostics for package b because it is excluded by a directory
+# filter
+
+[short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'
+
+vim ex 'e a/a.go'
+sleep $GOVIM_ERRLOGMATCH_WAIT
+vimexprwait empty.golden GOVIMTest_getqflist()
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- a/a.go --
+package a
+
+-- b/b.go --
+package b
+
+thisisaproblem
+-- empty.golden --
+[]

--- a/cmd/govim/testdata/scenario_directoryfilter/user_config.json
+++ b/cmd/govim/testdata/scenario_directoryfilter/user_config.json
@@ -1,0 +1,3 @@
+{
+	"GoplsDirectoryFilters": ["-b"]
+}


### PR DESCRIPTION
`gopls` has an option to [`DirectoryFilters`](https://github.com/golang/tools/blob/e9a2c0706a5b9cc8ee5965d5a50c996ffb255a7b/internal/lsp/source/options.go#L213). It allows to add or remove certain directories from workspace. This option is especially useful if workspace is a root of giant monorepository project. Without this option it is impossible to open such projects due to endless indexing process.

This PR adds support for this option via standard `govim` config option.