### PR TITLE
cmd/govim: support quickfix code actions returning commands

### DIFF
--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -262,7 +262,7 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 			defaultConfig:         *defaults,
 			config:                *defaults,
 			quickfixIsDiagnostics: true,
-			suggestedFixesPopups:  make(map[int][]protocol.WorkspaceEdit),
+			suggestedFixesPopups:  make(map[int][]suggestedFix),
 			progressPopups:        make(map[protocol.ProgressToken]*types.ProgressPopup),
 		},
 	}

--- a/cmd/govim/testdata/mod/example.com_withdeps_v1.0.0.txt
+++ b/cmd/govim/testdata/mod/example.com_withdeps_v1.0.0.txt
@@ -1,0 +1,18 @@
+-- .mod --
+module example.com/withdeps
+
+go 1.14
+
+require example.com/blah v1.0.0
+-- .info --
+{"Version":"v1.0.0","Time":"2019-06-05T18:43:18Z"}
+-- go.mod --
+module example.com/withdeps
+
+go 1.14
+
+require example.com/blah v1.0.0
+-- foo/foo.go --
+package foo
+
+import _ "example.com/blah"

--- a/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_go_get_package.txt
+++ b/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_go_get_package.txt
@@ -1,0 +1,79 @@
+# Test that suggested edits can be applied to go.mod - go get package
+
+[!go1.14] skip '-modfile only supported in Go 1.14'
+
+vim call 'govim#config#Set' '["ExperimentalAllowModfileModifications",0]'
+
+# Open go.mod that contain an unused depdendency
+vim ex 'e main.go'
+
+# Wait for the diag and open up suggested fixes
+vimexprwait errors.golden GOVIMTest_getqflist()
+vim ex 'call cursor(6,4)'
+vim ex 'GOVIMSuggestedFixes'
+
+# Wait for popup
+# 2021-02-15T19:52:03.163777_#1: sendJSONMsg: [0,[86,"call","popup_create",["go get package example.com/withdeps/foo"],{"callback":"GOVIM_internal_PopupSelection","col":"cursor","cursorline":1,"drag":1,"filter":"GOVIM_internal_SuggestedFixesFilter","line":"cursor+1","mapping":0,"title":"could not import example.com/withdeps/foo (no required module provides package \"example.com/withdeps/foo\")"}]]
+
+
+errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"go get package example.com/withdeps/foo\"\],{.*\"title\":\"could not import example.com/withdeps/foo \(no required module provides package \\\"example.com/withdeps/foo\\\"\)\"'
+! stderr .+
+
+# Can't do vim ex 'normal .. here since the key press must reach the popup menu
+vim ex 'call feedkeys(\"\\<Enter>\", \"xt\")'
+errlogmatch 'recvJSONMsg: .*GOVIM_internal_PopupSelection'
+
+# This check isn't necessary, since how gopls choose to provide the fix is just an implementation detail.
+# It do however verify that we can apply fixes that require govim to call ExecuteCommand (govim/govim#1025)
+# and acts as a canary as long as gopls use commands for this particular fix.
+errlogmatch '&protocol.ExecuteCommandParams{\n.*Command:   \"gopls.go_get_package\"'
+
+# Make sure that the diagnostic goes away when the fix is applied.
+vimexprwait errors.empty GOVIMTest_getqflist()
+
+vim ex 'w!'
+cmp go.mod go.mod.golden
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.14
+-- go.mod.golden --
+module mod.com
+
+go 1.14
+
+require example.com/withdeps v1.0.0
+-- main.go --
+package main
+
+import (
+	"fmt"
+
+	_ "example.com/withdeps/foo"
+)
+
+func main() {
+	fmt.Println("hello, world!")
+}
+-- errors.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 4,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "could not import example.com/withdeps/foo (no required module provides package \"example.com/withdeps/foo\")",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.empty --
+[]

--- a/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_remove_dep.txt
+++ b/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_remove_dep.txt
@@ -1,0 +1,69 @@
+# Test that suggested edits can be applied to go.mod - removing a dependency.
+
+[!go1.14] skip '-modfile only supported in Go 1.14'
+
+# Open go.mod that contain an unused depdendency
+vim ex 'e go.mod'
+
+# Wait for the diag and open up suggested fixes
+vimexprwait errors.golden GOVIMTest_getqflist()
+vim ex 'call cursor(3,1)'
+vim ex 'GOVIMSuggestedFixes'
+
+# Wait for popup
+errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove dependency: example.com/blah\"\],{.*\"title\":\"example.com/blah is not used in this module\"'
+! stderr .+
+
+# Can't do vim ex 'normal .. here since the key press must reach the popup menu
+vim ex 'call feedkeys(\"\\<Enter>\", \"xt\")'
+errlogmatch 'recvJSONMsg: .*GOVIM_internal_PopupSelection'
+
+# This check isn't necessary, since how gopls choose to provide the fix is just an implementation detail.
+# It do however verify that we can apply fixes that require govim to call ExecuteCommand (govim/govim#1025)
+# and acts as a canary as long as gopls use commands for this particular fix.
+errlogmatch '&protocol.ExecuteCommandParams{\n.*Command:   \"gopls.remove_dependency\"'
+
+vim ex 'w!'
+cmp go.mod go.mod.golden
+
+# Make sure that the diagnostic goes away when the fix is applied.
+vimexprwait errors.empty GOVIMTest_getqflist()
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+require example.com/blah v1.0.0
+
+go 1.14
+-- go.mod.golden --
+module mod.com
+
+go 1.14
+-- go.sum --
+example.com/blah v1.0.0 h1:Yr7B+aw1mdffvbZEpxOQr3JwCLQMmUvzFAzxw8p1gqk=
+example.com/blah v1.0.0/go.mod h1:LDRgDEBCzM88pzTnG9COwUsPcGLsgrBJyaYCbPaAEi8=
+-- main.go --
+package main
+
+func main() {}
+-- errors.golden --
+[
+  {
+    "bufname": "go.mod",
+    "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "example.com/blah is not used in this module",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.empty --
+[]

--- a/cmd/govim/testdata/scenario_tempmodfile/user_config.json
+++ b/cmd/govim/testdata/scenario_tempmodfile/user_config.json
@@ -1,3 +1,4 @@
 {
-	"TempModfile": true
+	"TempModfile": true,
+	"ExperimentalAllowModfileModifications": false
 }


### PR DESCRIPTION
Code action responses can contain both WorkspaceEdit and Command
according to LSP 3.16, and edits should be applied before executing
the command.

We ignored the command field when handling suggested fixes. If a
suggested fix includes a command it is now executed after any edits are
applied.

Closes #1025