### PR TITLE
cmd/govim: add ExperimentalAllowModfileModifications

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -186,6 +186,10 @@ function! s:validExperimentalProgressPopups(v)
   return s:validBool(a:v)
 endfunction
 
+function! s:validExperimentalAllowModfileModifications(v)
+  return s:validBool(a:v)
+endfunction
+
 let s:validators = {
       \ "FormatOnSave": function("s:validFormatOnSave"),
       \ "QuickfixAutoDiagnostics": function("s:validQuickfixAutoDiagnostics"),
@@ -211,4 +215,5 @@ let s:validators = {
       \ "ExperimentalCursorTriggeredHoverPopupOptions": function("s:validExperimentalCursorTriggeredHoverPopupOptions"),
       \ "ExperimentalWorkaroundCompleteoptLongest": function("s:validExperimentalWorkaroundCompleteoptLongest"),
       \ "ExperimentalProgressPopups": function("s:validExperimentalProgressPopups"),
+      \ "ExperimentalAllowModfileModifications": function("s:validExperimentalProgressPopups"),
       \ }

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -281,6 +281,22 @@ type Config struct {
 	//
 	// Default: false
 	ExperimentalProgressPopups *bool `json:",omitempty"`
+
+	// ExperimentalAllowModfileModifications controls whether gopls should
+	// automatically modify go.{mod,sum} as a side effect of its use of cmd/go
+	// or not. Setting this option to true can be considered a gopls equivalent
+	// to setting GOFLAGS=-mod=mod when using cmd/go. Leaving it unset or
+	// setting it to false is equivalent to -mod=readonly. Indeed setting
+	// GOFLAGS=-mod=XYZ is now considered deprecated as a means of controlling
+	// this behaviour in gopls.
+	//
+	// For reference: in Go 1.16 cmd/go build commands default to -mod=readonly
+	// (equivalent to leaving this option unset, or setting it to false),
+	// whereas prior to Go 1.16 the default was -mod=mod (equivalent to setting
+	// this option to true).
+	//
+	// Default: true
+	ExperimentalAllowModfileModifications *bool `json:",omitempty"`
 }
 
 type Command string

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -73,4 +73,7 @@ func (r *Config) Apply(v *Config) {
 	if v.ExperimentalProgressPopups != nil {
 		r.ExperimentalProgressPopups = v.ExperimentalProgressPopups
 	}
+	if v.ExperimentalAllowModfileModifications != nil {
+		r.ExperimentalAllowModfileModifications = v.ExperimentalAllowModfileModifications
+	}
 }

--- a/cmd/govim/gopls.go
+++ b/cmd/govim/gopls.go
@@ -156,11 +156,13 @@ func (g *govimplugin) startGopls() error {
 		goplsConfig[goplsSymbolStyle] = *conf.SymbolStyle
 	}
 
-	// TODO: This option was introduced as a way to opt-out from the changes introduced in CL 268597.
+	// This option was introduced as a way to opt-out from the changes introduced in CL 268597.
 	// According to CL 274532 (that added this opt-out), it is intended to be removed - "Ideally
 	// we'll be able to remove them in a few months after things stabilize.". We need to handle that
-	// case before it is removed.
-	goplsConfig["allowModfileModifications"] = true
+	// case before it is removed. Following up on that point is tracked in golang.org/issue/44008
+	if conf.ExperimentalAllowModfileModifications != nil {
+		goplsConfig["allowModfileModifications"] = *conf.ExperimentalAllowModfileModifications
+	}
 
 	initParams.InitializationOptions = goplsConfig
 

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -31,6 +31,7 @@ type VimConfig struct {
 	ExperimentalCursorTriggeredHoverPopupOptions *map[string]interface{}
 	ExperimentalWorkaroundCompleteoptLongest     *int
 	ExperimentalProgressPopups                   *int
+	ExperimentalAllowModfileModifications        *int
 }
 
 func (c *VimConfig) ToConfig(d config.Config) config.Config {
@@ -59,6 +60,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		ExperimentalCursorTriggeredHoverPopupOptions: copyMap(c.ExperimentalCursorTriggeredHoverPopupOptions, d.ExperimentalCursorTriggeredHoverPopupOptions),
 		ExperimentalWorkaroundCompleteoptLongest:     boolVal(c.ExperimentalWorkaroundCompleteoptLongest, d.ExperimentalWorkaroundCompleteoptLongest),
 		ExperimentalProgressPopups:                   boolVal(c.ExperimentalProgressPopups, d.ExperimentalProgressPopups),
+		ExperimentalAllowModfileModifications:        boolVal(c.ExperimentalAllowModfileModifications, d.ExperimentalAllowModfileModifications),
 	}
 	if v.FormatOnSave == nil {
 		v.FormatOnSave = d.FormatOnSave

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -229,18 +229,19 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 	}
 	if defaults == nil {
 		defaults = &config.Config{
-			FormatOnSave:                      vimconfig.FormatOnSaveVal(config.FormatOnSaveGoImportsGoFmt),
-			QuickfixAutoDiagnostics:           vimconfig.BoolVal(true),
-			QuickfixSigns:                     vimconfig.BoolVal(true),
-			Staticcheck:                       vimconfig.BoolVal(false),
-			HighlightDiagnostics:              vimconfig.BoolVal(true),
-			HighlightReferences:               vimconfig.BoolVal(true),
-			HoverDiagnostics:                  vimconfig.BoolVal(true),
-			TempModfile:                       vimconfig.BoolVal(false),
-			ExperimentalAutoreadLoadedBuffers: vimconfig.BoolVal(false),
-			SymbolMatcher:                     vimconfig.SymbolMatcherVal(config.SymbolMatcherFuzzy),
-			SymbolStyle:                       vimconfig.SymbolStyleVal(config.SymbolStyleFull),
-			OpenLastProgressWith:              vimconfig.StringVal("below 10split"),
+			FormatOnSave:                          vimconfig.FormatOnSaveVal(config.FormatOnSaveGoImportsGoFmt),
+			QuickfixAutoDiagnostics:               vimconfig.BoolVal(true),
+			QuickfixSigns:                         vimconfig.BoolVal(true),
+			Staticcheck:                           vimconfig.BoolVal(false),
+			HighlightDiagnostics:                  vimconfig.BoolVal(true),
+			HighlightReferences:                   vimconfig.BoolVal(true),
+			HoverDiagnostics:                      vimconfig.BoolVal(true),
+			TempModfile:                           vimconfig.BoolVal(false),
+			ExperimentalAutoreadLoadedBuffers:     vimconfig.BoolVal(false),
+			SymbolMatcher:                         vimconfig.SymbolMatcherVal(config.SymbolMatcherFuzzy),
+			SymbolStyle:                           vimconfig.SymbolStyleVal(config.SymbolStyleFull),
+			OpenLastProgressWith:                  vimconfig.StringVal("below 10split"),
+			ExperimentalAllowModfileModifications: vimconfig.BoolVal(true),
 		}
 	}
 	// Overlay the initial user values on the defaults

--- a/cmd/govim/testdata/scenario_modreadonly/user_config.json
+++ b/cmd/govim/testdata/scenario_modreadonly/user_config.json
@@ -1,3 +1,3 @@
 {
-	"GoplsEnv": {"GOFLAGS": "-mod=readonly"}
+	"ExperimentalAllowModfileModifications": false
 }


### PR DESCRIPTION
ExperimentalAllowModfileModifications controls whether gopls should
automatically modify go.{mod,sum} as a side effect of its use of cmd/go
or not. Setting this option to true can be considered a gopls equivalent
to setting GOFLAGS=-mod=mod when using cmd/go. Leaving it unset or
setting it to false is equivalent to -mod=readonly. Indeed setting
GOFLAGS=-mod=XYZ is now considered deprecated as a means of controlling
this behaviour in gopls.

For reference: in Go 1.16 cmd/go build commands default to -mod=readonly
(equivalent to leaving this option unset, or setting it to false),
whereas prior to Go 1.16 the default was -mod=mod (equivalent to setting
this option to true).

golang.org/issue/44008 tracks confirmation that this gopls option will
not be removed until a better alternative is found.