### PR TITLE
cmd/govim: do not add short-lived buffers during :vimgrep

### DIFF
--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -31,11 +31,9 @@ const (
 	PluginPrefix = "GOVIM"
 )
 
-var (
-	// exposeTestAPI is a rather hacky but clean way of only exposing certain
-	// functions, commands and autocommands to Vim when run from a test
-	exposeTestAPI = os.Getenv(testsetup.EnvLoadTestAPI) == "true"
-)
+// exposeTestAPI is a rather hacky but clean way of only exposing certain
+// functions, commands and autocommands to Vim when run from a test
+var exposeTestAPI = os.Getenv(testsetup.EnvLoadTestAPI) == "true"
 
 func mainerr() error {
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
@@ -288,6 +286,8 @@ func (g *govimplugin) Init(gg govim.Govim, errCh chan error) error {
 	g.DefineAutoCommand("", govim.Events{govim.EventBufRead, govim.EventBufNewFile}, govim.Patterns{"*.go", "go.mod", "go.sum"}, false, g.vimstate.bufReadPost, exprAutocmdCurrBufInfo)
 	g.DefineAutoCommand("", govim.Events{govim.EventBufWritePre}, govim.Patterns{"*.go", "go.mod", "go.sum"}, false, g.vimstate.formatCurrentBuffer, "eval(expand('<abuf>'))")
 	g.DefineAutoCommand("", govim.Events{govim.EventBufWritePost}, govim.Patterns{"*.go", "go.mod", "go.sum"}, false, g.vimstate.bufWritePost, "eval(expand('<abuf>'))")
+	g.DefineAutoCommand("", govim.Events{govim.EventQuickFixCmdPre}, govim.Patterns{"*vimgrep*"}, false, g.vimstate.bufQuickFixCmdPre)
+	g.DefineAutoCommand("", govim.Events{govim.EventQuickFixCmdPost}, govim.Patterns{"*vimgrep*"}, false, g.vimstate.bufQuickFixCmdPost)
 	g.DefineFunction(string(config.FunctionComplete), []string{"findarg", "base"}, g.vimstate.complete)
 	g.DefineCommand(string(config.CommandGoToDef), g.vimstate.gotoDef, govim.NArgsZeroOrOne)
 	g.DefineCommand(string(config.CommandGoToTypeDef), g.vimstate.gotoTypeDef, govim.NArgsZeroOrOne)

--- a/cmd/govim/vimstate.go
+++ b/cmd/govim/vimstate.go
@@ -89,6 +89,17 @@ type vimstate struct {
 	// lastProgressText points to the text in the most recently created progress
 	// popup.
 	lastProgressText *strings.Builder
+
+	// vimgrepPendingBufs contain buffers read during a vimgrep quickfix command,
+	// keyed by buffer number.
+	// The purpose is to avoid sending DidOpen/DidClose notifications to gopls
+	// for all files which contained no pattern match.
+	// Vim will reuse the buffer number as long as the searched file didn't contain
+	// a pattern match. See discussion at https://groups.google.com/g/vim_dev/c/qpu2O8cvprY.
+	//
+	// A nil value is used to indicate that there is no ongoing vimgrep.
+	// When vimgrep is done, these buffers are added to govim.
+	vimgrepPendingBufs map[int]*types.Buffer
 }
 
 func (v *vimstate) setConfig(args ...json.RawMessage) (interface{}, error) {


### PR DESCRIPTION
Using `:vimgrep` could result in a lot of short-lived buffers that is
sent to gopls since each file searched will trigger `BufReadPost`
autocommands.

Use `QuickFixCmdPre` & `QuickFixCmdPost` to detect when vimgrep runs,
and only add new buffers that still exists when vimgrep is done.
(see https://groups.google.com/g/vim_dev/c/qpu2O8cvprY/m/ZGAaOOlJBAAJ
for additional context)

Updates #1028