### PR TITLE
cmd/govim: refactor file watching

### DIFF
--- a/cmd/govim/internal/fswatcher/fswatcher.go
+++ b/cmd/govim/internal/fswatcher/fswatcher.go
@@ -1,4 +1,7 @@
+// Package fswatcher is responsible for providing file system events to govim
 package fswatcher
+
+import "fmt"
 
 type FSWatcher struct {
 	*fswatcher // os specific
@@ -9,6 +12,10 @@ type Event struct {
 	Op   Op
 }
 
+func (e Event) String() string {
+	return fmt.Sprintf("%s %q", e.Op, e.Path)
+}
+
 type Op string
 
 const (
@@ -16,3 +23,9 @@ const (
 	OpRemoved Op = "removed"
 	OpCreated Op = "created"
 )
+
+// watchFilterFn is used to determine if events should be sent for a particular
+// file or directory. It enables language specific rules in a generic context.
+type watchFilterFn func(path string) bool
+
+type logFn func(format string, args ...interface{})

--- a/cmd/govim/internal/fswatcher/os_others.go
+++ b/cmd/govim/internal/fswatcher/os_others.go
@@ -1,9 +1,12 @@
+//go:build !darwin
 // +build !darwin
 
 package fswatcher
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/fsnotify/fsnotify"
 	"gopkg.in/tomb.v2"
@@ -13,49 +16,177 @@ type fswatcher struct {
 	eventCh chan Event
 	errCh   chan error
 	mw      *fsnotify.Watcher
+	logf    logFn
+
+	// activeWatchers is a map keyed by directory paths for directories that has been
+	// added to watch. The bool value is used to dedup multiple remove events for the same
+	// directory from fsnotify (inotify sends two events when removing a dir, "DELETE_SELF"
+	// and "DELETE,ISDIR" where the difference isn't exposed by fsnotify). The value is true
+	// if the watcher is active, and false for directories that no longer are watched.
+	// By only sending events on the transition from true to false we ensure that only one
+	// event is sent even when we get duplicate remove events. The key must be removed if
+	// a file is created with the same name as a previous directory.
+	activeWatches map[string]bool
 }
 
-func New(gomodpath string, tomb *tomb.Tomb) (*FSWatcher, error) {
+// populateWatches is used to walk the provided path and add/remove directories to the
+// underlying fsnotify watcher since it isn't recursive. It return all files found in
+// watched directories during the walk. If the initPath is a newly created directory
+// we must also send create events for the returned files to prevent a race condition where
+// files are created before the directory is watched.
+func (w *fswatcher) populateWatches(initPath string, filter watchFilterFn) ([]string, error) {
+	var files []string
+	err := filepath.Walk(initPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// fast path for directories that are already watched
+		if w.activeWatches[path] {
+			return nil
+		}
+
+		if info.IsDir() && filter(path) {
+			// We might end up here if the user creates a go.mod in a watched dir
+			// for example. Then we need to remove the watch.
+			if v, ok := w.activeWatches[path]; ok && v {
+				w.logf("stopped watching dir %q", path)
+				w.mw.Remove(path)
+				w.activeWatches[path] = false
+			}
+			return filepath.SkipDir
+		}
+
+		if !info.IsDir() {
+			files = append(files, path)
+			return nil
+		}
+
+		if v, ok := w.activeWatches[path]; !ok || !v {
+			if err := w.mw.Add(path); err != nil {
+				return err
+			}
+			w.logf("started watching dir %q", path)
+			w.activeWatches[path] = true
+			// When mw.Add returns the folder might already contain files and/or
+			// directories that we must send events for manually. The recommended
+			// way in inotify(7) is to:
+			//
+			// "[...] new files (and subdirectories) may already exist inside the
+			// subdirectory. Therefore, you might want to scan the contents of ths
+			// subdirectory immediately after adding the watch (and, if desired,
+			// recursively add watchers for any subdirectories that it contains).
+			fs, err := w.populateWatches(path, filter)
+			files = append(files, fs...)
+			if err != nil {
+				return err
+			}
+			// We must stop walking here since we initiated a new walk above, to avoid
+			// duplicate events..
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	return files, err
+}
+
+// New creates a file watcher that provide events recursively for all files and directories
+// that aren't filtered by the watch filter. The root argument must be an existing directory,
+// in our case the module root. FSWatcher will not send events for any path (file or directory)
+// where the filter returns "true".
+func New(root string, filter watchFilterFn, logf logFn, tomb *tomb.Tomb) (*FSWatcher, error) {
+	if fi, err := os.Stat(root); err != nil || !fi.IsDir() {
+		return nil, fmt.Errorf("provided root %q must be an existing directory", root)
+	}
+
 	mw, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new watcher: %v", err)
 	}
 
 	eventCh := make(chan Event)
+	w := &fswatcher{
+		eventCh:       eventCh,
+		errCh:         mw.Errors,
+		mw:            mw,
+		logf:          logf,
+		activeWatches: make(map[string]bool),
+	}
+
+	if _, err := w.populateWatches(root, filter); err != nil {
+		return nil, fmt.Errorf("initial root walk failed: %w", err)
+	}
+
 	tomb.Go(func() error {
 		for {
 			e, ok := <-mw.Events
 			if !ok {
 				break
 			}
+			path := e.Name
 			switch e.Op {
+			// fsnotify processes file renaming as a Rename event followed by a
+			// Create event, so we can effectively treat renaming as removal.
 			case fsnotify.Rename, fsnotify.Remove:
-				// fsnotify processes file renaming as a Rename event followed by a
-				// Create event, so we can effectively treat renaming as removal.
-				eventCh <- Event{e.Name, OpRemoved}
-			case fsnotify.Chmod, fsnotify.Write:
-				eventCh <- Event{e.Name, OpChanged}
-			case fsnotify.Create:
-				eventCh <- Event{e.Name, OpCreated}
+				if v, ok := w.activeWatches[path]; ok {
+					if v {
+						logf("stopped watching (implicit) dir %q", path)
+					}
+					// We try to avoid sending remove events for directories, however
+					// fsnotify send is two events per delete. One for the "DELETE_SELF",
+					// and another for "DELETE,ISDIR". These flags aren't exposed by
+					// fsnotify so after the file/directory has been removed there is
+					// no way to tell if the path was a directory.
+					// To prevent events for the second we just set the entry to false
+					// w/o dropping it entirely.
+					w.activeWatches[path] = false
+					continue
+				}
+				eventCh <- Event{path, OpRemoved}
+			case fsnotify.Chmod, fsnotify.Write, fsnotify.Create:
+				var op Op
+				if e.Op == fsnotify.Create {
+					op = OpCreated
+				} else {
+					op = OpChanged
+				}
+
+				di, err := os.Stat(path)
+				if err != nil {
+					// This might happen for example when vim writes temporary files that
+					// are removed before the stat call.
+					logf("error: failed to stat %q: %v", path, err)
+					continue
+				}
+				if !di.IsDir() {
+					// We know for sure that this isn't a directory so we must remove
+					// any entry from activeWatchers in case we have had a directory
+					// with the same name earlier.
+					delete(w.activeWatches, path)
+					if !filter(path) {
+						eventCh <- Event{path, op}
+					}
+					continue
+				}
+				files, err := w.populateWatches(path, filter)
+				if err != nil {
+					logf("error: failed to walk %q: %v", path, err)
+					continue
+				}
+				// If the directory was just created, we need to send file creation events
+				// for all files created as well.
+				if op == OpCreated && w.activeWatches[path] {
+					for _, f := range files {
+						eventCh <- Event{f, op}
+					}
+				}
 			}
 		}
 		close(eventCh)
 		return nil
 	})
 
-	return &FSWatcher{&fswatcher{
-		eventCh: eventCh,
-		errCh:   mw.Errors,
-		mw:      mw,
-	}}, nil
-}
-
-func (w *fswatcher) Add(path string) error {
-	return w.mw.Add(path)
-}
-
-func (w *fswatcher) Remove(path string) error {
-	return w.mw.Remove(path)
+	return &FSWatcher{w}, nil
 }
 
 func (w *fswatcher) Close() error {

--- a/cmd/govim/testdata/scenario_default/watcher.txt
+++ b/cmd/govim/testdata/scenario_default/watcher.txt
@@ -25,20 +25,6 @@ rm const.go
 errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const.go'", Type:3\}'
 vimexprwait errors.empty GOVIMTest_getqflist()
 
-skip 'Temporary disabled due to https://github.com/govim/govim/issues/492'
-
-# New package, note that this is currently handled by a separate lib in darwin
-vim ex 'call cursor(7,1)'
-vim ex 'call feedkeys(\"ifmt.Println(foo.Bar)\n\\<ESC>\",\"x\")'
-errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
-mkdir foo
-cp foo_foo.go.orig foo/foo.go
-errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/foo/foo.go'", Type:1\}'
-errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/foo/foo.go
-vim ex 'w'
-errlogmatch 'PublishDiagnostics callback: &protocol.PublishDiagnosticsParams{\n\S+:\s+URI:\s+"file://'$WORK/main.go
-vimexprwait errors.updated GOVIMTest_getqflist()
-
 # No warnings or errors during the test
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages

--- a/cmd/govim/testdata/scenario_default/watcher_go_rules.txt
+++ b/cmd/govim/testdata/scenario_default/watcher_go_rules.txt
@@ -1,0 +1,84 @@
+# Test that the file watcher handle Go specific rules (as ignoring sub modules) correctly.
+
+# New file in the same package
+vim ex 'e main.go'
+
+# New packages should be watched
+mkdir a
+cp a.orig a/a.go
+errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/a/a.go'", Type:1\}'
+rm a/a.go
+errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/a/a.go'", Type:3\}'
+
+# Root go.mod should also be watched
+cp go.mod.other go.mod
+errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/go.mod'", Type:2\}'
+
+[short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'
+
+# Files that start with "." shouldn't be watched
+cp a.orig a/.nowatch.go
+# .. or files that starts with "_"
+cp a.orig a/_nowatch.go
+
+# Do not send didChange for files written to pre existing sub modules
+cp a.orig preexisting/submod/nowatch.go
+
+# Files in "testdata" shouldn't be watched
+mkdir testdata/b
+cp b.orig testdata/b/nowatch.go
+rm testdata/b/nowatch.go
+rm testdata
+
+# .. neither should files in a directory that starts with "."
+mkdir .b
+cp b.orig .b/nowatch.go
+
+# .. or starts with "_"
+mkdir _b
+cp b.orig _b/nowatch.go
+
+# Do not send didChange for created file in sub module
+mkdir submod
+cp gomod.empty submod/go.mod
+cp c.orig submod/nowatch.go
+
+# Do not send didChange for removed file in sub module (checked after sleep below)
+rm submod/a.go
+
+sleep $GOVIM_ERRLOGMATCH_WAIT
+errlogmatch -start -count=0 '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/.*/nowatch.go'", Type:1\}'
+errlogmatch -start -count=0 '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/.*/.nowatch.go'", Type:1\}'
+errlogmatch -start -count=0 '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/.*/_nowatch.go'", Type:1\}'
+errlogmatch -start -count=0 '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/submod/a.go'", Type:3\}'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- go.mod.other --
+module mod.com
+
+go 1.13
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println()
+}
+-- preexisting/foo.go --
+package foo
+-- preexisting/submod/go.mod --
+-- a.orig --
+package a
+-- b.orig --
+package b
+-- c.orig --
+package c
+-- gomod.empty --

--- a/cmd/govim/watcher.go
+++ b/cmd/govim/watcher.go
@@ -24,9 +24,6 @@ type modWatcher struct {
 
 	// root is the directory root of the watch
 	root string
-
-	// watches is the set of current watches "open" in the watcher
-	watches map[string]bool
 }
 
 func (m *modWatcher) close() error { return m.watcher.Close() }
@@ -34,9 +31,8 @@ func (m *modWatcher) close() error { return m.watcher.Close() }
 // newWatcher returns a new watcher that will "watch" on the Go files in the
 // module identified by gomodpath
 func newModWatcher(plug *govimplugin, gomodpath string) (*modWatcher, error) {
-	w, err := fswatcher.New(gomodpath, &plug.tomb)
-	if err != nil {
-		return nil, err
+	infof := func(format string, args ...interface{}) {
+		plug.Logf("file watcher event: "+format, args...)
 	}
 
 	dirpath := filepath.Dir(gomodpath)
@@ -45,30 +41,22 @@ func newModWatcher(plug *govimplugin, gomodpath string) (*modWatcher, error) {
 		return nil, fmt.Errorf("could not resolve dir from go.mod path %v: %v", gomodpath, err)
 	}
 
+	w, err := fswatcher.New(dirpath, eventFilter(dirpath), infof, &plug.tomb)
+	if err != nil {
+		return nil, err
+	}
+
 	res := &modWatcher{
 		govimplugin: plug,
 		watcher:     w,
 		root:        dirpath,
-		watches:     make(map[string]bool),
 	}
 
 	go res.watch()
-	// fake event to kick start the watching
-	res.watcher.Events() <- fswatcher.Event{
-		Path: dirpath,
-		Op:   fswatcher.OpChanged,
-	}
-
 	return res, nil
 }
 
 func (m *modWatcher) watch() {
-	errf := func(format string, args ...interface{}) {
-		m.Logf("**** file watcher error: "+format, args...)
-	}
-	infof := func(format string, args ...interface{}) {
-		m.Logf("file watcher event: "+format, args...)
-	}
 	eventCh := m.watcher.Events()
 	errCh := m.watcher.Errors()
 
@@ -79,81 +67,15 @@ func (m *modWatcher) watch() {
 				// watcher has been stopped?
 				return
 			}
-			switch event.Op {
-			case fswatcher.OpRemoved:
-				path := event.Path
-				var didFind bool
-				for ew := range m.watches {
-					if event.Path == ew || strings.HasPrefix(ew, event.Path+string(os.PathSeparator)) {
-						didFind = true
-						if err := m.watcher.Remove(ew); err != nil {
-							errf("failed to remove watch on %v: %v", ew, err)
-						}
-						infof("removed watch on %v", ew)
-					}
-				}
-				if didFind {
-					// it was a directory
-					continue
-				}
-				if !ofInterest(path) {
-					continue
-				}
-				m.Enqueue(func(govim.Govim) error {
-					return m.vimstate.handleEvent(event)
-				})
-			case fswatcher.OpChanged, fswatcher.OpCreated:
-				path := event.Path
-				dirInfo, err := os.Stat(path)
-				if err != nil {
-					errf("failed to stat %v: %v", path, err)
-					continue
-				}
-				if !dirInfo.IsDir() {
-					// Is Vim handling this file? Is this a file we care about?
-					if !ofInterest(path) {
-						continue
-					}
-					m.Enqueue(func(govim.Govim) error {
-						return m.vimstate.handleEvent(event)
-					})
-					continue
-				}
 
-				// Walk the dir that is event.Name. Because fsnotify isn't recursive,
-				// we must manually install watches ourselves.
-				// Note that this has a race condition:
-				// https://github.com/govim/govim/issues/492
-				err = filepath.Walk(event.Path, func(path string, info os.FileInfo, err error) error {
-					if err != nil {
-						return err
-					}
-					if !info.IsDir() {
-						return nil
-					}
-
-					// We have a dir
-					switch filepath.Base(path)[0] {
-					case '.', '_':
-						return filepath.SkipDir
-					}
-					if path != m.root {
-						// check we are not in a submodule
-						if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
-							return filepath.SkipDir
-						}
-					}
-					err = m.watcher.Add(path)
-					if err != nil {
-						m.watches[path] = true
-						infof("added watch on %v", path)
-					}
-					return err
-				})
-				if err != nil {
-					errf("failed to walk %v: %v", event.Path, err)
-				}
+			if !ofInterest(event.Path) {
+				continue
 			}
+
+			m.Enqueue(func(govim.Govim) error {
+				return m.vimstate.handleEvent(event)
+			})
+
 		case err, ok := <-errCh:
 			if !ok {
 				// watcher has been stopped?
@@ -162,6 +84,59 @@ func (m *modWatcher) watch() {
 			// TODO: handle this case better
 			m.Logf("***** file watcher error: %v", err)
 		}
+	}
+}
+
+// eventFilter return a function that is used to filter events according to the Go specific
+// rules described by https://golang.org/cmd/go/#hdr-Package_lists_and_patterns:
+//
+//  > Directory and file names that begin with "." or "_" are ignored by the go
+//    tool, as are directories named "testdata".
+//
+// and the module boundary described by https://golang.org/ref/mod#modules-overview:
+//
+//  > The module root directory is the directory that contains the go.mod file.
+//
+func eventFilter(root string) func(string) bool {
+	return func(path string) bool {
+		path = filepath.Clean(path)
+		if fi, err := os.Stat(path); err == nil && !fi.IsDir() {
+			var filename string
+			path, filename = filepath.Split(path)
+			switch filename[0] {
+			case '.', '_':
+				return true
+			}
+		}
+
+		// TODO: cache ignored directories to reduce amount of os.Stat(...) calls?
+		rel := strings.TrimPrefix(path, root)
+		rel = strings.Trim(rel, string(os.PathSeparator))
+		if rel == "" {
+			return false
+		}
+		parts := strings.Split(rel, string(os.PathSeparator))
+		if len(parts) == 0 {
+			return false
+		}
+
+		var curr string
+		for i := 0; i < len(parts); i++ {
+			dir := parts[i]
+			switch dir[0] {
+			case '.', '_':
+				return true
+			}
+			if dir == "testdata" {
+				return true
+			}
+
+			curr = filepath.Join(curr, dir)
+			if _, err := os.Stat(filepath.Join(root, curr, "go.mod")); err == nil {
+				return true
+			}
+		}
+		return false
 	}
 }
 


### PR DESCRIPTION
The previous file watchers was broken in several ways, where the two
major was:
* A race condition in the non-darwin watcher (#492)
* Darwin recursively watched the entire module directory, disregarding
  sub-modules, testdata directories and directories prefixed by _ or .
  This caused the test suite to always fail on macOS.

This change:
* Moves the non-recursive handling into os_other.go
* Adds an OS independent function that filter events specifically
  disallowed by Go (i.e. "testdata", sub-modules and directories
  prefixed by _ or .
* Adds more tests to raise file watching cover

Closes #492