### PR TITLE
deps: update x/tools and gopls to 68c7d11a

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
@@ -454,9 +454,7 @@ func (s *Session) DidModifyFiles(ctx context.Context, changes []source.FileModif
 		// Apply the changes to all affected views.
 		for _, view := range changedViews {
 			// Make sure that the file is added to the view.
-			if _, err := view.getFile(c.URI); err != nil {
-				return nil, nil, err
-			}
+			_ = view.getFile(c.URI)
 			if _, ok := views[view]; !ok {
 				views[view] = make(map[span.URI]*fileChange)
 			}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
@@ -12,6 +12,7 @@ import (
 	"go/token"
 	"go/types"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -253,6 +254,44 @@ func (s *snapshot) RunGoCommandPiped(ctx context.Context, mode source.Invocation
 	}
 	defer cleanup()
 	return s.view.session.gocmdRunner.RunPiped(ctx, *inv, stdout, stderr)
+}
+
+func (s *snapshot) RunGoCommands(ctx context.Context, allowNetwork bool, wd string, run func(invoke func(...string) (*bytes.Buffer, error)) error) (bool, []byte, []byte, error) {
+	var flags source.InvocationFlags
+	if s.workspaceMode()&tempModfile != 0 {
+		flags = source.WriteTemporaryModFile
+	} else {
+		flags = source.Normal
+	}
+	if allowNetwork {
+		flags |= source.AllowNetwork
+	}
+	tmpURI, inv, cleanup, err := s.goCommandInvocation(ctx, flags, &gocommand.Invocation{WorkingDir: wd})
+	if err != nil {
+		return false, nil, nil, err
+	}
+	defer cleanup()
+	invoke := func(args ...string) (*bytes.Buffer, error) {
+		inv.Verb = args[0]
+		inv.Args = args[1:]
+		return s.view.session.gocmdRunner.Run(ctx, *inv)
+	}
+	if err := run(invoke); err != nil {
+		return false, nil, nil, err
+	}
+	if flags.Mode() != source.WriteTemporaryModFile {
+		return false, nil, nil, nil
+	}
+	var modBytes, sumBytes []byte
+	modBytes, err = ioutil.ReadFile(tmpURI.Filename())
+	if err != nil && !os.IsNotExist(err) {
+		return false, nil, nil, err
+	}
+	sumBytes, err = ioutil.ReadFile(strings.TrimSuffix(tmpURI.Filename(), ".mod") + ".sum")
+	if err != nil && !os.IsNotExist(err) {
+		return false, nil, nil, err
+	}
+	return true, modBytes, sumBytes, nil
 }
 
 func (s *snapshot) goCommandInvocation(ctx context.Context, flags source.InvocationFlags, inv *gocommand.Invocation) (tmpURI span.URI, updatedInv *gocommand.Invocation, cleanup func(), err error) {
@@ -917,10 +956,7 @@ func (s *snapshot) isWorkspacePackage(id packageID) (packagePath, bool) {
 }
 
 func (s *snapshot) FindFile(uri span.URI) source.VersionedFileHandle {
-	f, err := s.view.getFile(uri)
-	if err != nil {
-		return nil
-	}
+	f := s.view.getFile(uri)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -934,10 +970,7 @@ func (s *snapshot) FindFile(uri span.URI) source.VersionedFileHandle {
 // GetVersionedFile succeeds even if the file does not exist. A non-nil error return
 // indicates some type of internal error, for example if ctx is cancelled.
 func (s *snapshot) GetVersionedFile(ctx context.Context, uri span.URI) (source.VersionedFileHandle, error) {
-	f, err := s.view.getFile(uri)
-	if err != nil {
-		return nil, err
-	}
+	f := s.view.getFile(uri)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1386,8 +1419,6 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 			}
 		}
 		if isGoMod(uri) {
-			// If the view's go.mod file's contents have changed, invalidate
-			// the metadata for every known package in the snapshot.
 			delete(result.parseModHandles, uri)
 		}
 		// Handle the invalidated file; it may have new contents or not exist.
@@ -1721,7 +1752,14 @@ func buildWorkspaceModFile(ctx context.Context, modFiles map[span.URI]struct{}, 
 	goVersion := "1.12"
 
 	paths := make(map[string]span.URI)
-	for modURI := range modFiles {
+	var sortedModURIs []span.URI
+	for uri := range modFiles {
+		sortedModURIs = append(sortedModURIs, uri)
+	}
+	sort.Slice(sortedModURIs, func(i, j int) bool {
+		return sortedModURIs[i] < sortedModURIs[j]
+	})
+	for _, modURI := range sortedModURIs {
 		fh, err := fs.GetFile(ctx, modURI)
 		if err != nil {
 			return nil, err
@@ -1762,7 +1800,7 @@ func buildWorkspaceModFile(ctx context.Context, modFiles map[span.URI]struct{}, 
 	}
 	// Go back through all of the modules to handle any of their replace
 	// statements.
-	for modURI := range modFiles {
+	for _, modURI := range sortedModURIs {
 		fh, err := fs.GetFile(ctx, modURI)
 		if err != nil {
 			return nil, err

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
@@ -384,24 +384,21 @@ func (v *View) knownFile(uri span.URI) bool {
 	return f != nil && err == nil
 }
 
-// getFile returns a file for the given URI. It will always succeed because it
-// adds the file to the managed set if needed.
-func (v *View) getFile(uri span.URI) (*fileBase, error) {
+// getFile returns a file for the given URI.
+func (v *View) getFile(uri span.URI) *fileBase {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
-	f, err := v.findFile(uri)
-	if err != nil {
-		return nil, err
-	} else if f != nil {
-		return f, nil
+	f, _ := v.findFile(uri)
+	if f != nil {
+		return f
 	}
 	f = &fileBase{
 		view:  v,
 		fname: uri.Filename(),
 	}
 	v.mapFile(uri, f)
-	return f, nil
+	return f
 }
 
 // findFile checks the cache for any file matching the given uri.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -52,7 +53,7 @@ type commandHandler struct {
 
 // commandConfig configures common command set-up and execution.
 type commandConfig struct {
-	async       bool
+	async       bool                 // whether to run the command asynchronously. Async commands cannot return results.
 	requireSave bool                 // whether all files must be saved for the command to work
 	progress    string               // title to use for progress reporting. If empty, no progress will be reported.
 	forURI      protocol.DocumentURI // URI to resolve to a snapshot. If unset, snapshot will be nil.
@@ -174,20 +175,19 @@ func (c *commandHandler) UpgradeDependency(ctx context.Context, args command.Dep
 
 func (c *commandHandler) GoGetModule(ctx context.Context, args command.DependencyArgs) error {
 	return c.run(ctx, commandConfig{
-		requireSave: true,
-		progress:    "Running go get",
-		forURI:      args.URI,
+		progress: "Running go get",
+		forURI:   args.URI,
 	}, func(ctx context.Context, deps commandDeps) error {
-		return runGoGetModule(ctx, deps.snapshot, args.URI.SpanURI(), args.AddRequire, args.GoCmdArgs)
+		return c.s.runGoModUpdateCommands(ctx, deps.snapshot, args.URI.SpanURI(), func(invoke func(...string) (*bytes.Buffer, error)) error {
+			return runGoGetModule(invoke, args.AddRequire, args.GoCmdArgs)
+		})
 	})
 }
 
 // TODO(rFindley): UpdateGoSum, Tidy, and Vendor could probably all be one command.
-
 func (c *commandHandler) UpdateGoSum(ctx context.Context, args command.URIArgs) error {
 	return c.run(ctx, commandConfig{
-		requireSave: true,
-		progress:    "Updating go.sum",
+		progress: "Updating go.sum",
 	}, func(ctx context.Context, deps commandDeps) error {
 		for _, uri := range args.URIs {
 			snapshot, fh, ok, release, err := c.s.beginFileRequest(ctx, uri, source.UnknownKind)
@@ -195,7 +195,10 @@ func (c *commandHandler) UpdateGoSum(ctx context.Context, args command.URIArgs) 
 			if !ok {
 				return err
 			}
-			if err := runSimpleGoCommand(ctx, snapshot, source.UpdateUserModFile|source.AllowNetwork, fh.URI(), "list", []string{"all"}); err != nil {
+			if err := c.s.runGoModUpdateCommands(ctx, snapshot, fh.URI(), func(invoke func(...string) (*bytes.Buffer, error)) error {
+				_, err := invoke("list", "all")
+				return err
+			}); err != nil {
 				return err
 			}
 		}
@@ -214,7 +217,10 @@ func (c *commandHandler) Tidy(ctx context.Context, args command.URIArgs) error {
 			if !ok {
 				return err
 			}
-			if err := runSimpleGoCommand(ctx, snapshot, source.UpdateUserModFile|source.AllowNetwork, fh.URI(), "mod", []string{"tidy"}); err != nil {
+			if err := c.s.runGoModUpdateCommands(ctx, snapshot, fh.URI(), func(invoke func(...string) (*bytes.Buffer, error)) error {
+				_, err := invoke("mod", "tidy")
+				return err
+			}); err != nil {
 				return err
 			}
 		}
@@ -228,15 +234,19 @@ func (c *commandHandler) Vendor(ctx context.Context, args command.URIArg) error 
 		progress:    "Running go mod vendor",
 		forURI:      args.URI,
 	}, func(ctx context.Context, deps commandDeps) error {
-		return runSimpleGoCommand(ctx, deps.snapshot, source.UpdateUserModFile|source.AllowNetwork, args.URI.SpanURI(), "mod", []string{"vendor"})
+		_, err := deps.snapshot.RunGoCommandDirect(ctx, source.Normal|source.AllowNetwork, &gocommand.Invocation{
+			Verb:       "mod",
+			Args:       []string{"vendor"},
+			WorkingDir: filepath.Dir(args.URI.SpanURI().Filename()),
+		})
+		return err
 	})
 }
 
 func (c *commandHandler) RemoveDependency(ctx context.Context, args command.RemoveDependencyArgs) error {
 	return c.run(ctx, commandConfig{
-		requireSave: true,
-		progress:    "Removing dependency",
-		forURI:      args.URI,
+		progress: "Removing dependency",
+		forURI:   args.URI,
 	}, func(ctx context.Context, deps commandDeps) error {
 		// If the module is tidied apart from the one unused diagnostic, we can
 		// run `go get module@none`, and then run `go mod tidy`. Otherwise, we
@@ -244,10 +254,13 @@ func (c *commandHandler) RemoveDependency(ctx context.Context, args command.Remo
 		// TODO(rstambler): In Go 1.17+, we will be able to use the go command
 		// without checking if the module is tidy.
 		if args.OnlyDiagnostic {
-			if err := runGoGetModule(ctx, deps.snapshot, args.URI.SpanURI(), false, []string{args.ModulePath + "@none"}); err != nil {
+			return c.s.runGoModUpdateCommands(ctx, deps.snapshot, args.URI.SpanURI(), func(invoke func(...string) (*bytes.Buffer, error)) error {
+				if err := runGoGetModule(invoke, false, []string{args.ModulePath + "@none"}); err != nil {
+					return err
+				}
+				_, err := invoke("mod", "tidy")
 				return err
-			}
-			return runSimpleGoCommand(ctx, deps.snapshot, source.UpdateUserModFile|source.AllowNetwork, args.URI.SpanURI(), "mod", []string{"tidy"})
+			})
 		}
 		pm, err := deps.snapshot.ParseMod(ctx, deps.fh)
 		if err != nil {
@@ -444,39 +457,114 @@ func (c *commandHandler) GoGetPackage(ctx context.Context, args command.GoGetPac
 		forURI:   args.URI,
 		progress: "Running go get",
 	}, func(ctx context.Context, deps commandDeps) error {
-		uri := args.URI.SpanURI()
+		// Run on a throwaway go.mod, otherwise it'll write to the real one.
 		stdout, err := deps.snapshot.RunGoCommandDirect(ctx, source.WriteTemporaryModFile|source.AllowNetwork, &gocommand.Invocation{
 			Verb:       "list",
 			Args:       []string{"-f", "{{.Module.Path}}@{{.Module.Version}}", args.Pkg},
-			WorkingDir: filepath.Dir(uri.Filename()),
+			WorkingDir: filepath.Dir(args.URI.SpanURI().Filename()),
 		})
 		if err != nil {
 			return err
 		}
 		ver := strings.TrimSpace(stdout.String())
-		return runGoGetModule(ctx, deps.snapshot, uri, args.AddRequire, []string{ver})
+		return c.s.runGoModUpdateCommands(ctx, deps.snapshot, args.URI.SpanURI(), func(invoke func(...string) (*bytes.Buffer, error)) error {
+			return runGoGetModule(invoke, args.AddRequire, []string{ver})
+		})
 	})
 }
 
-func runGoGetModule(ctx context.Context, snapshot source.Snapshot, uri span.URI, addRequire bool, args []string) error {
+func (s *Server) runGoModUpdateCommands(ctx context.Context, snapshot source.Snapshot, uri span.URI, run func(invoke func(...string) (*bytes.Buffer, error)) error) error {
+	tmpModfile, newModBytes, newSumBytes, err := snapshot.RunGoCommands(ctx, true, filepath.Dir(uri.Filename()), run)
+	if err != nil {
+		return err
+	}
+	if !tmpModfile {
+		return nil
+	}
+	modURI := snapshot.GoModForFile(uri)
+	sumURI := span.URIFromPath(strings.TrimSuffix(modURI.Filename(), ".mod") + ".sum")
+	modEdits, err := applyFileEdits(ctx, snapshot, modURI, newModBytes)
+	if err != nil {
+		return err
+	}
+	sumEdits, err := applyFileEdits(ctx, snapshot, sumURI, newSumBytes)
+	if err != nil {
+		return err
+	}
+	changes := append(sumEdits, modEdits...)
+	if len(changes) == 0 {
+		return nil
+	}
+	response, err := s.client.ApplyEdit(ctx, &protocol.ApplyWorkspaceEditParams{
+		Edit: protocol.WorkspaceEdit{
+			DocumentChanges: changes,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if !response.Applied {
+		return fmt.Errorf("edits not applied because of %s", response.FailureReason)
+	}
+	return nil
+}
+
+func applyFileEdits(ctx context.Context, snapshot source.Snapshot, uri span.URI, newContent []byte) ([]protocol.TextDocumentEdit, error) {
+	fh, err := snapshot.GetVersionedFile(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	oldContent, err := fh.Read()
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if bytes.Equal(oldContent, newContent) {
+		return nil, nil
+	}
+
+	// Sending a workspace edit to a closed file causes VS Code to open the
+	// file and leave it unsaved. We would rather apply the changes directly,
+	// especially to go.sum, which should be mostly invisible to the user.
+	if !snapshot.IsOpen(uri) {
+		err := ioutil.WriteFile(uri.Filename(), newContent, 0666)
+		return nil, err
+	}
+
+	m := &protocol.ColumnMapper{
+		URI:       fh.URI(),
+		Converter: span.NewContentConverter(fh.URI().Filename(), oldContent),
+		Content:   oldContent,
+	}
+	diff, err := snapshot.View().Options().ComputeEdits(uri, string(oldContent), string(newContent))
+	if err != nil {
+		return nil, err
+	}
+	edits, err := source.ToProtocolEdits(m, diff)
+	if err != nil {
+		return nil, err
+	}
+	return []protocol.TextDocumentEdit{{
+		TextDocument: protocol.OptionalVersionedTextDocumentIdentifier{
+			Version: fh.Version(),
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
+				URI: protocol.URIFromSpanURI(uri),
+			},
+		},
+		Edits: edits,
+	}}, nil
+}
+
+func runGoGetModule(invoke func(...string) (*bytes.Buffer, error), addRequire bool, args []string) error {
 	if addRequire {
 		// Using go get to create a new dependency results in an
 		// `// indirect` comment we may not want. The only way to avoid it
 		// is to add the require as direct first. Then we can use go get to
 		// update go.sum and tidy up.
-		if err := runSimpleGoCommand(ctx, snapshot, source.UpdateUserModFile, uri, "mod", append([]string{"edit", "-require"}, args...)); err != nil {
+		if _, err := invoke(append([]string{"mod", "edit", "-require"}, args...)...); err != nil {
 			return err
 		}
 	}
-	return runSimpleGoCommand(ctx, snapshot, source.UpdateUserModFile|source.AllowNetwork, uri, "get", append([]string{"-d"}, args...))
-}
-
-func runSimpleGoCommand(ctx context.Context, snapshot source.Snapshot, mode source.InvocationFlags, uri span.URI, verb string, args []string) error {
-	_, err := snapshot.RunGoCommandDirect(ctx, mode, &gocommand.Invocation{
-		Verb:       verb,
-		Args:       args,
-		WorkingDir: filepath.Dir(uri.Filename()),
-	})
+	_, err := invoke(append([]string{"get", "-d"}, args...)...)
 	return err
 }
 
@@ -555,4 +643,29 @@ func (c *commandHandler) GenerateGoplsMod(ctx context.Context, args command.URIA
 		}
 		return nil
 	})
+}
+
+func (c *commandHandler) ListKnownPackages(ctx context.Context, args command.URIArg) (command.ListKnownPackagesResult, error) {
+	var result command.ListKnownPackagesResult
+	err := c.run(ctx, commandConfig{
+		progress: "Listing packages", // optional, causes a progress report during command execution
+		forURI:   args.URI,           // optional, populates deps.snapshot and deps.fh
+	}, func(ctx context.Context, deps commandDeps) error {
+		// Marwan: add implementation here. deps.snapshot and deps.fh are available for use.
+		result.Packages = []string{}
+		return nil
+	})
+	return result, err
+}
+
+func (c *commandHandler) AddImport(ctx context.Context, args command.AddImportArgs) (command.AddImportResult, error) {
+	var result command.AddImportResult
+	err := c.run(ctx, commandConfig{
+		progress: "Adding import",
+		forURI:   args.URI,
+	}, func(ctx context.Context, deps commandDeps) error {
+		result.Edits = nil
+		return nil
+	})
+	return result, err
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command/command_gen.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command/command_gen.go
@@ -19,12 +19,14 @@ import (
 
 const (
 	AddDependency     Command = "add_dependency"
+	AddImport         Command = "add_import"
 	ApplyFix          Command = "apply_fix"
 	CheckUpgrades     Command = "check_upgrades"
 	GCDetails         Command = "gc_details"
 	Generate          Command = "generate"
 	GenerateGoplsMod  Command = "generate_gopls_mod"
 	GoGetPackage      Command = "go_get_package"
+	ListKnownPackages Command = "list_known_packages"
 	RegenerateCgo     Command = "regenerate_cgo"
 	RemoveDependency  Command = "remove_dependency"
 	RunTests          Command = "run_tests"
@@ -38,12 +40,14 @@ const (
 
 var Commands = []Command{
 	AddDependency,
+	AddImport,
 	ApplyFix,
 	CheckUpgrades,
 	GCDetails,
 	Generate,
 	GenerateGoplsMod,
 	GoGetPackage,
+	ListKnownPackages,
 	RegenerateCgo,
 	RemoveDependency,
 	RunTests,
@@ -62,71 +66,73 @@ func Dispatch(ctx context.Context, params *protocol.ExecuteCommandParams, s Inte
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.AddDependency(ctx, a0)
-		return nil, err
+		return nil, s.AddDependency(ctx, a0)
+	case "gopls.add_import":
+		var a0 AddImportArgs
+		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
+			return nil, err
+		}
+		return s.AddImport(ctx, a0)
 	case "gopls.apply_fix":
 		var a0 ApplyFixArgs
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.ApplyFix(ctx, a0)
-		return nil, err
+		return nil, s.ApplyFix(ctx, a0)
 	case "gopls.check_upgrades":
 		var a0 CheckUpgradesArgs
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.CheckUpgrades(ctx, a0)
-		return nil, err
+		return nil, s.CheckUpgrades(ctx, a0)
 	case "gopls.gc_details":
 		var a0 protocol.DocumentURI
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.GCDetails(ctx, a0)
-		return nil, err
+		return nil, s.GCDetails(ctx, a0)
 	case "gopls.generate":
 		var a0 GenerateArgs
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.Generate(ctx, a0)
-		return nil, err
+		return nil, s.Generate(ctx, a0)
 	case "gopls.generate_gopls_mod":
 		var a0 URIArg
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.GenerateGoplsMod(ctx, a0)
-		return nil, err
+		return nil, s.GenerateGoplsMod(ctx, a0)
 	case "gopls.go_get_package":
 		var a0 GoGetPackageArgs
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.GoGetPackage(ctx, a0)
-		return nil, err
+		return nil, s.GoGetPackage(ctx, a0)
+	case "gopls.list_known_packages":
+		var a0 URIArg
+		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
+			return nil, err
+		}
+		return s.ListKnownPackages(ctx, a0)
 	case "gopls.regenerate_cgo":
 		var a0 URIArg
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.RegenerateCgo(ctx, a0)
-		return nil, err
+		return nil, s.RegenerateCgo(ctx, a0)
 	case "gopls.remove_dependency":
 		var a0 RemoveDependencyArgs
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.RemoveDependency(ctx, a0)
-		return nil, err
+		return nil, s.RemoveDependency(ctx, a0)
 	case "gopls.run_tests":
 		var a0 RunTestsArgs
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.RunTests(ctx, a0)
-		return nil, err
+		return nil, s.RunTests(ctx, a0)
 	case "gopls.test":
 		var a0 protocol.DocumentURI
 		var a1 []string
@@ -134,43 +140,37 @@ func Dispatch(ctx context.Context, params *protocol.ExecuteCommandParams, s Inte
 		if err := UnmarshalArgs(params.Arguments, &a0, &a1, &a2); err != nil {
 			return nil, err
 		}
-		err := s.Test(ctx, a0, a1, a2)
-		return nil, err
+		return nil, s.Test(ctx, a0, a1, a2)
 	case "gopls.tidy":
 		var a0 URIArgs
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.Tidy(ctx, a0)
-		return nil, err
+		return nil, s.Tidy(ctx, a0)
 	case "gopls.toggle_gc_details":
 		var a0 URIArg
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.ToggleGCDetails(ctx, a0)
-		return nil, err
+		return nil, s.ToggleGCDetails(ctx, a0)
 	case "gopls.update_go_sum":
 		var a0 URIArgs
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.UpdateGoSum(ctx, a0)
-		return nil, err
+		return nil, s.UpdateGoSum(ctx, a0)
 	case "gopls.upgrade_dependency":
 		var a0 DependencyArgs
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.UpgradeDependency(ctx, a0)
-		return nil, err
+		return nil, s.UpgradeDependency(ctx, a0)
 	case "gopls.vendor":
 		var a0 URIArg
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		err := s.Vendor(ctx, a0)
-		return nil, err
+		return nil, s.Vendor(ctx, a0)
 	}
 	return nil, fmt.Errorf("unsupported command %q", params.Command)
 }
@@ -183,6 +183,18 @@ func NewAddDependencyCommand(title string, a0 DependencyArgs) (protocol.Command,
 	return protocol.Command{
 		Title:     title,
 		Command:   "gopls.add_dependency",
+		Arguments: args,
+	}, nil
+}
+
+func NewAddImportCommand(title string, a0 AddImportArgs) (protocol.Command, error) {
+	args, err := MarshalArgs(a0)
+	if err != nil {
+		return protocol.Command{}, err
+	}
+	return protocol.Command{
+		Title:     title,
+		Command:   "gopls.add_import",
 		Arguments: args,
 	}, nil
 }
@@ -255,6 +267,18 @@ func NewGoGetPackageCommand(title string, a0 GoGetPackageArgs) (protocol.Command
 	return protocol.Command{
 		Title:     title,
 		Command:   "gopls.go_get_package",
+		Arguments: args,
+	}, nil
+}
+
+func NewListKnownPackagesCommand(title string, a0 URIArg) (protocol.Command, error) {
+	args, err := MarshalArgs(a0)
+	if err != nil {
+		return protocol.Command{}, err
+	}
+	return protocol.Command{
+		Title:     title,
+		Command:   "gopls.list_known_packages",
 		Arguments: args,
 	}, nil
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command/generate/generate.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command/generate/generate.go
@@ -58,8 +58,7 @@ func Dispatch(ctx context.Context, params *protocol.ExecuteCommandParams, s Inte
 			return nil, err
 		}
 		{{end -}}
-		{{- if .Result -}}res, {{end}}err := s.{{.MethodName}}(ctx{{range $i, $v := .Args}}, a{{$i}}{{end}})
-		return {{if .Result}}res{{else}}nil{{end}}, err
+		return {{if not .Result}}nil, {{end}}s.{{.MethodName}}(ctx{{range $i, $v := .Args}}, a{{$i}}{{end}})
 	{{- end}}
 	}
 	return nil, fmt.Errorf("unsupported command %q", params.Command)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command/interface.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command/interface.go
@@ -114,6 +114,10 @@ type Interface interface {
 	//
 	// (Re)generate the gopls.mod file for a workspace.
 	GenerateGoplsMod(context.Context, URIArg) error
+
+	ListKnownPackages(context.Context, URIArg) (ListKnownPackagesResult, error)
+
+	AddImport(context.Context, AddImportArgs) (AddImportResult, error)
 }
 
 type RunTestsArgs struct {
@@ -186,4 +190,19 @@ type GoGetPackageArgs struct {
 	// The package to go get.
 	Pkg        string
 	AddRequire bool
+}
+
+// TODO (Marwan): document :)
+
+type AddImportArgs struct {
+	ImportPath string
+	URI        protocol.DocumentURI
+}
+
+type AddImportResult struct {
+	Edits []protocol.TextDocumentEdit
+}
+
+type ListKnownPackagesResult struct {
+	Packages []string
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/client.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/client.go
@@ -7,6 +7,7 @@ package fake
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 )
@@ -110,8 +111,7 @@ func (c *Client) WorkDoneProgressCreate(ctx context.Context, params *protocol.Wo
 	return nil
 }
 
-// ApplyEdit applies edits sent from the server. Note that as of writing gopls
-// doesn't use this feature, so it is untested.
+// ApplyEdit applies edits sent from the server.
 func (c *Client) ApplyEdit(ctx context.Context, params *protocol.ApplyWorkspaceEditParams) (*protocol.ApplyWorkspaceEditResponse, error) {
 	if len(params.Edit.Changes) != 0 {
 		return &protocol.ApplyWorkspaceEditResponse{FailureReason: "Edit.Changes is unsupported"}, nil
@@ -119,6 +119,16 @@ func (c *Client) ApplyEdit(ctx context.Context, params *protocol.ApplyWorkspaceE
 	for _, change := range params.Edit.DocumentChanges {
 		path := c.editor.sandbox.Workdir.URIToPath(change.TextDocument.URI)
 		edits := convertEdits(change.Edits)
+		if !c.editor.HasBuffer(path) {
+			err := c.editor.OpenFile(ctx, path)
+			if os.IsNotExist(err) {
+				c.editor.CreateBuffer(ctx, path, "")
+				err = nil
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
 		if err := c.editor.EditBuffer(ctx, path, edits); err != nil {
 			return nil, err
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -679,6 +679,12 @@ var GeneratedAPIJSON = &APIJSON{
 			ArgDoc:  "{\n\t// The go.mod file URI.\n\t\"URI\": string,\n\t// Additional args to pass to the go command.\n\t\"GoCmdArgs\": []string,\n\t// Whether to add a require directive.\n\t\"AddRequire\": bool,\n}",
 		},
 		{
+			Command: "gopls.add_import",
+			Title:   "",
+			Doc:     "",
+			ArgDoc:  "{\n\t\"ImportPath\": string,\n\t\"URI\": string,\n}",
+		},
+		{
 			Command: "gopls.apply_fix",
 			Title:   "Apply a fix",
 			Doc:     "Applies a fix to a region of source code.",
@@ -713,6 +719,12 @@ var GeneratedAPIJSON = &APIJSON{
 			Title:   "go get package",
 			Doc:     "Runs `go get` to fetch a package.",
 			ArgDoc:  "{\n\t// Any document URI within the relevant module.\n\t\"URI\": string,\n\t// The package to go get.\n\t\"Pkg\": string,\n\t\"AddRequire\": bool,\n}",
+		},
+		{
+			Command: "gopls.list_known_packages",
+			Title:   "",
+			Doc:     "",
+			ArgDoc:  "{\n\t// The file URI.\n\t\"URI\": string,\n}",
 		},
 		{
 			Command: "gopls.regenerate_cgo",

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -94,6 +94,10 @@ type Snapshot interface {
 	// WorkingDir must be specified.
 	RunGoCommandDirect(ctx context.Context, mode InvocationFlags, inv *gocommand.Invocation) (*bytes.Buffer, error)
 
+	// RunGoCommands runs a series of `go` commands that updates the go.mod
+	// and go.sum file for wd, and returns their updated contents.
+	RunGoCommands(ctx context.Context, allowNetwork bool, wd string, run func(invoke func(...string) (*bytes.Buffer, error)) error) (bool, []byte, []byte, error)
+
 	// RunProcessEnvFunc runs fn with the process env for this snapshot's view.
 	// Note: the process env contains cached module and filesystem state.
 	RunProcessEnvFunc(ctx context.Context, fn func(*imports.Options) error) error
@@ -185,7 +189,7 @@ const (
 
 	// AllowNetwork is a flag bit that indicates the invocation should be
 	// allowed to access the network.
-	AllowNetwork = 1 << 10
+	AllowNetwork InvocationFlags = 1 << 10
 )
 
 func (m InvocationFlags) Mode() InvocationFlags {

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.1
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
-	golang.org/x/tools v0.1.1-0.20210210153715-51f72a196fcd
-	golang.org/x/tools/gopls v0.0.0-20210210153715-51f72a196fcd
+	golang.org/x/tools v0.1.1-0.20210213011012-68c7d11ad44a
+	golang.org/x/tools/gopls v0.0.0-20210213011012-68c7d11ad44a
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1-0.20210210153715-51f72a196fcd h1:jnMMDopgAB011JzgjSqxhHarOOTlKqD+BLL35SE2SY4=
-golang.org/x/tools v0.1.1-0.20210210153715-51f72a196fcd/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
-golang.org/x/tools/gopls v0.0.0-20210210153715-51f72a196fcd h1:jQT9z3jwYqT5hNC2ERw9XPjN4/G+2iOlIojNP5CI5kA=
-golang.org/x/tools/gopls v0.0.0-20210210153715-51f72a196fcd/go.mod h1:q2ebn/wWEF1eM4RLz1NFKDK1JvIzDUrKvKw5RRfW+rI=
+golang.org/x/tools v0.1.1-0.20210213011012-68c7d11ad44a h1:sGQXH1dCASiBG+CPLgeDZtSzmEDrbY+e7YqgDXWdBdE=
+golang.org/x/tools v0.1.1-0.20210213011012-68c7d11ad44a/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
+golang.org/x/tools/gopls v0.0.0-20210213011012-68c7d11ad44a h1:MZ2DJdnqS4VfdLZOiAYycW/FRqMmNPekbJ6OasrBOxM=
+golang.org/x/tools/gopls v0.0.0-20210213011012-68c7d11ad44a/go.mod h1:q2ebn/wWEF1eM4RLz1NFKDK1JvIzDUrKvKw5RRfW+rI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* go/analysis: extend the loopclosure checker to considering errgroup.Group.Go. 68c7d11a
* internal/lsp: always return file handles for nonexistent files add869b6
* internal/lsp/cache: build the workspace module deterministically 701d1429
* gopls/internal/regtest: exit if small machine ed2b1e9f
* godoc: convert Markdown files to HTML during serving 5bd3da9b
* gopls/internal/regtest: skip known flake TestGCDetails 9eba6e15
* gopls/internal/regtest/workspace: disable flaky MultiModule_OneBrokenModule test 9f3e2260
* internal/lsp: apply go.mod/sum changes via workspace edits 706a59cb
* internal/lsp/command: stub out the ListKnownPackages and AddImport commands 8316e564