### PR TITLE
deps: update x/tools and gopls to db4c57db

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
@@ -203,8 +203,8 @@ func (s *snapshot) workspaceLayoutError(ctx context.Context) *source.CriticalErr
 	if !s.ValidBuildConfiguration() {
 		msg := `gopls requires a module at the root of your workspace.
 You can work with multiple modules by opening each one as a workspace folder.
-Improvements to this workflow will be coming soon (https://github.com/golang/go/issues/32394),
-and you can learn more here: https://github.com/golang/go/issues/36899.`
+Improvements to this workflow will be coming soon, and you can learn more here:
+https://github.com/golang/tools/blob/master/gopls/doc/workspace.md.`
 		return &source.CriticalError{
 			MainError: errors.Errorf(msg),
 			ErrorList: s.applyCriticalErrorToFiles(ctx, msg, openFiles),
@@ -236,13 +236,15 @@ and you can learn more here: https://github.com/golang/go/issues/36899.`
 			msg := fmt.Sprintf(`This file is in %s, which is a nested module in the %s module.
 gopls currently requires one module per workspace folder.
 Please open %s as a separate workspace folder.
-You can learn more here: https://github.com/golang/go/issues/36899.
+You can learn more here: https://github.com/golang/tools/blob/master/gopls/doc/workspace.md.
 `, modDir, filepath.Dir(rootModURI.Filename()), modDir)
 			srcErrs = append(srcErrs, s.applyCriticalErrorToFiles(ctx, msg, uris)...)
 		}
 		if len(srcErrs) != 0 {
 			return &source.CriticalError{
-				MainError: errors.Errorf(`You are working in a nested module. Please open it as a separate workspace folder.`),
+				MainError: errors.Errorf(`You are working in a nested module.
+Please open it as a separate workspace folder. Learn more:
+https://github.com/golang/tools/blob/master/gopls/doc/workspace.md.`),
 				ErrorList: srcErrs,
 			}
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/call_hierarchy.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/call_hierarchy.go
@@ -30,8 +30,6 @@ Example:
   $ # 1-indexed location (:line:column or :#offset) of the target identifier
   $ gopls call_hierarchy helper/helper.go:8:6
   $ gopls call_hierarchy helper/helper.go:#53
-
-  gopls call_hierarchy flags are:
 `)
 	f.PrintDefaults()
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/check.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/check.go
@@ -26,8 +26,6 @@ func (c *check) DetailedHelp(f *flag.FlagSet) {
 Example: show the diagnostic results of this file:
 
   $ gopls check internal/lsp/cmd/check.go
-
-	gopls check flags are:
 `)
 	f.PrintDefaults()
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/highlight.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/highlight.go
@@ -30,8 +30,6 @@ Example:
   $ # 1-indexed location (:line:column or :#offset) of the target identifier
   $ gopls highlight helper/helper.go:8:6
   $ gopls highlight helper/helper.go:#53
-
-  gopls highlight flags are:
 `)
 	f.PrintDefaults()
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/implementation.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/implementation.go
@@ -30,8 +30,6 @@ Example:
   $ # 1-indexed location (:line:column or :#offset) of the target identifier
   $ gopls implementation helper/helper.go:8:6
   $ gopls implementation helper/helper.go:#53
-
-  gopls implementation flags are:
 `)
 	f.PrintDefaults()
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/prepare_rename.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/prepare_rename.go
@@ -30,8 +30,6 @@ Example:
 	$ # 1-indexed location (:line:column or :#offset) of the target identifier
 	$ gopls prepare_rename helper/helper.go:8:6
 	$ gopls prepare_rename helper/helper.go:#53
-
-	gopls prepare_rename flags are:
 `)
 	f.PrintDefaults()
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/semantictokens.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/semantictokens.go
@@ -67,8 +67,6 @@ func (c *semtok) DetailedHelp(f *flag.FlagSet) {
 Example: show the semantic tokens for this file:
 
   $ gopls semtok internal/lsp/cmd/semtok.go
-
-	gopls semtok flags are:
 `)
 	f.PrintDefaults()
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/signature.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/signature.go
@@ -29,8 +29,6 @@ Example:
   $ # 1-indexed location (:line:column or :#offset) of the target identifier
   $ gopls signature helper/helper.go:8:6
   $ gopls signature helper/helper.go:#53
