### PR TITLE
test: re-enable quickfix_empty_files test

### DIFF
--- a/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
@@ -10,7 +10,7 @@
 # the definition of DoIt to take an integer argument at which point all
 # diagnostics should disappear.
 
-[golang.org/issues/39646] skip
+[!go1.16] skip
 
 # Create all the new files
 vim ex 'e p/p.go'
@@ -99,7 +99,7 @@ func TestDoIt(t *testing.T) {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "cannot convert 5 (untyped int constant) to string",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to p.DoIt",
     "type": "",
     "valid": 1,
     "vcol": 0
@@ -111,7 +111,7 @@ func TestDoIt(t *testing.T) {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "cannot convert 5 (untyped int constant) to string",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to DoIt",
     "type": "",
     "valid": 1,
     "vcol": 0
@@ -123,7 +123,7 @@ func TestDoIt(t *testing.T) {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "cannot convert 5 (untyped int constant) to string",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to p.DoIt",
     "type": "",
     "valid": 1,
     "vcol": 0


### PR DESCRIPTION
As golang/go#39646 is closed we now re-enable the skipped test.