### PR TITLE
deps: update x/tools and gopls to f3748ed8

### DIFF
--- a/_scripts/dockerRun.sh
+++ b/_scripts/dockerRun.sh
@@ -88,7 +88,11 @@ go run honnef.co/go/tools/cmd/staticcheck $(go list ./... | grep -v 'govim/inter
 
 if [ "${CI:-}" == "true" ] && [ "${GITHUB_EVENT_NAME:-}" != "schedule" ]
 then
-	go mod tidy
+	# Hack to work around golang.org/issue/40067
+	if go list -f {{context.ReleaseTags}} runtime | grep $(echo "$MAX_GO_VERSION" | sed -e 's/^\([^.]*\.[^.]*\).*/\1/') > /dev/null
+	then
+		go mod tidy
+	fi
 	diff <(echo -n) <(go run golang.org/x/tools/cmd/goimports -d $(git ls-files '**/*.go' '*.go' | grep -v golang_org_x_tools))
 	test -z "$(git status --porcelain)" || (git status; git diff; false)
 fi

--- a/_scripts/revendorToolsInternal.sh
+++ b/_scripts/revendorToolsInternal.sh
@@ -28,4 +28,8 @@ find ./cmd/govim/internal/golang_org_x_tools/ -type d -name testdata -exec rm -r
 # Copy license
 cp $tools/LICENSE ./cmd/govim/internal/golang_org_x_tools
 
-go mod tidy
+# Hack to work around golang.org/issue/40067
+if go list -f {{context.ReleaseTags}} runtime | grep $(echo "$MAX_GO_VERSION" | sed -e 's/^\([^.]*\.[^.]*\).*/\1/') > /dev/null
+then
+	go mod tidy
+fi

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
@@ -1264,6 +1264,11 @@ func (c *completer) lexical(ctx context.Context) error {
 	var (
 		builtinIota = types.Universe.Lookup("iota")
 		builtinNil  = types.Universe.Lookup("nil")
+		// comparable is an interface that exists on the dev.typeparams Go branch.
+		// Filter it out from completion results to stabilize tests.
+		// TODO(rFindley) update (or remove) our handling for comparable once the
+		//                type parameter API has stabilized.
+		builtinComparable = types.Universe.Lookup("comparable")
 	)
 
 	// Track seen variables to avoid showing completions for shadowed variables.
@@ -1281,6 +1286,9 @@ func (c *completer) lexical(ctx context.Context) error {
 			declScope, obj := scope.LookupParent(name, c.pos)
 			if declScope != scope {
 				continue // Name was declared in some enclosing scope, or not at all.
+			}
+			if obj == builtinComparable {
+				continue
 			}
 
 			// If obj's type is invalid, find the AST node that defines the lexical block

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.1
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
-	golang.org/x/tools v0.1.1-0.20210218202311-4b19790092d6
-	golang.org/x/tools/gopls v0.0.0-20210218202311-4b19790092d6
+	golang.org/x/tools v0.1.1-0.20210219012152-f3748ed8ec89
+	golang.org/x/tools/gopls v0.0.0-20210219012152-f3748ed8ec89
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1-0.20210218202311-4b19790092d6 h1:9JHfHJUggBzKTtyY7EUmEqz44EvRbbRa598KCi1JC3E=
-golang.org/x/tools v0.1.1-0.20210218202311-4b19790092d6/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
-golang.org/x/tools/gopls v0.0.0-20210218202311-4b19790092d6 h1:HorSjapcWI2CGA3sRsnE8I4b251JmTmuaruW7/OrYOc=
-golang.org/x/tools/gopls v0.0.0-20210218202311-4b19790092d6/go.mod h1:q2ebn/wWEF1eM4RLz1NFKDK1JvIzDUrKvKw5RRfW+rI=
+golang.org/x/tools v0.1.1-0.20210219012152-f3748ed8ec89 h1:CEQ9B2ID7kyvD17eBaAu+yYOtnawoOFcUxxtCVRBPzo=
+golang.org/x/tools v0.1.1-0.20210219012152-f3748ed8ec89/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
+golang.org/x/tools/gopls v0.0.0-20210219012152-f3748ed8ec89 h1:gv7t9S5r+UFeolH4lCH46k4fF0kVo1iQJMQ5/kM5BzA=
+golang.org/x/tools/gopls v0.0.0-20210219012152-f3748ed8ec89/go.mod h1:q2ebn/wWEF1eM4RLz1NFKDK1JvIzDUrKvKw5RRfW+rI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Also includes some fixes for our CI build to work around
golang.org/issue/40067

* internal/lsp/source: filter out comparable from completion results f3748ed8
* go/analysis/passes/buildtag: update check for //go:build f47cb783
* go/loader: fix race 06713c25
* internal/regtest: fix regtests for the dev.typeparams Go branch 1f00549a
* txtar: minor fix in unit test input 4b197900
* internal/lsp: 'go get' packages instead of modules 9eb35354
* go/internal/cgo: set pkgdir with -srcdir instead of CWD 67e49ef2
* go/analysis/unitchecker: tell the user how to list the flags and analyzers 19ff21fb
* internal/lsp/command: rename package generate to gen d5b83329
* go/internal/gcimporter: reference golang/go#44339 in TODO 4534fc34
* go/internal/gcimporter: fix tests on darwin 35839b70
* go/internal/gcimporter: add "bundled" export data formats a1db63cc
* go/internal/gcimporter: fix reexporting compiler data b79f76fe
* go/internal/gcimporter: refactor IExportData tests 7fde01ff
* go/internal/gcimporter: simplify IExportData API 6055ccf0
* internal/lsp: refactor go command error handling 1e7abacf
* internal/lsp: fix nil pointer in hover when (types.Object).Pkg() is nil ffc20750
* internal/lsp: handle nil pointer with import shortcut = link fca89925
* internal/typesinternal: sync error codes with go1.16 5848b84f
* go/analysis/passes: add sigchanyzer Analyzer 3a5a0519
* godoc/vfs: add io/fs adapter 123adc86