### PR TITLE
cmd/govim: set the user to not be busy when window focus is lost

### DIFF
--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -234,7 +234,7 @@ function s:define(channel, msg)
       doautoall govim FileType
       if $GOVIM_DISABLE_USER_BUSY != "true"
         au govim CursorMoved,CursorMovedI * ++nested :call s:userBusy(1)
-        au govim CursorHold,CursorHoldI * ++nested :call s:userBusy(0)
+        au govim CursorHold,CursorHoldI,FocusLost * ++nested :call s:userBusy(0)
       endif
       for F in s:loadStatusCallbacks
         call call(F, [s:govim_status])


### PR DESCRIPTION
This feels like the right thing to do, and indeed in practice it's a
problem if we don't do this.

Tested by hand locally, because writing a test for this might well be
impossible given the infrastructure we have.

Fixes #1044