### PR TITLE
deps: update x/tools and gopls to 376db572

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/analysis.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/analysis.go
@@ -18,17 +18,21 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/analysisinternal"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag"
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/memoize"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	errors "golang.org/x/xerrors"
 )
 
-func (s *snapshot) Analyze(ctx context.Context, id string, analyzers ...*analysis.Analyzer) ([]*source.Diagnostic, error) {
+func (s *snapshot) Analyze(ctx context.Context, id string, analyzers []*source.Analyzer) ([]*source.Diagnostic, error) {
 	var roots []*actionHandle
 
 	for _, a := range analyzers {
-		ah, err := s.actionHandle(ctx, packageID(id), a)
+
+		if !a.IsEnabled(s.view) {
+			continue
+		}
+		ah, err := s.actionHandle(ctx, packageID(id), a.Analyzer)
 		if err != nil {
 			return nil, err
 		}
@@ -324,7 +328,7 @@ func runAnalysis(ctx context.Context, snapshot *snapshot, analyzer *analysis.Ana
 	analysisinternal.SetTypeErrors(pass, pkg.typeErrors)
 
 	if pkg.IsIllTyped() {
-		data.err = errors.Errorf("analysis skipped due to errors in package: %v", pkg.GetDiagnostics())
+		data.err = errors.Errorf("analysis skipped due to errors in package")
 		return data
 	}
 	data.result, data.err = pass.Analyzer.Run(pass)
@@ -348,7 +352,7 @@ func runAnalysis(ctx context.Context, snapshot *snapshot, analyzer *analysis.Ana
 	}
 
 	for _, diag := range diagnostics {
-		srcDiags, err := sourceDiagnostics(ctx, snapshot, pkg, protocol.SeverityWarning, diag)
+		srcDiags, err := analysisDiagnosticDiagnostics(ctx, snapshot, pkg, analyzer, diag)
 		if err != nil {
 			event.Error(ctx, "unable to compute analysis error position", err, tag.Category.Of(diag.Category), tag.Package.Of(pkg.ID()))
 			continue
@@ -390,4 +394,39 @@ func factType(fact analysis.Fact) reflect.Type {
 		panic(fmt.Sprintf("invalid Fact type: got %T, want pointer", t))
 	}
 	return t
+}
+
+func (s *snapshot) DiagnosePackage(ctx context.Context, spkg source.Package) (map[span.URI][]*source.Diagnostic, error) {
+	pkg := spkg.(*pkg)
+	// Apply type error analyzers. They augment type error diagnostics with their own fixes.
+	var analyzers []*source.Analyzer
+	for _, a := range s.View().Options().TypeErrorAnalyzers {
+		analyzers = append(analyzers, a)
+	}
+	var errorAnalyzerDiag []*source.Diagnostic
+	if pkg.hasTypeErrors {
+		var err error
+		errorAnalyzerDiag, err = s.Analyze(ctx, pkg.ID(), analyzers)
+		if err != nil {
+			return nil, err
+		}
+	}
+	diags := map[span.URI][]*source.Diagnostic{}
+	for _, diag := range pkg.diagnostics {
+		for _, eaDiag := range errorAnalyzerDiag {
+			if eaDiag.URI == diag.URI && eaDiag.Range == diag.Range && eaDiag.Message == diag.Message {
+				// Type error analyzers just add fixes and tags. Make a copy,
+				// since we don't own either, and overwrite.
+				// The analyzer itself can't do this merge because
+				// analysis.Diagnostic doesn't have all the fields, and Analyze
+				// can't because it doesn't have the type error, notably its code.
+				clone := *diag
+				clone.SuggestedFixes = eaDiag.SuggestedFixes
+				clone.Tags = eaDiag.Tags
+				diag = &clone
+			}
+		}
+		diags[diag.URI] = append(diags[diag.URI], diag)
+	}
+	return diags, nil
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"go/ast"
+	"go/scanner"
 	"go/types"
 	"path"
 	"path/filepath"
@@ -271,11 +272,6 @@ func typeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode source
 	ctx, done := event.Start(ctx, "cache.importer.typeCheck", tag.Package.Of(string(m.id)))
 	defer done()
 
-	var rawErrors []error
-	for _, err := range m.errors {
-		rawErrors = append(rawErrors, err)
-	}
-
 	fset := snapshot.view.session.cache.fset
 	pkg := &pkg{
 		m:               m,
@@ -307,12 +303,12 @@ func typeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode source
 	}
 	var (
 		files        = make([]*ast.File, len(m.compiledGoFiles))
-		parseErrors  = make([]error, len(m.compiledGoFiles))
+		parseErrors  = make([]scanner.ErrorList, len(m.compiledGoFiles))
 		actualErrors = make([]error, len(m.compiledGoFiles))
 		wg           sync.WaitGroup
 
 		mu             sync.Mutex
-		skipTypeErrors bool
+		haveFixedFiles bool
 	)
 	for i, cgf := range m.compiledGoFiles {
 		wg.Add(1)
@@ -332,8 +328,10 @@ func typeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode source
 			pkg.compiledGoFiles[i] = pgf
 			files[i], parseErrors[i], actualErrors[i] = pgf.File, pgf.ParseErr, err
 
+			// If we have fixed parse errors in any of the files, we should hide type
+			// errors, as they may be completely nonsensical.
 			mu.Lock()
-			skipTypeErrors = skipTypeErrors || fixed
+			haveFixedFiles = haveFixedFiles || fixed
 			mu.Unlock()
 		}(i, cgf)
 	}
@@ -357,13 +355,16 @@ func typeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode source
 		}
 	}
 
+	var i int
 	for _, e := range parseErrors {
 		if e != nil {
-			rawErrors = append(rawErrors, e)
+			parseErrors[i] = e
+			i++
 		}
 	}
+	parseErrors = parseErrors[:i]
 
-	var i int
+	i = 0
 	for _, f := range files {
 		if f != nil {
 			files[i] = f
@@ -379,10 +380,10 @@ func typeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode source
 		// race to Unsafe.completed.
 		return pkg, nil
 	} else if len(files) == 0 { // not the unsafe package, no parsed files
-		// Try to attach errors messages to the file as much as possible.
+		// Try to attach error messages to the file as much as possible.
 		var found bool
-		for _, e := range rawErrors {
-			srcDiags, err := sourceDiagnostics(ctx, snapshot, pkg, protocol.SeverityError, e)
+		for _, e := range m.errors {
+			srcDiags, err := goPackagesErrorDiagnostics(ctx, snapshot, pkg, e)
 			if err != nil {
 				continue
 			}
@@ -392,19 +393,15 @@ func typeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode source
 		if found {
 			return pkg, nil
 		}
-		return nil, errors.Errorf("no parsed files for package %s, expected: %v, list errors: %v", pkg.m.pkgPath, pkg.compiledGoFiles, rawErrors)
+		return nil, errors.Errorf("no parsed files for package %s, expected: %v, errors: %v", pkg.m.pkgPath, pkg.compiledGoFiles, m.errors)
 	} else {
 		pkg.types = types.NewPackage(string(m.pkgPath), string(m.name))
 	}
 
+	var typeErrors []types.Error
 	cfg := &types.Config{
 		Error: func(e error) {
-			// If we have fixed parse errors in any of the files,
-			// we should hide type errors, as they may be completely nonsensical.
-			if skipTypeErrors {
-				return
-			}
-			rawErrors = append(rawErrors, e)
+			typeErrors = append(typeErrors, e.(types.Error))
 		},
 		Importer: importerFunc(func(pkgPath string) (*types.Package, error) {
 			// If the context was cancelled, we should abort.
@@ -441,29 +438,79 @@ func typeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode source
 	}
 
 	// We don't care about a package's errors unless we have parsed it in full.
-	if mode == source.ParseFull {
-		expandErrors(rawErrors)
-		for _, e := range rawErrors {
-			srcDiags, err := sourceDiagnostics(ctx, snapshot, pkg, protocol.SeverityError, e)
+	if mode != source.ParseFull {
+		return pkg, nil
+	}
+
+	if len(m.errors) != 0 {
+		pkg.hasListOrParseErrors = true
+		for _, e := range m.errors {
+			diags, err := goPackagesErrorDiagnostics(ctx, snapshot, pkg, e)
 			if err != nil {
-				event.Error(ctx, "unable to compute error positions", err, tag.Package.Of(pkg.ID()))
+				event.Error(ctx, "unable to compute positions for list errors", err, tag.Package.Of(pkg.ID()))
 				continue
 			}
-			pkg.diagnostics = append(pkg.diagnostics, srcDiags...)
+			pkg.diagnostics = append(pkg.diagnostics, diags...)
+		}
+	}
 
-			if err, ok := e.(extendedError); ok {
-				pkg.typeErrors = append(pkg.typeErrors, err.primary)
+	// Our heuristic for whether to show type checking errors is:
+	//  + If any file was 'fixed', don't show type checking errors as we
+	//    can't guarantee that they reference accurate locations in the source.
+	//  + If there is a parse error _in the current file_, suppress type
+	//    errors in that file.
+	//  + Otherwise, show type errors even in the presence of parse errors in
+	//    other package files. go/types attempts to suppress follow-on errors
+	//    due to bad syntax, so on balance type checking errors still provide
+	//    a decent signal/noise ratio as long as the file in question parses.
+
+	// Track URIs with parse errors so that we can suppress type errors for these
+	// files.
+	unparseable := map[span.URI]bool{}
+	if len(parseErrors) != 0 {
+		pkg.hasListOrParseErrors = true
+		for _, e := range parseErrors {
+			diags, err := parseErrorDiagnostics(ctx, snapshot, pkg, e)
+			if err != nil {
+				event.Error(ctx, "unable to compute positions for parse errors", err, tag.Package.Of(pkg.ID()))
+				continue
+			}
+			for _, diag := range diags {
+				unparseable[diag.URI] = true
+				pkg.diagnostics = append(pkg.diagnostics, diag)
 			}
 		}
+	}
 
-		depsErrors, err := snapshot.depsErrors(ctx, pkg)
+	if haveFixedFiles {
+		return pkg, nil
+	}
+
+	for _, e := range expandErrors(typeErrors, snapshot.View().Options().RelatedInformationSupported) {
+		pkg.hasTypeErrors = true
+		diags, err := typeErrorDiagnostics(ctx, snapshot, pkg, e)
 		if err != nil {
-			return nil, err
+			event.Error(ctx, "unable to compute positions for type errors", err, tag.Package.Of(pkg.ID()))
+			continue
 		}
-		pkg.diagnostics = append(pkg.diagnostics, depsErrors...)
-		if err := addGoGetFixes(ctx, snapshot, pkg); err != nil {
-			return nil, err
+		pkg.typeErrors = append(pkg.typeErrors, e.primary)
+		for _, diag := range diags {
+			// If the file didn't parse cleanly, it is highly likely that type
+			// checking errors will be confusing or redundant. But otherwise, type
+			// checking usually provides a good enough signal to include.
+			if !unparseable[diag.URI] {
+				pkg.diagnostics = append(pkg.diagnostics, diag)
+			}
 		}
+	}
+
+	depsErrors, err := snapshot.depsErrors(ctx, pkg)
+	if err != nil {
+		return nil, err
+	}
+	pkg.diagnostics = append(pkg.diagnostics, depsErrors...)
+	if err := addGoGetFixes(ctx, snapshot, pkg); err != nil {
+		return nil, err
 	}
 
 	return pkg, nil
@@ -651,30 +698,55 @@ func (e extendedError) Error() string {
 // there is a multiply-defined function, the secondary error points back to the
 // definition first noticed.
 //
-// This code associates the secondary error with its primary error, which can
+// This function associates the secondary error with its primary error, which can
 // then be used as RelatedInformation when the error becomes a diagnostic.
-func expandErrors(errs []error) []error {
+//
+// If supportsRelatedInformation is false, the secondary is instead embedded as
+// additional context in the primary error.
+func expandErrors(errs []types.Error, supportsRelatedInformation bool) []extendedError {
+	var result []extendedError
 	for i := 0; i < len(errs); {
-		e, ok := errs[i].(types.Error)
-		if !ok {
-			i++
-			continue
+		original := extendedError{
+			primary: errs[i],
 		}
-		enew := extendedError{
-			primary: e,
-		}
-		j := i + 1
-		for ; j < len(errs); j++ {
-			spl, ok := errs[j].(types.Error)
-			if !ok || len(spl.Msg) == 0 || spl.Msg[0] != '\t' {
+		for i++; i < len(errs); i++ {
+			spl := errs[i]
+			if len(spl.Msg) == 0 || spl.Msg[0] != '\t' {
 				break
 			}
-			enew.secondaries = append(enew.secondaries, spl)
+			spl.Msg = spl.Msg[1:]
+			original.secondaries = append(original.secondaries, spl)
 		}
-		errs[i] = enew
-		i = j
+
+		// Clone the error to all its related locations -- VS Code, at least,
+		// doesn't do it for us.
+		result = append(result, original)
+		for i, mainSecondary := range original.secondaries {
+			// Create the new primary error, with a tweaked message, in the
+			// secondary's location. We need to start from the secondary to
+			// capture its unexported location fields.
+			relocatedSecondary := mainSecondary
+			if supportsRelatedInformation {
+				relocatedSecondary.Msg = fmt.Sprintf("%v (see details)", original.primary.Msg)
+			} else {
+				relocatedSecondary.Msg = fmt.Sprintf("%v (this error: %v)", original.primary.Msg, mainSecondary.Msg)
+			}
+			relocatedSecondary.Soft = original.primary.Soft
+
+			// Copy over the secondary errors, noting the location of the
+			// current error we're cloning.
+			clonedError := extendedError{primary: relocatedSecondary, secondaries: []types.Error{original.primary}}
+			for j, secondary := range original.secondaries {
+				if i == j {
+					secondary.Msg += " (this error)"
+				}
+				clonedError.secondaries = append(clonedError.secondaries, secondary)
+			}
+			result = append(result, clonedError)
+		}
+
 	}
-	return errs
+	return result
 }
 
 // resolveImportPath resolves an import path in pkg to a package from deps.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/errors.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/errors.go
@@ -14,156 +14,201 @@ import (
 	"strconv"
 	"strings"
 
-	errors "golang.org/x/xerrors"
-
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/packages"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/analysisinternal"
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/command"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/typesinternal"
+	errors "golang.org/x/xerrors"
 )
 
-func sourceDiagnostics(ctx context.Context, snapshot *snapshot, pkg *pkg, severity protocol.DiagnosticSeverity, e interface{}) ([]*source.Diagnostic, error) {
-	fset := snapshot.view.session.cache.fset
-	var (
-		spn     span.Span
-		err     error
-		msg     string
-		code    typesinternal.ErrorCode
-		diagSrc source.DiagnosticSource
-		fixes   []source.SuggestedFix
-		related []source.RelatedInformation
-	)
-	switch e := e.(type) {
-	case packages.Error:
-		diagSrc = toDiagnosticSource(e.Kind)
-		var ok bool
-		if msg, spn, ok = parseGoListImportCycleError(ctx, snapshot, e, pkg); ok {
-			diagSrc = source.TypeError
-			break
+func goPackagesErrorDiagnostics(ctx context.Context, snapshot *snapshot, pkg *pkg, e packages.Error) ([]*source.Diagnostic, error) {
+	if msg, spn, ok := parseGoListImportCycleError(ctx, snapshot, e, pkg); ok {
+		rng, err := spanToRange(snapshot, pkg, spn)
+		if err != nil {
+			return nil, err
 		}
-		if e.Pos == "" {
-			spn = parseGoListError(e.Msg)
+		return []*source.Diagnostic{{
+			URI:      spn.URI(),
+			Range:    rng,
+			Severity: protocol.SeverityError,
+			Source:   source.TypeError,
+			Message:  msg,
+		}}, nil
+	}
 
-			// We may not have been able to parse a valid span.
-			if _, err := spanToRange(snapshot, pkg, spn); err != nil {
-				var diags []*source.Diagnostic
-				for _, cgf := range pkg.compiledGoFiles {
-					diags = append(diags, &source.Diagnostic{
-						URI:      cgf.URI,
-						Severity: severity,
-						Source:   diagSrc,
-						Message:  msg,
-					})
-				}
-				return diags, nil
+	var spn span.Span
+	if e.Pos == "" {
+		spn = parseGoListError(e.Msg, pkg.m.config.Dir)
+		// We may not have been able to parse a valid span. Apply the errors to all files.
+		if _, err := spanToRange(snapshot, pkg, spn); err != nil {
+			var diags []*source.Diagnostic
+			for _, cgf := range pkg.compiledGoFiles {
+				diags = append(diags, &source.Diagnostic{
+					URI:      cgf.URI,
+					Severity: protocol.SeverityError,
+					Source:   source.ListError,
+					Message:  e.Msg,
+				})
 			}
-		} else {
-			spn = span.Parse(e.Pos)
+			return diags, nil
 		}
-	case *scanner.Error:
-		msg = e.Msg
-		diagSrc = source.ParseError
-		spn, err = scannerErrorRange(snapshot, pkg, e.Pos)
-		if err != nil {
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
-			event.Error(ctx, "no span for scanner.Error pos", err, tag.Package.Of(pkg.ID()))
-			spn = span.Parse(e.Pos.String())
-		}
+	} else {
+		spn = span.ParseInDir(e.Pos, pkg.m.config.Dir)
+	}
 
-	case scanner.ErrorList:
-		// The first parser error is likely the root cause of the problem.
-		if e.Len() <= 0 {
-			return nil, errors.Errorf("no errors in %v", e)
-		}
-		msg = e[0].Msg
-		diagSrc = source.ParseError
-		spn, err = scannerErrorRange(snapshot, pkg, e[0].Pos)
-		if err != nil {
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
-			event.Error(ctx, "no span for scanner.Error pos", err, tag.Package.Of(pkg.ID()))
-			spn = span.Parse(e[0].Pos.String())
-		}
-	case types.Error:
-		msg = e.Msg
-		diagSrc = source.TypeError
-		if !e.Pos.IsValid() {
-			return nil, fmt.Errorf("invalid position for type error %v", e)
-		}
-		code, spn, err = typeErrorData(fset, pkg, e)
-		if err != nil {
-			return nil, err
-		}
-	case extendedError:
-		perr := e.primary
-		msg = perr.Msg
-		diagSrc = source.TypeError
-		if !perr.Pos.IsValid() {
-			return nil, fmt.Errorf("invalid position for type error %v", e)
-		}
-		code, spn, err = typeErrorData(fset, pkg, e.primary)
-		if err != nil {
-			return nil, err
-		}
-		for _, s := range e.secondaries {
-			var x source.RelatedInformation
-			x.Message = s.Msg
-			_, xspn, err := typeErrorData(fset, pkg, s)
-			if err != nil {
-				return nil, fmt.Errorf("invalid position for type error %v", s)
-			}
-			x.URI = xspn.URI()
-			rng, err := spanToRange(snapshot, pkg, xspn)
-			if err != nil {
-				return nil, err
-			}
-			x.Range = rng
-			related = append(related, x)
-		}
-	case *analysis.Diagnostic:
-		spn, err = span.NewRange(fset, e.Pos, e.End).Span()
-		if err != nil {
-			return nil, err
-		}
-		msg = e.Message
-		diagSrc = source.AnalyzerErrorKind(e.Category)
-		fixes, err = suggestedAnalysisFixes(snapshot, pkg, e)
-		if err != nil {
-			return nil, err
-		}
-		related, err = relatedInformation(snapshot, pkg, e)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		panic(fmt.Sprintf("%T unexpected", e))
+	rng, err := spanToRange(snapshot, pkg, spn)
+	if err != nil {
+		return nil, err
+	}
+	return []*source.Diagnostic{{
+		URI:      spn.URI(),
+		Range:    rng,
+		Severity: protocol.SeverityError,
+		Source:   source.ListError,
+		Message:  e.Msg,
+	}}, nil
+}
+
+func parseErrorDiagnostics(ctx context.Context, snapshot *snapshot, pkg *pkg, errList scanner.ErrorList) ([]*source.Diagnostic, error) {
+	// The first parser error is likely the root cause of the problem.
+	if errList.Len() <= 0 {
+		return nil, errors.Errorf("no errors in %v", errList)
+	}
+	e := errList[0]
+	pgf, err := pkg.File(span.URIFromPath(e.Pos.Filename))
+	if err != nil {
+		return nil, err
+	}
+	pos := pgf.Tok.Pos(e.Pos.Offset)
+	spn, err := span.NewRange(snapshot.FileSet(), pos, pos).Span()
+	if err != nil {
+		return nil, err
 	}
 	rng, err := spanToRange(snapshot, pkg, spn)
 	if err != nil {
 		return nil, err
 	}
-	sd := &source.Diagnostic{
-		URI:            spn.URI(),
-		Range:          rng,
-		Severity:       severity,
-		Source:         diagSrc,
-		Message:        msg,
-		Related:        related,
-		SuggestedFixes: fixes,
+	return []*source.Diagnostic{{
+		URI:      spn.URI(),
+		Range:    rng,
+		Severity: protocol.SeverityError,
+		Source:   source.ParseError,
+		Message:  e.Msg,
+	}}, nil
+}
+
+func typeErrorDiagnostics(ctx context.Context, snapshot *snapshot, pkg *pkg, e extendedError) ([]*source.Diagnostic, error) {
+	code, spn, err := typeErrorData(snapshot.FileSet(), pkg, e.primary)
+	if err != nil {
+		return nil, err
+	}
+	rng, err := spanToRange(snapshot, pkg, spn)
+	if err != nil {
+		return nil, err
+	}
+	diag := &source.Diagnostic{
+		URI:      spn.URI(),
+		Range:    rng,
+		Severity: protocol.SeverityError,
+		Source:   source.TypeError,
+		Message:  e.primary.Msg,
 	}
 	if code != 0 {
-		sd.Code = code.String()
-		sd.CodeHref = typesCodeHref(snapshot, code)
+		diag.Code = code.String()
+		diag.CodeHref = typesCodeHref(snapshot, code)
 	}
-	return []*source.Diagnostic{sd}, nil
+
+	for _, secondary := range e.secondaries {
+		_, secondarySpan, err := typeErrorData(snapshot.FileSet(), pkg, secondary)
+		if err != nil {
+			return nil, err
+		}
+		rng, err := spanToRange(snapshot, pkg, secondarySpan)
+		if err != nil {
+			return nil, err
+		}
+		diag.Related = append(diag.Related, source.RelatedInformation{
+			URI:     secondarySpan.URI(),
+			Range:   rng,
+			Message: secondary.Msg,
+		})
+	}
+	return []*source.Diagnostic{diag}, nil
+}
+
+func analysisDiagnosticDiagnostics(ctx context.Context, snapshot *snapshot, pkg *pkg, a *analysis.Analyzer, e *analysis.Diagnostic) ([]*source.Diagnostic, error) {
+	var srcAnalyzer *source.Analyzer
+	// Find the analyzer that generated this diagnostic.
+	for _, sa := range source.EnabledAnalyzers(snapshot) {
+		if a == sa.Analyzer {
+			srcAnalyzer = sa
+			break
+		}
+	}
+
+	spn, err := span.NewRange(snapshot.FileSet(), e.Pos, e.End).Span()
+	if err != nil {
+		return nil, err
+	}
+	rng, err := spanToRange(snapshot, pkg, spn)
+	if err != nil {
+		return nil, err
+	}
+	fixes, err := suggestedAnalysisFixes(snapshot, pkg, e)
+	if err != nil {
+		return nil, err
+	}
+	if srcAnalyzer.Fix != "" {
+		cmd, err := command.NewApplyFixCommand(e.Message, command.ApplyFixArgs{
+			URI:   protocol.URIFromSpanURI(spn.URI()),
+			Range: rng,
+			Fix:   srcAnalyzer.Fix,
+		})
+		if err != nil {
+			return nil, err
+		}
+		fixes = append(fixes, source.SuggestedFixFromCommand(cmd))
+	}
+	related, err := relatedInformation(snapshot, pkg, e)
+	if err != nil {
+		return nil, err
+	}
+	diag := &source.Diagnostic{
+		URI:            spn.URI(),
+		Range:          rng,
+		Severity:       protocol.SeverityWarning,
+		Source:         source.AnalyzerErrorKind(e.Category),
+		Message:        e.Message,
+		Related:        related,
+		SuggestedFixes: fixes,
+		Analyzer:       srcAnalyzer,
+	}
+	// If the fixes only delete code, assume that the diagnostic is reporting dead code.
+	if onlyDeletions(fixes) {
+		diag.Tags = []protocol.DiagnosticTag{protocol.Unnecessary}
+	}
+	return []*source.Diagnostic{diag}, nil
+}
+
+// onlyDeletions returns true if all of the suggested fixes are deletions.
+func onlyDeletions(fixes []source.SuggestedFix) bool {
+	for _, fix := range fixes {
+		for _, edits := range fix.Edits {
+			for _, edit := range edits {
+				if edit.NewText != "" {
+					return false
+				}
+				if protocol.ComparePosition(edit.Range.Start, edit.Range.End) == 0 {
+					return false
+				}
+			}
+		}
+	}
+	return len(fixes) > 0
 }
 
 func typesCodeHref(snapshot *snapshot, code typesinternal.ErrorCode) string {
@@ -217,19 +262,6 @@ func relatedInformation(snapshot *snapshot, pkg *pkg, diag *analysis.Diagnostic)
 	return out, nil
 }
 
-func toDiagnosticSource(kind packages.ErrorKind) source.DiagnosticSource {
-	switch kind {
-	case packages.ListError:
-		return source.ListError
-	case packages.ParseError:
-		return source.ParseError
-	case packages.TypeError:
-		return source.TypeError
-	default:
-		return source.UnknownError
-	}
-}
-
 func typeErrorData(fset *token.FileSet, pkg *pkg, terr types.Error) (typesinternal.ErrorCode, span.Span, error) {
 	ecode, start, end, ok := typesinternal.ReadGo116ErrorData(terr)
 	if !ok {
@@ -255,16 +287,6 @@ func parsedGoSpan(pgf *source.ParsedGoFile, start, end token.Pos) (span.Span, er
 	return span.FileSpan(pgf.Tok, pgf.Mapper.Converter, start, end)
 }
 
-func scannerErrorRange(snapshot *snapshot, pkg *pkg, posn token.Position) (span.Span, error) {
-	fset := snapshot.view.session.cache.fset
-	pgf, err := pkg.File(span.URIFromPath(posn.Filename))
-	if err != nil {
-		return span.Span{}, err
-	}
-	pos := pgf.Tok.Pos(posn.Offset)
-	return span.NewRange(fset, pos, pos).Span()
-}
-
 // spanToRange converts a span.Span to a protocol.Range,
 // assuming that the span belongs to the package whose diagnostics are being computed.
 func spanToRange(snapshot *snapshot, pkg *pkg, spn span.Span) (protocol.Range, error) {
@@ -283,13 +305,13 @@ func spanToRange(snapshot *snapshot, pkg *pkg, spn span.Span) (protocol.Range, e
 //
 //   attributes.go:13:1: expected 'package', found 'type'
 //
-func parseGoListError(input string) span.Span {
+func parseGoListError(input, wd string) span.Span {
 	input = strings.TrimSpace(input)
 	msgIndex := strings.Index(input, ": ")
 	if msgIndex < 0 {
 		return span.Parse(input)
 	}
-	return span.Parse(input[:msgIndex])
+	return span.ParseInDir(input[:msgIndex], wd)
 }
 
 func parseGoListImportCycleError(ctx context.Context, snapshot *snapshot, e packages.Error, pkg *pkg) (string, span.Span, bool) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
@@ -372,10 +372,19 @@ func (s *snapshot) setMetadata(ctx context.Context, pkgPath packagePath, pkg *pa
 		name:       packageName(pkg.Name),
 		forTest:    packagePath(packagesinternal.GetForTest(pkg)),
 		typesSizes: pkg.TypesSizes,
-		errors:     pkg.Errors,
 		config:     cfg,
 		module:     pkg.Module,
 		depsErrors: packagesinternal.GetDepsErrors(pkg),
+	}
+
+	for _, err := range pkg.Errors {
+		// Filter out parse errors from go list. We'll get them when we
+		// actually parse, and buggy overlay support may generate spurious
+		// errors. (See TestNewModule_Issue38207.)
+		if strings.Contains(err.Msg, "expected '") {
+			continue
+		}
+		m.errors = append(m.errors, err)
 	}
 
 	for _, filename := range pkg.CompiledGoFiles {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
@@ -16,17 +16,19 @@ import (
 
 // pkg contains the type information needed by the source package.
 type pkg struct {
-	m               *metadata
-	mode            source.ParseMode
-	goFiles         []*source.ParsedGoFile
-	compiledGoFiles []*source.ParsedGoFile
-	diagnostics     []*source.Diagnostic
-	imports         map[packagePath]*pkg
-	version         *module.Version
-	typeErrors      []types.Error
-	types           *types.Package
-	typesInfo       *types.Info
-	typesSizes      types.Sizes
+	m                    *metadata
+	mode                 source.ParseMode
+	goFiles              []*source.ParsedGoFile
+	compiledGoFiles      []*source.ParsedGoFile
+	diagnostics          []*source.Diagnostic
+	imports              map[packagePath]*pkg
+	version              *module.Version
+	typeErrors           []types.Error
+	types                *types.Package
+	typesInfo            *types.Info
+	typesSizes           types.Sizes
+	hasListOrParseErrors bool
+	hasTypeErrors        bool
 }
 
 // Declare explicit types for package paths, names, and IDs to ensure that we
@@ -82,10 +84,6 @@ func (p *pkg) GetSyntax() []*ast.File {
 		syntax = append(syntax, pgf.File)
 	}
 	return syntax
-}
-
-func (p *pkg) GetDiagnostics() []*source.Diagnostic {
-	return p.diagnostics
 }
 
 func (p *pkg) GetTypes() *types.Package {
@@ -145,4 +143,12 @@ func (p *pkg) Imports() []source.Package {
 
 func (p *pkg) Version() *module.Version {
 	return p.version
+}
+
+func (p *pkg) HasListOrParseErrors() bool {
+	return p.hasListOrParseErrors
+}
+
+func (p *pkg) HasTypeErrors() bool {
+	return p.hasTypeErrors
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/cmd.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/cmd.go
@@ -218,7 +218,7 @@ func (app *Application) connect(ctx context.Context) (*connection, error) {
 		if app.options != nil {
 			app.options(opts)
 		}
-		key := fmt.Sprintf("%s %v", app.wd, opts)
+		key := fmt.Sprintf("%s %v %v %v", app.wd, opts.PreferredContentFormat, opts.HierarchicalDocumentSymbolSupport, opts.SymbolMatcher)
 		if c := internalConnections[key]; c != nil {
 			return c, nil
 		}
@@ -278,6 +278,7 @@ func (c *connection) initialize(ctx context.Context, options func(*source.Option
 	if options != nil {
 		options(opts)
 	}
+	// If you add an additional option here, you must update the map key in connect.
 	params.Capabilities.TextDocument.Hover = protocol.HoverClientCapabilities{
 		ContentFormat: []protocol.MarkupKind{opts.PreferredContentFormat},
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/code_action.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/code_action.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"golang.org/x/tools/go/analysis"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/imports"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/command"
@@ -63,14 +62,18 @@ func (s *Server) codeAction(ctx context.Context, params *protocol.CodeActionPara
 	switch fh.Kind() {
 	case source.Mod:
 		if diagnostics := params.Context.Diagnostics; len(diagnostics) > 0 {
-			modQuickFixes, err := moduleQuickFixes(ctx, snapshot, fh, diagnostics)
+			diags, err := mod.DiagnosticsForMod(ctx, snapshot, fh)
 			if source.IsNonFatalGoModError(err) {
 				return nil, nil
 			}
 			if err != nil {
 				return nil, err
 			}
-			codeActions = append(codeActions, modQuickFixes...)
+			quickFixes, err := quickFixesForDiagnostics(ctx, snapshot, diagnostics, diags)
+			if err != nil {
+				return nil, err
+			}
+			codeActions = append(codeActions, quickFixes...)
 		}
 	case source.Go:
 		// Don't suggest fixes for generated files, since they are generally
@@ -126,36 +129,61 @@ func (s *Server) codeAction(ctx context.Context, params *protocol.CodeActionPara
 			return nil, err
 		}
 		if (wanted[protocol.QuickFix] || wanted[protocol.SourceFixAll]) && len(diagnostics) > 0 {
-			pkgQuickFixes, err := quickFixesForDiagnostics(ctx, snapshot, diagnostics, pkg.GetDiagnostics())
+			analysisDiags, err := source.Analyze(ctx, snapshot, pkg)
 			if err != nil {
 				return nil, err
 			}
-			codeActions = append(codeActions, pkgQuickFixes...)
-			analysisQuickFixes, highConfidenceEdits, err := analysisFixes(ctx, snapshot, pkg, diagnostics)
-			if err != nil {
-				return nil, err
-			}
-			if wanted[protocol.QuickFix] {
-				// Add the quick fixes reported by go/analysis.
-				codeActions = append(codeActions, analysisQuickFixes...)
 
-				// If there are any diagnostics relating to the go.mod file,
-				// add their corresponding quick fixes.
-				modQuickFixes, err := moduleQuickFixes(ctx, snapshot, fh, diagnostics)
-				if source.IsNonFatalGoModError(err) {
-					// Not a fatal error.
-					event.Error(ctx, "module suggested fixes failed", err, tag.Directory.Of(snapshot.View().Folder()))
+			if wanted[protocol.QuickFix] {
+				pkgDiagnostics, err := snapshot.DiagnosePackage(ctx, pkg)
+				if err != nil {
+					return nil, err
 				}
-				codeActions = append(codeActions, modQuickFixes...)
+				quickFixDiags := append(pkgDiagnostics[uri], analysisDiags[uri]...)
+				modURI := snapshot.GoModForFile(fh.URI())
+				if modURI != "" {
+					modFH, err := snapshot.GetVersionedFile(ctx, modURI)
+					if err != nil {
+						return nil, err
+					}
+					modDiags, err := mod.DiagnosticsForMod(ctx, snapshot, modFH)
+					if err != nil && !source.IsNonFatalGoModError(err) {
+						// Not a fatal error.
+						event.Error(ctx, "module suggested fixes failed", err, tag.Directory.Of(snapshot.View().Folder()))
+					}
+					quickFixDiags = append(quickFixDiags, modDiags...)
+				}
+				quickFixes, err := quickFixesForDiagnostics(ctx, snapshot, diagnostics, quickFixDiags)
+				if err != nil {
+					return nil, err
+				}
+				codeActions = append(codeActions, quickFixes...)
+
 			}
-			if wanted[protocol.SourceFixAll] && len(highConfidenceEdits) > 0 {
-				codeActions = append(codeActions, protocol.CodeAction{
-					Title: "Simplifications",
-					Kind:  protocol.SourceFixAll,
-					Edit: protocol.WorkspaceEdit{
-						DocumentChanges: highConfidenceEdits,
-					},
-				})
+			if wanted[protocol.SourceFixAll] {
+				var fixAllEdits []protocol.TextDocumentEdit
+				for _, ad := range analysisDiags[uri] {
+					if ad.Analyzer == nil || !ad.Analyzer.HighConfidence {
+						continue
+					}
+					for _, fix := range ad.SuggestedFixes {
+						edits := fix.Edits[fh.URI()]
+						if len(edits) == 0 {
+							continue
+						}
+						fixAllEdits = append(fixAllEdits, documentChanges(fh, edits)...)
+					}
+
+				}
+				if len(fixAllEdits) != 0 {
+					codeActions = append(codeActions, protocol.CodeAction{
+						Title: "Simplifications",
+						Kind:  protocol.SourceFixAll,
+						Edit: protocol.WorkspaceEdit{
+							DocumentChanges: fixAllEdits,
+						},
+					})
+				}
 			}
 		}
 		if ctx.Err() != nil {
@@ -250,78 +278,6 @@ func importDiagnostics(fix *imports.ImportFix, diagnostics []protocol.Diagnostic
 	return results
 }
 
-func analysisFixes(ctx context.Context, snapshot source.Snapshot, pkg source.Package, diagnostics []protocol.Diagnostic) ([]protocol.CodeAction, []protocol.TextDocumentEdit, error) {
-	if len(diagnostics) == 0 {
-		return nil, nil, nil
-	}
-	var (
-		codeActions       []protocol.CodeAction
-		sourceFixAllEdits []protocol.TextDocumentEdit
-	)
-	for _, diag := range diagnostics {
-		srcErr, analyzer, ok := findDiagnostic(ctx, snapshot, pkg.ID(), diag)
-		if !ok {
-			continue
-		}
-		// If the suggested fix for the diagnostic is expected to be separate,
-		// see if there are any supported commands available.
-		if analyzer.Fix != "" {
-			action, err := diagnosticToCommandCodeAction(ctx, snapshot, srcErr, &diag, protocol.QuickFix)
-			if err != nil {
-				return nil, nil, err
-			}
-			codeActions = append(codeActions, *action)
-			continue
-		}
-		for _, fix := range srcErr.SuggestedFixes {
-			action := protocol.CodeAction{
-				Title:       fix.Title,
-				Kind:        protocol.QuickFix,
-				Diagnostics: []protocol.Diagnostic{diag},
-				Edit:        protocol.WorkspaceEdit{},
-			}
-			for uri, edits := range fix.Edits {
-				fh, err := snapshot.GetVersionedFile(ctx, uri)
-				if err != nil {
-					return nil, nil, err
-				}
-				docChanges := documentChanges(fh, edits)
-				if analyzer.HighConfidence {
-					sourceFixAllEdits = append(sourceFixAllEdits, docChanges...)
-				}
-				action.Edit.DocumentChanges = append(action.Edit.DocumentChanges, docChanges...)
-			}
-			codeActions = append(codeActions, action)
-		}
-	}
-	return codeActions, sourceFixAllEdits, nil
-}
-
-func findDiagnostic(ctx context.Context, snapshot source.Snapshot, pkgID string, diag protocol.Diagnostic) (*source.Diagnostic, source.Analyzer, bool) {
-	analyzer := diagnosticToAnalyzer(snapshot, diag.Source, diag.Message)
-	if analyzer == nil {
-		return nil, source.Analyzer{}, false
-	}
-	analysisErrors, err := snapshot.Analyze(ctx, pkgID, analyzer.Analyzer)
-	if err != nil {
-		return nil, source.Analyzer{}, false
-	}
-	for _, err := range analysisErrors {
-		if err.Message != diag.Message {
-			continue
-		}
-		if protocol.CompareRange(err.Range, diag.Range) != 0 {
-			continue
-		}
-		if string(err.Source) != analyzer.Analyzer.Name {
-			continue
-		}
-		// The error matches.
-		return err, *analyzer, true
-	}
-	return nil, source.Analyzer{}, false
-}
-
 // diagnosticToAnalyzer return the analyzer associated with a given diagnostic.
 // It assumes that the diagnostic's source will be the name of the analyzer.
 // If this changes, this approach will need to be reworked.
@@ -333,32 +289,19 @@ func diagnosticToAnalyzer(snapshot source.Snapshot, src, msg string) (analyzer *
 		}
 	}()
 	if a, ok := snapshot.View().Options().DefaultAnalyzers[src]; ok {
-		return &a
+		return a
 	}
 	if a, ok := snapshot.View().Options().StaticcheckAnalyzers[src]; ok {
-		return &a
+		return a
 	}
 	if a, ok := snapshot.View().Options().ConvenienceAnalyzers[src]; ok {
-		return &a
-	}
-	// Hack: We publish diagnostics with the source "compiler" for type errors,
-	// but these analyzers have different names. Try both possibilities.
-	if a, ok := snapshot.View().Options().TypeErrorAnalyzers[src]; ok {
-		return &a
-	}
-	if src != "compiler" {
-		return nil
-	}
-	for _, a := range snapshot.View().Options().TypeErrorAnalyzers {
-		if a.FixesError(msg) {
-			return &a
-		}
+		return a
 	}
 	return nil
 }
 
 func convenienceFixes(ctx context.Context, snapshot source.Snapshot, pkg source.Package, uri span.URI, rng protocol.Range) ([]protocol.CodeAction, error) {
-	var analyzers []*analysis.Analyzer
+	var analyzers []*source.Analyzer
 	for _, a := range snapshot.View().Options().ConvenienceAnalyzers {
 		if !a.IsEnabled(snapshot.View()) {
 			continue
@@ -367,9 +310,9 @@ func convenienceFixes(ctx context.Context, snapshot source.Snapshot, pkg source.
 			event.Error(ctx, "convenienceFixes", fmt.Errorf("no suggested fixes for convenience analyzer %s", a.Analyzer.Name))
 			continue
 		}
-		analyzers = append(analyzers, a.Analyzer)
+		analyzers = append(analyzers, a)
 	}
-	diagnostics, err := snapshot.Analyze(ctx, pkg.ID(), analyzers...)
+	diagnostics, err := snapshot.Analyze(ctx, pkg.ID(), analyzers)
 	if err != nil {
 		return nil, err
 	}
@@ -486,29 +429,6 @@ func documentChanges(fh source.VersionedFileHandle, edits []protocol.TextEdit) [
 			Edits: edits,
 		},
 	}
-}
-
-func moduleQuickFixes(ctx context.Context, snapshot source.Snapshot, fh source.VersionedFileHandle, pdiags []protocol.Diagnostic) ([]protocol.CodeAction, error) {
-	var modFH source.VersionedFileHandle
-	switch fh.Kind() {
-	case source.Mod:
-		modFH = fh
-	case source.Go:
-		modURI := snapshot.GoModForFile(fh.URI())
-		if modURI == "" {
-			return nil, nil
-		}
-		var err error
-		modFH, err = snapshot.GetVersionedFile(ctx, modURI)
-		if err != nil {
-			return nil, err
-		}
-	}
-	diags, err := mod.DiagnosticsForMod(ctx, snapshot, modFH)
-	if err != nil {
-		return nil, err
-	}
-	return quickFixesForDiagnostics(ctx, snapshot, pdiags, diags)
 }
 
 func quickFixesForDiagnostics(ctx context.Context, snapshot source.Snapshot, pdiags []protocol.Diagnostic, sdiags []*source.Diagnostic) ([]protocol.CodeAction, error) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command.go
@@ -613,13 +613,16 @@ func (c *commandHandler) ToggleGCDetails(ctx context.Context, args command.URIAr
 		progress:    "Toggling GC Details",
 		forURI:      args.URI,
 	}, func(ctx context.Context, deps commandDeps) error {
-		pkgDir := span.URIFromPath(filepath.Dir(args.URI.SpanURI().Filename()))
+		pkg, err := deps.snapshot.PackageForFile(ctx, deps.fh.URI(), source.TypecheckWorkspace, source.NarrowestPackage)
+		if err != nil {
+			return err
+		}
 		c.s.gcOptimizationDetailsMu.Lock()
-		if _, ok := c.s.gcOptimizationDetails[pkgDir]; ok {
-			delete(c.s.gcOptimizationDetails, pkgDir)
+		if _, ok := c.s.gcOptimizationDetails[pkg.ID()]; ok {
+			delete(c.s.gcOptimizationDetails, pkg.ID())
 			c.s.clearDiagnosticSource(gcDetailsSource)
 		} else {
-			c.s.gcOptimizationDetails[pkgDir] = struct{}{}
+			c.s.gcOptimizationDetails[pkg.ID()] = struct{}{}
 		}
 		c.s.gcOptimizationDetailsMu.Unlock()
 		c.s.diagnoseSnapshot(deps.snapshot, nil, false)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
@@ -245,41 +245,43 @@ func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, forceAn
 func (s *Server) diagnosePkg(ctx context.Context, snapshot source.Snapshot, pkg source.Package, alwaysAnalyze bool) {
 	ctx, done := event.Start(ctx, "Server.diagnosePkg", tag.Snapshot.Of(snapshot.ID()), tag.Package.Of(pkg.ID()))
 	defer done()
+	enableDiagnostics := false
 	includeAnalysis := alwaysAnalyze // only run analyses for packages with open files
-	var gcDetailsDir span.URI        // find the package's optimization details, if available
 	for _, pgf := range pkg.CompiledGoFiles() {
-		if snapshot.IsOpen(pgf.URI) {
-			includeAnalysis = true
+		enableDiagnostics = enableDiagnostics || !snapshot.IgnoredFile(pgf.URI)
+		includeAnalysis = includeAnalysis || snapshot.IsOpen(pgf.URI)
+	}
+	// Don't show any diagnostics on ignored files.
+	if !enableDiagnostics {
+		return
+	}
+
+	pkgDiagnostics, err := snapshot.DiagnosePackage(ctx, pkg)
+	if err != nil {
+		event.Error(ctx, "warning: diagnosing package", err, tag.Snapshot.Of(snapshot.ID()), tag.Package.Of(pkg.ID()))
+		return
+	}
+	for _, cgf := range pkg.CompiledGoFiles() {
+		s.storeDiagnostics(snapshot, cgf.URI, typeCheckSource, pkgDiagnostics[cgf.URI])
+	}
+	if includeAnalysis && !pkg.HasListOrParseErrors() {
+		reports, err := source.Analyze(ctx, snapshot, pkg)
+		if err != nil {
+			event.Error(ctx, "warning: analyzing package", err, tag.Snapshot.Of(snapshot.ID()), tag.Package.Of(pkg.ID()))
+			return
 		}
-		if gcDetailsDir == "" {
-			dirURI := span.URIFromPath(filepath.Dir(pgf.URI.Filename()))
-			s.gcOptimizationDetailsMu.Lock()
-			_, ok := s.gcOptimizationDetails[dirURI]
-			s.gcOptimizationDetailsMu.Unlock()
-			if ok {
-				gcDetailsDir = dirURI
-			}
+		for _, cgf := range pkg.CompiledGoFiles() {
+			s.storeDiagnostics(snapshot, cgf.URI, analysisSource, reports[cgf.URI])
 		}
 	}
 
-	typeCheckResults := source.GetTypeCheckDiagnostics(ctx, snapshot, pkg)
-	for uri, diags := range typeCheckResults.Diagnostics {
-		s.storeDiagnostics(snapshot, uri, typeCheckSource, diags)
-	}
-	if includeAnalysis && !typeCheckResults.HasParseOrListErrors {
-		reports, err := source.Analyze(ctx, snapshot, pkg, typeCheckResults)
-		if err != nil {
-			event.Error(ctx, "warning: diagnose package", err, tag.Snapshot.Of(snapshot.ID()), tag.Package.Of(pkg.ID()))
-			return
-		}
-		for uri, diags := range reports {
-			s.storeDiagnostics(snapshot, uri, analysisSource, diags)
-		}
-	}
-	// If gc optimization details are available, add them to the
+	// If gc optimization details are requested, add them to the
 	// diagnostic reports.
-	if gcDetailsDir != "" {
-		gcReports, err := source.GCOptimizationDetails(ctx, snapshot, gcDetailsDir)
+	s.gcOptimizationDetailsMu.Lock()
+	_, enableGCDetails := s.gcOptimizationDetails[pkg.ID()]
+	s.gcOptimizationDetailsMu.Unlock()
+	if enableGCDetails {
+		gcReports, err := source.GCOptimizationDetails(ctx, snapshot, pkg)
 		if err != nil {
 			event.Error(ctx, "warning: gc details", err, tag.Snapshot.Of(snapshot.ID()), tag.Package.Of(pkg.ID()))
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/diagnostics.go
@@ -92,11 +92,11 @@ func DiagnosticsForMod(ctx context.Context, snapshot source.Snapshot, fh source.
 	}
 	if err == nil {
 		for _, pkg := range wspkgs {
-			for _, diag := range pkg.GetDiagnostics() {
-				if diag.URI == fh.URI() {
-					diagnostics = append(diagnostics, diag)
-				}
+			pkgDiagnostics, err := snapshot.DiagnosePackage(ctx, pkg)
+			if err != nil {
+				return nil, err
 			}
+			diagnostics = append(diagnostics, pkgDiagnostics[fh.URI()]...)
 		}
 	}
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/server.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/server.go
@@ -24,7 +24,7 @@ const concurrentAnalyses = 1
 func NewServer(session source.Session, client protocol.Client) *Server {
 	return &Server{
 		diagnostics:           map[span.URI]*fileReports{},
-		gcOptimizationDetails: make(map[span.URI]struct{}),
+		gcOptimizationDetails: make(map[string]struct{}),
 		watchedGlobPatterns:   make(map[string]struct{}),
 		changedFiles:          make(map[span.URI]struct{}),
 		session:               session,
@@ -91,9 +91,9 @@ type Server struct {
 
 	// gcOptimizationDetails describes the packages for which we want
 	// optimization details to be included in the diagnostics. The key is the
-	// directory of the package.
+	// ID of the package.
 	gcOptimizationDetailsMu sync.Mutex
-	gcOptimizationDetails   map[span.URI]struct{}
+	gcOptimizationDetails   map[string]struct{}
 
 	// diagnosticsSema limits the concurrency of diagnostics runs, which can be
 	// expensive.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/diagnostics.go
@@ -7,9 +7,6 @@ package source
 import (
 	"context"
 
-	"golang.org/x/tools/go/analysis"
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 )
@@ -26,32 +23,20 @@ type RelatedInformation struct {
 	Message string
 }
 
-func GetTypeCheckDiagnostics(ctx context.Context, snapshot Snapshot, pkg Package) TypeCheckDiagnostics {
-	onlyIgnoredFiles := true
-	for _, pgf := range pkg.CompiledGoFiles() {
-		onlyIgnoredFiles = onlyIgnoredFiles && snapshot.IgnoredFile(pgf.URI)
-	}
-	if onlyIgnoredFiles {
-		return TypeCheckDiagnostics{}
-	}
-	return typeCheckDiagnostics(ctx, snapshot, pkg)
-}
-
-func Analyze(ctx context.Context, snapshot Snapshot, pkg Package, typeCheckResult TypeCheckDiagnostics) (map[span.URI][]*Diagnostic, error) {
+func Analyze(ctx context.Context, snapshot Snapshot, pkg Package) (map[span.URI][]*Diagnostic, error) {
 	// Exit early if the context has been canceled. This also protects us
 	// from a race on Options, see golang/go#36699.
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
 	// If we don't have any list or parse errors, run analyses.
-	analyzers := pickAnalyzers(snapshot, typeCheckResult.HasTypeErrors)
-	analysisDiagnostics, err := snapshot.Analyze(ctx, pkg.ID(), analyzers...)
+	analyzers := pickAnalyzers(snapshot, pkg.HasTypeErrors())
+	analysisDiagnostics, err := snapshot.Analyze(ctx, pkg.ID(), analyzers)
 	if err != nil {
 		return nil, err
 	}
-	analysisDiagnostics = cloneDiagnostics(analysisDiagnostics)
 
-	reports := emptyDiagnostics(pkg)
+	reports := map[span.URI][]*Diagnostic{}
 	// Report diagnostics and errors from root analyzers.
 	for _, diag := range analysisDiagnostics {
 		// If the diagnostic comes from a "convenience" analyzer, it is not
@@ -61,59 +46,22 @@ func Analyze(ctx context.Context, snapshot Snapshot, pkg Package, typeCheckResul
 		if isConvenienceAnalyzer(string(diag.Source)) {
 			continue
 		}
-		// This is a bit of a hack, but clients > 3.15 will be able to grey out unnecessary code.
-		// If we are deleting code as part of all of our suggested fixes, assume that this is dead code.
-		// TODO(golang/go#34508): Return these codes from the diagnostics themselves.
-		var tags []protocol.DiagnosticTag
-		if onlyDeletions(diag.SuggestedFixes) {
-			tags = append(tags, protocol.Unnecessary)
-		}
-		// Type error analyzers only alter the tags for existing type errors.
-		if _, ok := snapshot.View().Options().TypeErrorAnalyzers[string(diag.Source)]; ok {
-			existingDiagnostics := typeCheckResult.Diagnostics[diag.URI]
-			for _, existing := range existingDiagnostics {
-				if r := protocol.CompareRange(diag.Range, existing.Range); r != 0 {
-					continue
-				}
-				if diag.Message != existing.Message {
-					continue
-				}
-				existing.Tags = append(existing.Tags, tags...)
-			}
-		} else {
-			diag.Tags = append(diag.Tags, tags...)
-			reports[diag.URI] = append(reports[diag.URI], diag)
-		}
+		reports[diag.URI] = append(reports[diag.URI], diag)
 	}
 	return reports, nil
 }
 
-// cloneDiagnostics makes a shallow copy of diagnostics so that Analyze
-// can add tags to them without affecting the cached diagnostics.
-func cloneDiagnostics(diags []*Diagnostic) []*Diagnostic {
-	result := []*Diagnostic{}
-	for _, d := range diags {
-		clone := *d
-		result = append(result, &clone)
-	}
-	return result
-}
-
-func pickAnalyzers(snapshot Snapshot, hadTypeErrors bool) []*analysis.Analyzer {
+func pickAnalyzers(snapshot Snapshot, hadTypeErrors bool) []*Analyzer {
 	// Always run convenience analyzers.
-	categories := []map[string]Analyzer{snapshot.View().Options().ConvenienceAnalyzers}
-	// If we had type errors, only run type error analyzers.
-	if hadTypeErrors {
-		categories = append(categories, snapshot.View().Options().TypeErrorAnalyzers)
-	} else {
+	categories := []map[string]*Analyzer{snapshot.View().Options().ConvenienceAnalyzers}
+	// If we had type errors, don't run any other analyzers.
+	if !hadTypeErrors {
 		categories = append(categories, snapshot.View().Options().DefaultAnalyzers, snapshot.View().Options().StaticcheckAnalyzers)
 	}
-	var analyzers []*analysis.Analyzer
-	for _, m := range categories {
-		for _, a := range m {
-			if a.IsEnabled(snapshot.View()) {
-				analyzers = append(analyzers, a.Analyzer)
-			}
+	var analyzers []*Analyzer
+	for _, cat := range categories {
+		for _, a := range cat {
+			analyzers = append(analyzers, a)
 		}
 	}
 	return analyzers
@@ -128,97 +76,19 @@ func FileDiagnostics(ctx context.Context, snapshot Snapshot, uri span.URI) (Vers
 	if err != nil {
 		return VersionedFileIdentity{}, nil, err
 	}
-	typeCheckResults := GetTypeCheckDiagnostics(ctx, snapshot, pkg)
-	diagnostics := typeCheckResults.Diagnostics[fh.URI()]
-	if !typeCheckResults.HasParseOrListErrors {
-		reports, err := Analyze(ctx, snapshot, pkg, typeCheckResults)
+	diagnostics, err := snapshot.DiagnosePackage(ctx, pkg)
+	if err != nil {
+		return VersionedFileIdentity{}, nil, err
+	}
+	fileDiags := diagnostics[fh.URI()]
+	if !pkg.HasListOrParseErrors() {
+		analysisDiags, err := Analyze(ctx, snapshot, pkg)
 		if err != nil {
 			return VersionedFileIdentity{}, nil, err
 		}
-		diagnostics = append(diagnostics, reports[fh.URI()]...)
+		fileDiags = append(fileDiags, analysisDiags[fh.URI()]...)
 	}
-	return fh.VersionedFileIdentity(), diagnostics, nil
-}
-
-type TypeCheckDiagnostics struct {
-	HasTypeErrors        bool
-	HasParseOrListErrors bool
-	Diagnostics          map[span.URI][]*Diagnostic
-}
-
-type diagnosticSet struct {
-	listErrors, parseErrors, typeErrors []*Diagnostic
-}
-
-func typeCheckDiagnostics(ctx context.Context, snapshot Snapshot, pkg Package) TypeCheckDiagnostics {
-	ctx, done := event.Start(ctx, "source.typeCheckDiagnostics", tag.Package.Of(pkg.ID()))
-	_ = ctx // circumvent SA4006
-	defer done()
-
-	diagSets := make(map[span.URI]*diagnosticSet)
-	for _, diag := range pkg.GetDiagnostics() {
-		set, ok := diagSets[diag.URI]
-		if !ok {
-			set = &diagnosticSet{}
-			diagSets[diag.URI] = set
-		}
-		switch diag.Source {
-		case ParseError:
-			set.parseErrors = append(set.parseErrors, diag)
-		case TypeError:
-			set.typeErrors = append(set.typeErrors, diag)
-		case ListError:
-			set.listErrors = append(set.listErrors, diag)
-		}
-	}
-	typecheck := TypeCheckDiagnostics{
-		Diagnostics: emptyDiagnostics(pkg),
-	}
-	for uri, set := range diagSets {
-		// Don't report type errors if there are parse errors or list errors.
-		diags := set.typeErrors
-		switch {
-		case len(set.parseErrors) > 0:
-			typecheck.HasParseOrListErrors = true
-			diags = set.parseErrors
-		case len(set.listErrors) > 0:
-			typecheck.HasParseOrListErrors = true
-			if len(pkg.MissingDependencies()) > 0 {
-				diags = set.listErrors
-			}
-		case len(set.typeErrors) > 0:
-			typecheck.HasTypeErrors = true
-		}
-		typecheck.Diagnostics[uri] = cloneDiagnostics(diags)
-	}
-	return typecheck
-}
-
-func emptyDiagnostics(pkg Package) map[span.URI][]*Diagnostic {
-	diags := map[span.URI][]*Diagnostic{}
-	for _, pgf := range pkg.CompiledGoFiles() {
-		if _, ok := diags[pgf.URI]; !ok {
-			diags[pgf.URI] = nil
-		}
-	}
-	return diags
-}
-
-// onlyDeletions returns true if all of the suggested fixes are deletions.
-func onlyDeletions(fixes []SuggestedFix) bool {
-	for _, fix := range fixes {
-		for _, edits := range fix.Edits {
-			for _, edit := range edits {
-				if edit.NewText != "" {
-					return false
-				}
-				if protocol.ComparePosition(edit.Range.Start, edit.Range.End) == 0 {
-					return false
-				}
-			}
-		}
-	}
-	return len(fixes) > 0
+	return fh.VersionedFileIdentity(), fileDiags, nil
 }
 
 func isConvenienceAnalyzer(category string) bool {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
@@ -9,10 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/ast"
+	"go/constant"
 	"go/doc"
 	"go/format"
 	"go/types"
 	"strings"
+	"time"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
@@ -232,6 +234,18 @@ func objectString(obj types.Object, qf types.Qualifier) string {
 	switch obj := obj.(type) {
 	case *types.Const:
 		str = fmt.Sprintf("%s = %s", str, obj.Val())
+
+		// Try to add a formatted duration as an inline comment
+		typ, ok := obj.Type().(*types.Named)
+		if !ok {
+			break
+		}
+		pkg := typ.Obj().Pkg()
+		if pkg.Path() == "time" && pkg.Scope().Lookup("Duration") != nil {
+			if d, ok := constant.Int64Val(obj.Val()); ok {
+				str += " // " + time.Duration(d).String()
+			}
+		}
 	}
 	return str
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/rename_check.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/rename_check.go
@@ -812,7 +812,7 @@ func (r *renamer) satisfy() map[satisfy.Constraint]bool {
 			// type-checker.
 			//
 			// Only proceed if all packages have no errors.
-			if diags := pkg.GetDiagnostics(); len(diags) > 0 {
+			if pkg.HasListOrParseErrors() || pkg.HasTypeErrors() {
 				r.errorf(token.NoPos, // we don't have a position for this error.
 					"renaming %q to %q not possible because %q has errors",
 					r.from, r.to, pkg.PkgPath())

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"go/ast"
+	"go/scanner"
 	"go/token"
 	"go/types"
 	"io"
@@ -83,8 +84,12 @@ type Snapshot interface {
 	// string for the objects.
 	PosToDecl(ctx context.Context, pgf *ParsedGoFile) (map[token.Pos]ast.Decl, error)
 
+	// DiagnosePackage returns basic diagnostics, including list, parse, and type errors
+	// for pkg, grouped by file.
+	DiagnosePackage(ctx context.Context, pkg Package) (map[span.URI][]*Diagnostic, error)
+
 	// Analyze runs the analyses for the given package at this snapshot.
-	Analyze(ctx context.Context, pkgID string, analyzers ...*analysis.Analyzer) ([]*Diagnostic, error)
+	Analyze(ctx context.Context, pkgID string, analyzers []*Analyzer) ([]*Diagnostic, error)
 
 	// RunGoCommandPiped runs the given `go` command, writing its output
 	// to stdout and stderr. Verb, Args, and WorkingDir must be specified.
@@ -262,7 +267,7 @@ type ParsedGoFile struct {
 	// actual content of the file if we have fixed the AST.
 	Src      []byte
 	Mapper   *protocol.ColumnMapper
-	ParseErr error
+	ParseErr scanner.ErrorList
 }
 
 // A ParsedModule contains the results of parsing a go.mod file.
@@ -518,11 +523,6 @@ type Analyzer struct {
 	// If this is true, then we can apply the suggested fixes
 	// as part of a source.FixAll codeaction.
 	HighConfidence bool
-
-	// FixesError is only set for type-error analyzers.
-	// It reports true if the message provided indicates an error that could be
-	// fixed by the analyzer.
-	FixesError func(msg string) bool
 }
 
 func (a Analyzer) IsEnabled(view View) bool {
@@ -547,7 +547,6 @@ type Package interface {
 	CompiledGoFiles() []*ParsedGoFile
 	File(uri span.URI) (*ParsedGoFile, error)
 	GetSyntax() []*ast.File
-	GetDiagnostics() []*Diagnostic
 	GetTypes() *types.Package
 	GetTypesInfo() *types.Info
 	GetTypesSizes() types.Sizes
@@ -557,6 +556,8 @@ type Package interface {
 	MissingDependencies() []string
 	Imports() []Package
 	Version() *module.Version
+	HasListOrParseErrors() bool
+	HasTypeErrors() bool
 }
 
 type CriticalError struct {
@@ -584,9 +585,10 @@ type Diagnostic struct {
 	Tags    []protocol.DiagnosticTag
 	Related []RelatedInformation
 
-	// SuggestedFixes is used to generate quick fixes for a CodeAction request.
-	// It isn't part of the Diagnostic type.
+	// Fields below are used internally to generate quick fixes. They aren't
+	// part of the LSP spec and don't leave the server.
 	SuggestedFixes []SuggestedFix
+	Analyzer       *Analyzer
 }
 
 type DiagnosticSource string

--- a/cmd/govim/internal/golang_org_x_tools/span/parse.go
+++ b/cmd/govim/internal/golang_org_x_tools/span/parse.go
@@ -5,6 +5,7 @@
 package span
 
 import (
+	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -15,6 +16,17 @@ import (
 // The returned span will be normalized, and thus if printed may produce a
 // different string.
 func Parse(input string) Span {
+	return ParseInDir(input, ".")
+}
+
+// ParseInDir is like Parse, but interprets paths relative to wd.
+func ParseInDir(input, wd string) Span {
+	uri := func(path string) URI {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(wd, path)
+		}
+		return URIFromPath(path)
+	}
 	// :0:0#0-0:0#0
 	valid := input
 	var hold, offset int
@@ -32,12 +44,12 @@ func Parse(input string) Span {
 	}
 	switch {
 	case suf.sep == ":":
-		return New(URIFromPath(suf.remains), NewPoint(suf.num, hold, offset), Point{})
+		return New(uri(suf.remains), NewPoint(suf.num, hold, offset), Point{})
 	case suf.sep == "-":
 		// we have a span, fall out of the case to continue
 	default:
 		// separator not valid, rewind to either the : or the start
-		return New(URIFromPath(valid), NewPoint(hold, 0, offset), Point{})
+		return New(uri(valid), NewPoint(hold, 0, offset), Point{})
 	}
 	// only the span form can get here
 	// at this point we still don't know what the numbers we have mean
@@ -53,20 +65,20 @@ func Parse(input string) Span {
 	}
 	if suf.sep != ":" {
 		// turns out we don't have a span after all, rewind
-		return New(URIFromPath(valid), end, Point{})
+		return New(uri(valid), end, Point{})
 	}
 	valid = suf.remains
 	hold = suf.num
 	suf = rstripSuffix(suf.remains)
 	if suf.sep != ":" {
 		// line#offset only
-		return New(URIFromPath(valid), NewPoint(hold, 0, offset), end)
+		return New(uri(valid), NewPoint(hold, 0, offset), end)
 	}
 	// we have a column, so if end only had one number, it is also the column
 	if !hadCol {
 		end = NewPoint(suf.num, end.v.Line, end.v.Offset)
 	}
-	return New(URIFromPath(suf.remains), NewPoint(suf.num, hold, offset), end)
+	return New(uri(suf.remains), NewPoint(suf.num, hold, offset), end)
 }
 
 type suffix struct {

--- a/cmd/govim/testdata/scenario_default/watcher.txt
+++ b/cmd/govim/testdata/scenario_default/watcher.txt
@@ -115,7 +115,7 @@ const Bar = 1
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "other declaration of Const1",
+    "text": "Const1 redeclared in this block (this error: other declaration of Const1)",
     "type": "",
     "valid": 1,
     "vcol": 0

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.1
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
-	golang.org/x/tools v0.1.1-0.20210227203037-f5a4005dda57
-	golang.org/x/tools/gopls v0.0.0-20210227203037-f5a4005dda57
+	golang.org/x/tools v0.1.1-0.20210303215420-376db57240db
+	golang.org/x/tools/gopls v0.0.0-20210303215420-376db57240db
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1-0.20210227203037-f5a4005dda57 h1:x5EXcwAOUCfHm97vi+APgjp6BWSgZ+63dHs+pwtH2Tc=
-golang.org/x/tools v0.1.1-0.20210227203037-f5a4005dda57/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
-golang.org/x/tools/gopls v0.0.0-20210227203037-f5a4005dda57 h1:gYKUxwx3GEvmsYzyk/w/MPeyQ66aZmcDcu62eE+/pWA=
-golang.org/x/tools/gopls v0.0.0-20210227203037-f5a4005dda57/go.mod h1:q2ebn/wWEF1eM4RLz1NFKDK1JvIzDUrKvKw5RRfW+rI=
+golang.org/x/tools v0.1.1-0.20210303215420-376db57240db h1:vRASVXCk4fZnCcCvGb6xrhQE1Zd5PMfESAvrIagpWDg=
+golang.org/x/tools v0.1.1-0.20210303215420-376db57240db/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
+golang.org/x/tools/gopls v0.0.0-20210303215420-376db57240db h1:1xwGDHrFatYhzIjP1ZnQ4C2LQeOAkPwmRUQiXdhhehg=
+golang.org/x/tools/gopls v0.0.0-20210303215420-376db57240db/go.mod h1:q2ebn/wWEF1eM4RLz1NFKDK1JvIzDUrKvKw5RRfW+rI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Includes a small fix up for a diagnostic error message to match the new
expected value from gopls.

* internal/lsp: use pre-existing quick fixes for analysis diagnostics 376db572
* internal/lsp: run type error analyzers as part of diagnostics 144d5ced
* internal/lsp/source: eliminate GetTypeCheckDiagnostics 24439e3c
* internal/lsp: show human-readable const time.Duration as a comment dafbee50
* internal/lsp/cache: don't rely on related diagnostics if unsupported 9c452d85
* internal/lsp: key GC details off package ID 2ac05c83
* gopls/internal/hooks: compile URL regexp once 303d8bbb
* internal/lsp/cache: show type errors on parse errors in other files 94327d32
* gopls/internal/regtest: add a failing test for issue 44736 16b2c870
* internal/lsp/cache: split up sourceDiagnostics 78002535
* internal/lsp/cache: refactor Go file parsing 47985cf3
* internal/lsp/cache: invalidate metadata on magic comment changes 6422c5c8
* gopls/internal/regtest: add test for bad embed rules f9c628b1
* internal/lsp/cache: parse filenames from go list errors correctly 89a9cb6e
* internal/lsp/cache: refactor diagnostic suppression eb48d3f6
* internal/lsp/cache: fix related error processing 7a079fcd