### PR TITLE
cmd/govim: remember previous position before GOVIMMotion call

### DIFF
--- a/cmd/govim/motions.go
+++ b/cmd/govim/motions.go
@@ -131,6 +131,7 @@ func (v *vimstate) motion(args ...json.RawMessage) (interface{}, error) {
 	}
 
 	if targetNode != nil {
+		v.ChannelEx("normal! m'")
 		position := b.Fset.Position(resolv(targetNode))
 		v.ChannelCall("cursor", position.Line, position.Column)
 	}

--- a/cmd/govim/testdata/scenario_default/motion.txt
+++ b/cmd/govim/testdata/scenario_default/motion.txt
@@ -2,8 +2,21 @@
 
 vim ex 'e main.go'
 
+# Move to line 2
+vim ex 'call cursor(2,1)'
+
 # Next start of File.Decl
 vim ex 'normal ]['
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '\[3,1\]'
+
+# Jump back to where we were
+vim ex 'call feedkeys(\"\\<C-O>\")'
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '\[2,1\]'
+
+# Jump forward
+vim ex 'call feedkeys(\"\\<C-I>\")'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
 stdout '\[3,1\]'
 


### PR DESCRIPTION
This allows CTRL-O to return the cursor to position at which the
GOVIMMotion call was made. CTRL-I then returns you to that same "call
site".

With thanks to @roy2220 for raising the initial issue and proposing a
fix.

Fixes #931