### PR TITLE
cmd/govim: be more specific in our call to getbufinfo

### DIFF
--- a/cmd/govim/rename.go
+++ b/cmd/govim/rename.go
@@ -66,7 +66,7 @@ func (v *vimstate) applyMultiBufTextedits(splitMods govim.CommModList, changes [
 			BufNr   int   `json:"bufnr"`
 			Windows []int `json:"windows"`
 		}
-		v.Parse(v.ChannelCall("getbufinfo", tf), &bufinfo)
+		v.Parse(v.ChannelExprf(`map(getbufinfo(%q), {_, v -> filter(v, 'v:key == "bufnr" || v:key == "windows"')})`, tf), &bufinfo)
 		switch len(bufinfo) {
 		case 0:
 		case 1:


### PR DESCRIPTION
Issue #1017 turns out to be caused by getbufinfo() returning a value
where at some level a field maps to a function. This cannot be JSON
encoded, obviously. The rather broad error message is fixed in:

https://github.com/vim/vim/commit/a853089479b60b829bab1c4a0a737a073415f8a7

Thanks to @LemonBoy for the excellent analysis in vim/vim#7802.

Fix this by being more specific in our call to getbufinfo. We only need
specific keys, so we should only fetch those.

Fixes #1017