### PR TITLE
cmd/govim: populate go.sum files for tests that use non-std packages

### DIFF
--- a/cmd/govim/testdata/scenario_default/complete_module_cache.txt
+++ b/cmd/govim/testdata/scenario_default/complete_module_cache.txt
@@ -16,6 +16,9 @@ module mod.com
 go 1.12
 
 require example.com/blah v1.0.0
+-- go.sum --
+example.com/blah v1.0.0 h1:Yr7B+aw1mdffvbZEpxOQr3JwCLQMmUvzFAzxw8p1gqk=
+example.com/blah v1.0.0/go.mod h1:LDRgDEBCzM88pzTnG9COwUsPcGLsgrBJyaYCbPaAEi8=
 -- main.go --
 package main
 

--- a/cmd/govim/testdata/scenario_default/go_to_def_module_cache.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_module_cache.txt
@@ -29,6 +29,9 @@ module mod.com
 go 1.12
 
 require example.com/blah v1.0.0
+-- go.sum --
+example.com/blah v1.0.0 h1:Yr7B+aw1mdffvbZEpxOQr3JwCLQMmUvzFAzxw8p1gqk=
+example.com/blah v1.0.0/go.mod h1:LDRgDEBCzM88pzTnG9COwUsPcGLsgrBJyaYCbPaAEi8=
 -- p.go --
 package p
 

--- a/cmd/govim/testdata/scenario_default/go_to_def_newtab.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_newtab.txt
@@ -28,6 +28,9 @@ module mod.com/p
 go 1.12
 
 require example.com/blah v1.0.0
+-- go.sum --
+example.com/blah v1.0.0 h1:Yr7B+aw1mdffvbZEpxOQr3JwCLQMmUvzFAzxw8p1gqk=
+example.com/blah v1.0.0/go.mod h1:LDRgDEBCzM88pzTnG9COwUsPcGLsgrBJyaYCbPaAEi8=
 -- p.go --
 package p
 

--- a/cmd/govim/testdata/scenario_default/go_to_def_split.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_split.txt
@@ -28,6 +28,9 @@ module mod.com/p
 go 1.12
 
 require example.com/blah v1.0.0
+-- go.sum --
+example.com/blah v1.0.0 h1:Yr7B+aw1mdffvbZEpxOQr3JwCLQMmUvzFAzxw8p1gqk=
+example.com/blah v1.0.0/go.mod h1:LDRgDEBCzM88pzTnG9COwUsPcGLsgrBJyaYCbPaAEi8=
 -- p.go --
 package p
 

--- a/cmd/govim/testdata/scenario_default/go_to_def_vsplit.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_vsplit.txt
@@ -28,6 +28,9 @@ module mod.com/p
 go 1.12
 
 require example.com/blah v1.0.0
+-- go.sum --
+example.com/blah v1.0.0 h1:Yr7B+aw1mdffvbZEpxOQr3JwCLQMmUvzFAzxw8p1gqk=
+example.com/blah v1.0.0/go.mod h1:LDRgDEBCzM88pzTnG9COwUsPcGLsgrBJyaYCbPaAEi8=
 -- p.go --
 package p
 


### PR DESCRIPTION
This ensures that go.{mod,sum} are tidy when gopls starts.

Adding an unimported completion test that verifies go.{mod,sum} are
changed when we add a non-std package is captured in #1029.