-
-  gopls signature flags are:
 `)
 	f.PrintDefaults()
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/workdir.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/workdir.go
@@ -211,7 +211,7 @@ func (w *Workdir) sendEvents(ctx context.Context, evts []FileEvent) {
 	copy(watchers, w.watchers)
 	w.watcherMu.Unlock()
 	for _, w := range watchers {
-		go w(ctx, evts)
+		w(ctx, evts)
 	}
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/lsprpc.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/lsprpc.go
@@ -61,6 +61,7 @@ func (s *StreamServer) ServeStream(ctx context.Context, conn jsonrpc2.Conn) erro
 	server := s.serverForTest
 	if server == nil {
 		server = lsp.NewServer(session, client)
+		debug.GetInstance(ctx).AddService(server, session)
 	}
 	// Clients may or may not send a shutdown message. Make sure the server is
 	// shut down.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/rename.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/rename.go
@@ -43,9 +43,11 @@ func (s *Server) prepareRename(ctx context.Context, params *protocol.PrepareRena
 	}
 	// Do not return errors here, as it adds clutter.
 	// Returning a nil result means there is not a valid rename.
-	item, err := source.PrepareRename(ctx, snapshot, fh, params.Position)
+	item, usererr, err := source.PrepareRename(ctx, snapshot, fh, params.Position)
 	if err != nil {
-		return nil, nil // ignore errors
+		// Return usererr here rather than err, to avoid cluttering the UI with
+		// internal error details.
+		return nil, usererr
 	}
 	// TODO(suzmue): return ident.Name as the placeholder text.
 	return &item.Range, nil

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.0
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
-	golang.org/x/tools v0.1.0
-	golang.org/x/tools/gopls v0.0.0-20210119222503-fe37c9e135b9
+	golang.org/x/tools v0.1.1-0.20210128154556-db4c57db23ae
+	golang.org/x/tools/gopls v0.0.0-20210128154556-db4c57db23ae
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -52,7 +52,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -69,7 +68,6 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -80,10 +78,10 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210104081019-d8d6ddbec6ee/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
-golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools/gopls v0.0.0-20210119222503-fe37c9e135b9 h1:m/gSy0uHyeasX1od4adOLgmq00J3ravAEiAvRSGyH4k=
-golang.org/x/tools/gopls v0.0.0-20210119222503-fe37c9e135b9/go.mod h1:DWl5nefYvX46i2mLQVu6Ud0ycJQ3HNPbQKzUHT3VUek=
+golang.org/x/tools v0.1.1-0.20210128154556-db4c57db23ae h1:lHjfmzd4vJIV4PFi2iDdZRTF4un5Tta3CnckK3w7xjI=
+golang.org/x/tools v0.1.1-0.20210128154556-db4c57db23ae/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools/gopls v0.0.0-20210128154556-db4c57db23ae h1:ZTSL8I5Bc/qtv1gzI0yBry7UZ4RBo9LNi7FcVLNGjxk=
+golang.org/x/tools/gopls v0.0.0-20210128154556-db4c57db23ae/go.mod h1:DWl5nefYvX46i2mLQVu6Ud0ycJQ3HNPbQKzUHT3VUek=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* gopls/internal/regtest: split regtests up into multiple packages db4c57db
* internal/lsp/cache: lock in snapshot.knownFilesInDir f871472f
* internal/lsp/source: make it an error to rename embedded fields c2bea79d
* gopls/internal/hooks: improve license file test 514964b7
* internal/lsp/cmd: improve help output of gopls subcommands 68bf78a6
* go/analysis/passes/fieldalignment: delete doc style comments in fix 4922717d
* gopls/internal/regtest: automate counting of editor notifications to await 917f61df
* internal/lsp: correct links provided in critical error pop-ups 2972602e
* internal/lsp: display current diagnostics in the debug server e13398c8
* gopls: factor out advanced documentation from the README cf1022a4
* gopls: mention workspaces and build systems in the README 87bc10f2
* internal/lsp: don't show context cancellation in the progress bar ce34e269
* gopls: merge README and user.md bec622c3
* gopls/internal/regtest: re-enable android builder 7e51fbd4