### PR TITLE
cmd/govim: check quickfix list origin before update

### DIFF
--- a/cmd/govim/buffer_events.go
+++ b/cmd/govim/buffer_events.go
@@ -85,8 +85,6 @@ func (v *vimstate) bufQuickFixCmdPre(args ...json.RawMessage) error {
 func (v *vimstate) bufQuickFixCmdPost(args ...json.RawMessage) error {
 	defer func() { v.vimgrepPendingBufs = nil }()
 
-	v.quickfixIsDiagnostics = v.quickfixIsDiagnostics && len(v.vimgrepPendingBufs) == 0
-
 	// Vim versions older than 8.2.2185 did not notify when buffers opened during vimgrep
 	// closed so we need to explicitly check if any of the buffers are still open.
 	for _, b := range v.vimgrepPendingBufs {

--- a/cmd/govim/diagnostics.go
+++ b/cmd/govim/diagnostics.go
@@ -86,7 +86,7 @@ func (v *vimstate) diagnostics() *[]types.Diagnostic {
 }
 
 func (v *vimstate) handleDiagnosticsChanged() error {
-	if err := v.updateQuickfixWithDiagnostics(false, false); err != nil {
+	if err := v.updateQuickfixWithDiagnostics(false); err != nil {
 		return err
 	}
 

--- a/cmd/govim/implements.go
+++ b/cmd/govim/implements.go
@@ -9,7 +9,6 @@ import (
 )
 
 func (v *vimstate) implements(flags govim.CommandFlags, args ...string) error {
-	v.quickfixIsDiagnostics = false
 	b, pos, err := v.bufCursorPos()
 	if err != nil {
 		return fmt.Errorf("failed to get current position: %v", err)

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -257,13 +257,12 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 		inShutdown:       make(chan struct{}),
 		diagnosticsCache: &emptyDiags,
 		vimstate: &vimstate{
-			Driver:                d,
-			buffers:               make(map[int]*types.Buffer),
-			defaultConfig:         *defaults,
-			config:                *defaults,
-			quickfixIsDiagnostics: true,
-			suggestedFixesPopups:  make(map[int][]suggestedFix),
-			progressPopups:        make(map[protocol.ProgressToken]*types.ProgressPopup),
+			Driver:               d,
+			buffers:              make(map[int]*types.Buffer),
+			defaultConfig:        *defaults,
+			config:               *defaults,
+			suggestedFixesPopups: make(map[int][]suggestedFix),
+			progressPopups:       make(map[protocol.ProgressToken]*types.ProgressPopup),
 		},
 	}
 	res.vimstate.govimplugin = res

--- a/cmd/govim/references.go
+++ b/cmd/govim/references.go
@@ -9,7 +9,6 @@ import (
 )
 
 func (v *vimstate) references(flags govim.CommandFlags, args ...string) error {
-	v.quickfixIsDiagnostics = false
 	b, pos, err := v.bufCursorPos()
 	if err != nil {
 		return fmt.Errorf("failed to get current position: %v", err)

--- a/cmd/govim/testdata/scenario_default/quickfix_from_other.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_from_other.txt
@@ -1,0 +1,118 @@
+# Test that the quickfix window is updated by diagnostics only in some situations
+
+vim ex 'e main.go'
+vimexprwait errors.golden1 GOVIMTest_getqflist()
+vim ex 'call setqflist([{\"filename\":\"foo\"}, {\"filename\":\"bar\"}, {\"filename\":\"baz\"}], \"r\")'
+vimexprwait errors.other GOVIMTest_getqflist()
+
+# Add an error, the quickfix should remain because it's not already filled with diagnostics
+vim ex 'call cursor(6, 1)'
+vim ex 'call feedkeys(\"yyp\")'
+vimexprwait errors.other GOVIMTest_getqflist()
+
+# Force display diagnostics now
+vim ex 'GOVIMQuickfixDiagnostics'
+vimexprwait errors.golden2 GOVIMTest_getqflist()
+
+# Fill quickfix with empty array, this time it shouldn't remain because it's empty
+vim ex 'call setqflist([])'
+vim ex 'call feedkeys(\"dd\")'
+vimexprwait errors.golden1 GOVIMTest_getqflist()
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- main.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("%v")
+}
+-- errors.other --
+[
+  {
+    "bufname": "foo",
+    "col": 0,
+    "lnum": 0,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "",
+    "type": "",
+    "valid": 0,
+    "vcol": 0
+  },
+  {
+    "bufname": "bar",
+    "col": 0,
+    "lnum": 0,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "",
+    "type": "",
+    "valid": 0,
+    "vcol": 0
+  },
+  {
+    "bufname": "baz",
+    "col": 0,
+    "lnum": 0,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "",
+    "type": "",
+    "valid": 0,
+    "vcol": 0
+  }
+]
+-- errors.golden1 --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.golden2 --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]


### PR DESCRIPTION
QuickfixDiagnostics routine updates the quickfix list each time it
receives new diagnostics from gopls. This can be problematic if the
quickfix list has been populated by an other plugin, because the user
could be using this plugin.

The fix uses the quickfix title to determine if the quickfix is "owned"
by govim or by an other plugin. If the quicfix title is empty (which
means the quickfix has never been used before) or equal to "govim", then
govim considers it can change it, else it considers it cannot.

This condition is ignored when :GOVIMQuickfixDiagnostics is invoked by
the user, making possible for the user to display again the diagnostics
when he wants to.