### PR TITLE
deps: update x/tools and gopls to 4b197900

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/command/gen/gen.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command/gen/gen.go
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package generate is used to generate command bindings from the gopls command
+// Package gen is used to generate command bindings from the gopls command
 // interface.
-package generate
+package gen
 
 import (
 	"bytes"

--- a/cmd/govim/internal/golang_org_x_tools/lsp/definition.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/definition.go
@@ -21,7 +21,9 @@ func (s *Server) definition(ctx context.Context, params *protocol.DefinitionPara
 	if err != nil {
 		return nil, err
 	}
-
+	if !snapshot.View().Options().ImportShortcut.ShowDefinition() {
+		return nil, nil
+	}
 	var locations []protocol.Location
 	for _, ref := range ident.Declaration.MappedRange {
 		decRange, err := ref.Range()

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
@@ -109,6 +109,8 @@ type EditorConfig struct {
 	DirectoryFilters []string
 
 	VerboseOutput bool
+
+	ImportShortcut string
 }
 
 // NewEditor Creates a new Editor.
@@ -236,6 +238,10 @@ func (e *Editor) configuration() map[string]interface{} {
 
 	if e.Config.VerboseOutput {
 		config["verboseOutput"] = true
+	}
+
+	if e.Config.ImportShortcut != "" {
+		config["importShortcut"] = e.Config.ImportShortcut
 	}
 
 	// TODO(rFindley): change to the new settings name once it is no longer
@@ -741,17 +747,26 @@ func (e *Editor) Symbol(ctx context.Context, query string) ([]SymbolInformation,
 
 // OrganizeImports requests and performs the source.organizeImports codeAction.
 func (e *Editor) OrganizeImports(ctx context.Context, path string) error {
-	return e.codeAction(ctx, path, nil, nil, protocol.SourceOrganizeImports)
+	_, err := e.codeAction(ctx, path, nil, nil, protocol.SourceOrganizeImports)
+	return err
 }
 
 // RefactorRewrite requests and performs the source.refactorRewrite codeAction.
 func (e *Editor) RefactorRewrite(ctx context.Context, path string, rng *protocol.Range) error {
-	return e.codeAction(ctx, path, rng, nil, protocol.RefactorRewrite)
+	applied, err := e.codeAction(ctx, path, rng, nil, protocol.RefactorRewrite)
+	if applied == 0 {
+		return errors.Errorf("no refactorings were applied")
+	}
+	return err
 }
 
 // ApplyQuickFixes requests and performs the quickfix codeAction.
 func (e *Editor) ApplyQuickFixes(ctx context.Context, path string, rng *protocol.Range, diagnostics []protocol.Diagnostic) error {
-	return e.codeAction(ctx, path, rng, diagnostics, protocol.QuickFix, protocol.SourceFixAll)
+	applied, err := e.codeAction(ctx, path, rng, diagnostics, protocol.QuickFix, protocol.SourceFixAll)
+	if applied == 0 {
+		return errors.Errorf("no quick fixes were applied")
+	}
+	return err
 }
 
 // GetQuickFixes returns the available quick fix code actions.
@@ -759,14 +774,15 @@ func (e *Editor) GetQuickFixes(ctx context.Context, path string, rng *protocol.R
 	return e.getCodeActions(ctx, path, rng, diagnostics, protocol.QuickFix, protocol.SourceFixAll)
 }
 
-func (e *Editor) codeAction(ctx context.Context, path string, rng *protocol.Range, diagnostics []protocol.Diagnostic, only ...protocol.CodeActionKind) error {
+func (e *Editor) codeAction(ctx context.Context, path string, rng *protocol.Range, diagnostics []protocol.Diagnostic, only ...protocol.CodeActionKind) (int, error) {
 	actions, err := e.getCodeActions(ctx, path, rng, diagnostics, only...)
 	if err != nil {
-		return err
+		return 0, err
 	}
+	applied := 0
 	for _, action := range actions {
 		if action.Title == "" {
-			return errors.Errorf("empty title for code action")
+			return 0, errors.Errorf("empty title for code action")
 		}
 		var match bool
 		for _, o := range only {
@@ -778,6 +794,7 @@ func (e *Editor) codeAction(ctx context.Context, path string, rng *protocol.Rang
 		if !match {
 			continue
 		}
+		applied++
 		for _, change := range action.Edit.DocumentChanges {
 			path := e.sandbox.Workdir.URIToPath(change.TextDocument.URI)
 			if int32(e.buffers[path].version) != change.TextDocument.Version {
@@ -786,7 +803,7 @@ func (e *Editor) codeAction(ctx context.Context, path string, rng *protocol.Rang
 			}
 			edits := convertEdits(change.Edits)
 			if err := e.EditBuffer(ctx, path, edits); err != nil {
-				return errors.Errorf("editing buffer %q: %w", path, err)
+				return 0, errors.Errorf("editing buffer %q: %w", path, err)
 			}
 		}
 		// Execute any commands. The specification says that commands are
@@ -796,15 +813,15 @@ func (e *Editor) codeAction(ctx context.Context, path string, rng *protocol.Rang
 				Command:   action.Command.Command,
 				Arguments: action.Command.Arguments,
 			}); err != nil {
-				return err
+				return 0, err
 			}
 		}
 		// Some commands may edit files on disk.
 		if err := e.sandbox.Workdir.CheckForFileChanges(ctx); err != nil {
-			return err
+			return 0, err
 		}
 	}
-	return nil
+	return applied, nil
 }
 
 func (e *Editor) getCodeActions(ctx context.Context, path string, rng *protocol.Range, diagnostics []protocol.Diagnostic, only ...protocol.CodeActionKind) ([]protocol.CodeAction, error) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
@@ -187,6 +187,10 @@ func HoverIdentifier(ctx context.Context, i *IdentifierInfo) (*HoverInformation,
 			}
 		}
 	}
+	if obj.Pkg() == nil {
+		event.Log(ctx, fmt.Sprintf("nil package for %s", obj))
+		return h, nil
+	}
 	h.importPath = obj.Pkg().Path()
 	h.LinkPath = h.importPath
 	if mod, version, ok := moduleAtVersion(h.LinkPath, i); ok {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/identifier.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/identifier.go
@@ -98,10 +98,7 @@ func findIdentifier(ctx context.Context, snapshot Snapshot, pkg Package, file *a
 	// Handle import specs separately, as there is no formal position for a
 	// package declaration.
 	if result, err := importSpec(snapshot, pkg, file, pos); result != nil || err != nil {
-		if snapshot.View().Options().ImportShortcut.ShowDefinition() {
-			return result, err
-		}
-		return nil, nil
+		return result, err
 	}
 	path := pathEnclosingObjNode(file, pos)
 	if path == nil {

--- a/cmd/govim/internal/golang_org_x_tools/typesinternal/errorcode.go
+++ b/cmd/govim/internal/golang_org_x_tools/typesinternal/errorcode.go
@@ -1209,6 +1209,16 @@ const (
 	//  }
 	InvalidTypeSwitch
 
+	// InvalidExprSwitch occurs when a switch expression is not comparable.
+	//
+	// Example:
+	//  func _() {
+	//  	var a struct{ _ func() }
+	//  	switch a /* ERROR cannot switch on a */ {
+	//  	}
+	//  }
+	InvalidExprSwitch
+
 	/* control flow > select */
 
 	// InvalidSelectCase occurs when a select case is not a channel send or

--- a/cmd/govim/internal/golang_org_x_tools/typesinternal/errorcode_string.go
+++ b/cmd/govim/internal/golang_org_x_tools/typesinternal/errorcode_string.go
@@ -124,24 +124,25 @@ func _() {
 	_ = x[DuplicateDefault-114]
 	_ = x[BadTypeKeyword-115]
 	_ = x[InvalidTypeSwitch-116]
-	_ = x[InvalidSelectCase-117]
-	_ = x[UndeclaredLabel-118]
-	_ = x[DuplicateLabel-119]
-	_ = x[MisplacedLabel-120]
-	_ = x[UnusedLabel-121]
-	_ = x[JumpOverDecl-122]
-	_ = x[JumpIntoBlock-123]
-	_ = x[InvalidMethodExpr-124]
-	_ = x[WrongArgCount-125]
-	_ = x[InvalidCall-126]
-	_ = x[UnusedResults-127]
-	_ = x[InvalidDefer-128]
-	_ = x[InvalidGo-129]
+	_ = x[InvalidExprSwitch-117]
+	_ = x[InvalidSelectCase-118]
+	_ = x[UndeclaredLabel-119]
+	_ = x[DuplicateLabel-120]
+	_ = x[MisplacedLabel-121]
+	_ = x[UnusedLabel-122]
+	_ = x[JumpOverDecl-123]
+	_ = x[JumpIntoBlock-124]
+	_ = x[InvalidMethodExpr-125]
+	_ = x[WrongArgCount-126]
+	_ = x[InvalidCall-127]
+	_ = x[UnusedResults-128]
+	_ = x[InvalidDefer-129]
+	_ = x[InvalidGo-130]
 }
 
-const _ErrorCode_name = "TestBlankPkgNameMismatchedPkgNameInvalidPkgUseBadImportPathBrokenImportImportCRenamedUnusedImportInvalidInitCycleDuplicateDeclInvalidDeclCycleInvalidTypeCycleInvalidConstInitInvalidConstValInvalidConstTypeUntypedNilWrongAssignCountUnassignableOperandNoNewVarMultiValAssignOpInvalidIfaceAssignInvalidChanAssignIncompatibleAssignUnaddressableFieldAssignNotATypeInvalidArrayLenBlankIfaceMethodIncomparableMapKeyInvalidIfaceEmbedInvalidPtrEmbedBadRecvInvalidRecvDuplicateFieldAndMethodDuplicateMethodInvalidBlankInvalidIotaMissingInitBodyInvalidInitSigInvalidInitDeclInvalidMainDeclTooManyValuesNotAnExprTruncatedFloatNumericOverflowUndefinedOpMismatchedTypesDivByZeroNonNumericIncDecUnaddressableOperandInvalidIndirectionNonIndexableOperandInvalidIndexSwappedSliceIndicesNonSliceableOperandInvalidSliceExprInvalidShiftCountInvalidShiftOperandInvalidReceiveInvalidSendDuplicateLitKeyMissingLitKeyInvalidLitIndexOversizeArrayLitMixedStructLitInvalidStructLitMissingLitFieldDuplicateLitFieldUnexportedLitFieldInvalidLitFieldUntypedLitInvalidLitAmbiguousSelectorUndeclaredImportedNameUnexportedNameUndeclaredNameMissingFieldOrMethodBadDotDotDotSyntaxNonVariadicDotDotDotMisplacedDotDotDotInvalidDotDotDotOperandInvalidDotDotDotUncalledBuiltinInvalidAppendInvalidCapInvalidCloseInvalidCopyInvalidComplexInvalidDeleteInvalidImagInvalidLenSwappedMakeArgsInvalidMakeInvalidRealInvalidAssertImpossibleAssertInvalidConversionInvalidUntypedConversionBadOffsetofSyntaxInvalidOffsetofUnusedExprUnusedVarMissingReturnWrongResultCountOutOfScopeResultInvalidCondInvalidPostDeclInvalidChanRangeInvalidIterVarInvalidRangeExprMisplacedBreakMisplacedContinueMisplacedFallthroughDuplicateCaseDuplicateDefaultBadTypeKeywordInvalidTypeSwitchInvalidSelectCaseUndeclaredLabelDuplicateLabelMisplacedLabelUnusedLabelJumpOverDeclJumpIntoBlockInvalidMethodExprWrongArgCountInvalidCallUnusedResultsInvalidDeferInvalidGo"
+const _ErrorCode_name = "TestBlankPkgNameMismatchedPkgNameInvalidPkgUseBadImportPathBrokenImportImportCRenamedUnusedImportInvalidInitCycleDuplicateDeclInvalidDeclCycleInvalidTypeCycleInvalidConstInitInvalidConstValInvalidConstTypeUntypedNilWrongAssignCountUnassignableOperandNoNewVarMultiValAssignOpInvalidIfaceAssignInvalidChanAssignIncompatibleAssignUnaddressableFieldAssignNotATypeInvalidArrayLenBlankIfaceMethodIncomparableMapKeyInvalidIfaceEmbedInvalidPtrEmbedBadRecvInvalidRecvDuplicateFieldAndMethodDuplicateMethodInvalidBlankInvalidIotaMissingInitBodyInvalidInitSigInvalidInitDeclInvalidMainDeclTooManyValuesNotAnExprTruncatedFloatNumericOverflowUndefinedOpMismatchedTypesDivByZeroNonNumericIncDecUnaddressableOperandInvalidIndirectionNonIndexableOperandInvalidIndexSwappedSliceIndicesNonSliceableOperandInvalidSliceExprInvalidShiftCountInvalidShiftOperandInvalidReceiveInvalidSendDuplicateLitKeyMissingLitKeyInvalidLitIndexOversizeArrayLitMixedStructLitInvalidStructLitMissingLitFieldDuplicateLitFieldUnexportedLitFieldInvalidLitFieldUntypedLitInvalidLitAmbiguousSelectorUndeclaredImportedNameUnexportedNameUndeclaredNameMissingFieldOrMethodBadDotDotDotSyntaxNonVariadicDotDotDotMisplacedDotDotDotInvalidDotDotDotOperandInvalidDotDotDotUncalledBuiltinInvalidAppendInvalidCapInvalidCloseInvalidCopyInvalidComplexInvalidDeleteInvalidImagInvalidLenSwappedMakeArgsInvalidMakeInvalidRealInvalidAssertImpossibleAssertInvalidConversionInvalidUntypedConversionBadOffsetofSyntaxInvalidOffsetofUnusedExprUnusedVarMissingReturnWrongResultCountOutOfScopeResultInvalidCondInvalidPostDeclInvalidChanRangeInvalidIterVarInvalidRangeExprMisplacedBreakMisplacedContinueMisplacedFallthroughDuplicateCaseDuplicateDefaultBadTypeKeywordInvalidTypeSwitchInvalidExprSwitchInvalidSelectCaseUndeclaredLabelDuplicateLabelMisplacedLabelUnusedLabelJumpOverDeclJumpIntoBlockInvalidMethodExprWrongArgCountInvalidCallUnusedResultsInvalidDeferInvalidGo"
 
-var _ErrorCode_index = [...]uint16{0, 4, 16, 33, 46, 59, 71, 85, 97, 113, 126, 142, 158, 174, 189, 205, 215, 231, 250, 258, 274, 292, 309, 327, 351, 359, 374, 390, 408, 425, 440, 447, 458, 481, 496, 508, 519, 534, 548, 563, 578, 591, 600, 614, 629, 640, 655, 664, 680, 700, 718, 737, 749, 768, 787, 803, 820, 839, 853, 864, 879, 892, 907, 923, 937, 953, 968, 985, 1003, 1018, 1028, 1038, 1055, 1077, 1091, 1105, 1125, 1143, 1163, 1181, 1204, 1220, 1235, 1248, 1258, 1270, 1281, 1295, 1308, 1319, 1329, 1344, 1355, 1366, 1379, 1395, 1412, 1436, 1453, 1468, 1478, 1487, 1500, 1516, 1532, 1543, 1558, 1574, 1588, 1604, 1618, 1635, 1655, 1668, 1684, 1698, 1715, 1732, 1747, 1761, 1775, 1786, 1798, 1811, 1828, 1841, 1852, 1865, 1877, 1886}
+var _ErrorCode_index = [...]uint16{0, 4, 16, 33, 46, 59, 71, 85, 97, 113, 126, 142, 158, 174, 189, 205, 215, 231, 250, 258, 274, 292, 309, 327, 351, 359, 374, 390, 408, 425, 440, 447, 458, 481, 496, 508, 519, 534, 548, 563, 578, 591, 600, 614, 629, 640, 655, 664, 680, 700, 718, 737, 749, 768, 787, 803, 820, 839, 853, 864, 879, 892, 907, 923, 937, 953, 968, 985, 1003, 1018, 1028, 1038, 1055, 1077, 1091, 1105, 1125, 1143, 1163, 1181, 1204, 1220, 1235, 1248, 1258, 1270, 1281, 1295, 1308, 1319, 1329, 1344, 1355, 1366, 1379, 1395, 1412, 1436, 1453, 1468, 1478, 1487, 1500, 1516, 1532, 1543, 1558, 1574, 1588, 1604, 1618, 1635, 1655, 1668, 1684, 1698, 1715, 1732, 1749, 1764, 1778, 1792, 1803, 1815, 1828, 1845, 1858, 1869, 1882, 1894, 1903}
 
 func (i ErrorCode) String() string {
 	i -= 1

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.1
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
-	golang.org/x/tools v0.1.1-0.20210213011012-68c7d11ad44a
-	golang.org/x/tools/gopls v0.0.0-20210213011012-68c7d11ad44a
+	golang.org/x/tools v0.1.1-0.20210218202311-4b19790092d6
+	golang.org/x/tools/gopls v0.0.0-20210218202311-4b19790092d6
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1-0.20210213011012-68c7d11ad44a h1:sGQXH1dCASiBG+CPLgeDZtSzmEDrbY+e7YqgDXWdBdE=
-golang.org/x/tools v0.1.1-0.20210213011012-68c7d11ad44a/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
-golang.org/x/tools/gopls v0.0.0-20210213011012-68c7d11ad44a h1:MZ2DJdnqS4VfdLZOiAYycW/FRqMmNPekbJ6OasrBOxM=
-golang.org/x/tools/gopls v0.0.0-20210213011012-68c7d11ad44a/go.mod h1:q2ebn/wWEF1eM4RLz1NFKDK1JvIzDUrKvKw5RRfW+rI=
+golang.org/x/tools v0.1.1-0.20210218202311-4b19790092d6 h1:9JHfHJUggBzKTtyY7EUmEqz44EvRbbRa598KCi1JC3E=
+golang.org/x/tools v0.1.1-0.20210218202311-4b19790092d6/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
+golang.org/x/tools/gopls v0.0.0-20210218202311-4b19790092d6 h1:HorSjapcWI2CGA3sRsnE8I4b251JmTmuaruW7/OrYOc=
+golang.org/x/tools/gopls v0.0.0-20210218202311-4b19790092d6/go.mod h1:q2ebn/wWEF1eM4RLz1NFKDK1JvIzDUrKvKw5RRfW+rI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* txtar: minor fix in unit test input 4b197900
* internal/lsp: 'go get' packages instead of modules 9eb35354
* go/internal/cgo: set pkgdir with -srcdir instead of CWD 67e49ef2
* go/analysis/unitchecker: tell the user how to list the flags and analyzers 19ff21fb
* internal/lsp/command: rename package generate to gen d5b83329
* go/internal/gcimporter: reference golang/go#44339 in TODO 4534fc34
* go/internal/gcimporter: fix tests on darwin 35839b70
* go/internal/gcimporter: add "bundled" export data formats a1db63cc
* go/internal/gcimporter: fix reexporting compiler data b79f76fe
* go/internal/gcimporter: refactor IExportData tests 7fde01ff
* go/internal/gcimporter: simplify IExportData API 6055ccf0
* internal/lsp: refactor go command error handling 1e7abacf
* internal/lsp: fix nil pointer in hover when (types.Object).Pkg() is nil ffc20750
* internal/lsp: handle nil pointer with import shortcut = link fca89925
* internal/typesinternal: sync error codes with go1.16 5848b84f
* go/analysis/passes: add sigchanyzer Analyzer 3a5a0519
* godoc/vfs: add io/fs adapter 123adc86