### PR TITLE
cmd/govim: add posibility to set GoImports timeout as config

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -156,6 +156,10 @@ function! s:validGofumpt(v)
   return s:validBool(a:v)
 endfunction
 
+function! s:validGoImportsTimeout(v)
+  return s:validString(a:v)
+endfunction
+
 function! s:validExperimentalAutoreadLoadedBuffers(v)
   return s:validBool(a:v)
 endfunction
@@ -196,6 +200,7 @@ endfunction
 
 let s:validators = {
       \ "FormatOnSave": function("s:validFormatOnSave"),
+      \ "GoImportsTimeout": function("s:validGoImportsTimeout"),
       \ "QuickfixAutoDiagnostics": function("s:validQuickfixAutoDiagnostics"),
       \ "CompletionDeepCompletions": function("s:validCompletionDeepCompletions"),
       \ "CompletionMatcher": function("s:validCompletionMatcher"),

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -2,6 +2,8 @@
 // used by govim
 package config
 
+import "time"
+
 const (
 	InternalFunctionPrefix = "_internal_"
 )
@@ -45,6 +47,13 @@ type Config struct {
 	//
 	// Default: FormatOnSaveGoImportsGoFmt.
 	FormatOnSave *FormatOnSave `json:",omitempty"`
+
+	// GoImportsTimeout configures how long a goimports call is allowed to run
+	// before being explicitly cancelled. The main use case is to avoid blocking
+	// for long when saving a buffer with GoImports as a part of FormatOnSave.
+	//
+	// Default: 0 (no timeout)
+	GoImportsTimeout *time.Duration `json:",omitempty"`
 
 	// QuickfixAutoDiagnostics is a boolean (0 or 1 in VimScript) that controls
 	// whether auto-population of the quickfix window with gopls diagnostics is

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -4,6 +4,9 @@ func (r *Config) Apply(v *Config) {
 	if v.FormatOnSave != nil {
 		r.FormatOnSave = v.FormatOnSave
 	}
+	if v.GoImportsTimeout != nil {
+		r.GoImportsTimeout = v.GoImportsTimeout
+	}
 	if v.QuickfixAutoDiagnostics != nil {
 		r.QuickfixAutoDiagnostics = v.QuickfixAutoDiagnostics
 	}

--- a/cmd/govim/format.go
+++ b/cmd/govim/format.go
@@ -78,7 +78,13 @@ func (v *vimstate) formatBufferRange(b *types.Buffer, mode config.FormatOnSave, 
 		if flags.Range != nil {
 			params.Range = *ran
 		}
-		actions, err := v.server.CodeAction(context.Background(), params)
+		ctx := context.Background()
+		var cancel context.CancelFunc
+		if v.config.GoImportsTimeout != nil && *v.config.GoImportsTimeout > 0 {
+			ctx, cancel = context.WithTimeout(ctx, *v.config.GoImportsTimeout)
+			defer cancel()
+		}
+		actions, err := v.server.CodeAction(ctx, params)
 		if err != nil {
 			v.Logf("gopls.CodeAction returned an error; nothing to do")
 			return nil

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -3,11 +3,14 @@
 package vimconfig
 
 import (
+	"time"
+
 	"github.com/govim/govim/cmd/govim/config"
 )
 
 type VimConfig struct {
 	FormatOnSave                                 *config.FormatOnSave
+	GoImportsTimeout                             *string
 	QuickfixAutoDiagnostics                      *int
 	QuickfixSigns                                *int
 	HighlightDiagnostics                         *int
@@ -38,6 +41,7 @@ type VimConfig struct {
 func (c *VimConfig) ToConfig(d config.Config) config.Config {
 	v := config.Config{
 		FormatOnSave:                      c.FormatOnSave,
+		GoImportsTimeout:                  durationVal(c.GoImportsTimeout, d.GoImportsTimeout),
 		QuickfixSigns:                     boolVal(c.QuickfixSigns, d.QuickfixSigns),
 		QuickfixAutoDiagnostics:           boolVal(c.QuickfixAutoDiagnostics, d.QuickfixAutoDiagnostics),
 		HighlightDiagnostics:              boolVal(c.HighlightDiagnostics, d.HighlightDiagnostics),
@@ -92,6 +96,16 @@ func stringVal(i, j *string) *string {
 		return j
 	}
 	return i
+}
+
+func durationVal(i *string, j *time.Duration) *time.Duration {
+	if i == nil {
+		return j
+	}
+	if t, err := time.ParseDuration(*i); err == nil {
+		return &t
+	}
+	return j
 }
 
 func copyStringValMap(i, j *map[string]string) *map[string]string {
@@ -153,6 +167,10 @@ func SymbolStyleVal(v config.SymbolStyle) *config.SymbolStyle {
 
 func FormatOnSaveVal(v config.FormatOnSave) *config.FormatOnSave {
 	return &v
+}
+
+func DurationVal(t time.Duration) *time.Duration {
+	return &t
 }
 
 func BoolVal(v bool) *bool {


### PR DESCRIPTION
This change adds a new config, `GoImportsTimeout` expressed as a
time.Duration string, e.g.

```
call govim#config#Set("GoImportsTimeout", "1s")
```

Setting this will cancel the goimports call during buffer save after one
second.

Default: `0` (no timeout)