### PR TITLE
deps: update x/tools and gopls to d7a25ada

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/imports/mod.go
+++ b/cmd/govim/internal/golang_org_x_tools/imports/mod.go
@@ -89,8 +89,10 @@ func (r *ModuleResolver) init() error {
 		err := r.initAllMods()
 		// We expect an error when running outside of a module with
 		// GO111MODULE=on. Other errors are fatal.
-		if err != nil && !strings.Contains(err.Error(), "working directory is not part of a module") {
-			return err
+		if err != nil {
+			if errMsg := err.Error(); !strings.Contains(errMsg, "working directory is not part of a module") && !strings.Contains(errMsg, "go.mod file not found") {
+				return err
+			}
 		}
 	}
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
@@ -13,7 +13,6 @@ import (
 	"go/types"
 	"path"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -22,7 +21,6 @@ import (
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/packages"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/command"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
@@ -509,42 +507,8 @@ func typeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode source
 		return nil, err
 	}
 	pkg.diagnostics = append(pkg.diagnostics, depsErrors...)
-	if err := addGoGetFixes(ctx, snapshot, pkg); err != nil {
-		return nil, err
-	}
 
 	return pkg, nil
-}
-
-var importErrorRe = regexp.MustCompile(`could not import ([^\s]+)`)
-var missingModuleErrorRe = regexp.MustCompile(`cannot find module providing package ([^\s:]+)`)
-
-func addGoGetFixes(ctx context.Context, snapshot source.Snapshot, pkg *pkg) error {
-	if len(pkg.compiledGoFiles) == 0 || snapshot.GoModForFile(pkg.compiledGoFiles[0].URI) == "" {
-		// Go get only supports module mode for now.
-		return nil
-	}
-	for _, diag := range pkg.diagnostics {
-		matches := importErrorRe.FindStringSubmatch(diag.Message)
-		if len(matches) == 0 {
-			matches = missingModuleErrorRe.FindStringSubmatch(diag.Message)
-		}
-		if len(matches) == 0 {
-			continue
-		}
-		direct := !strings.Contains(diag.Message, "error while importing")
-		title := fmt.Sprintf("go get package %v", matches[1])
-		cmd, err := command.NewGoGetPackageCommand(title, command.GoGetPackageArgs{
-			URI:        protocol.URIFromSpanURI(pkg.compiledGoFiles[0].URI),
-			AddRequire: direct,
-			Pkg:        matches[1],
-		})
-		if err != nil {
-			return err
-		}
-		diag.SuggestedFixes = append(diag.SuggestedFixes, source.SuggestedFixFromCommand(cmd))
-	}
-	return nil
 }
 
 func (s *snapshot) depsErrors(ctx context.Context, pkg *pkg) ([]*source.Diagnostic, error) {
@@ -592,27 +556,33 @@ func (s *snapshot) depsErrors(ctx context.Context, pkg *pkg) ([]*source.Diagnost
 		}
 	}
 
-	// Apply a diagnostic to any import involved in the error, stopping after
+	// Apply a diagnostic to any import involved in the error, stopping once
 	// we reach the workspace.
 	var errors []*source.Diagnostic
 	for _, depErr := range relevantErrors {
 		for i := len(depErr.ImportStack) - 1; i >= 0; i-- {
 			item := depErr.ImportStack[i]
+			if _, ok := s.isWorkspacePackage(packageID(item)); ok {
+				break
+			}
+
 			for _, imp := range allImports[item] {
 				rng, err := source.NewMappedRange(s.FileSet(), imp.cgf.Mapper, imp.imp.Pos(), imp.imp.End()).Range()
 				if err != nil {
 					return nil, err
 				}
+				fixes, err := goGetQuickFixes(s, imp.cgf.URI, item)
+				if err != nil {
+					return nil, err
+				}
 				errors = append(errors, &source.Diagnostic{
-					URI:      imp.cgf.URI,
-					Range:    rng,
-					Severity: protocol.SeverityError,
-					Source:   source.TypeError,
-					Message:  fmt.Sprintf("error while importing %v: %v", item, depErr.Err),
+					URI:            imp.cgf.URI,
+					Range:          rng,
+					Severity:       protocol.SeverityError,
+					Source:         source.TypeError,
+					Message:        fmt.Sprintf("error while importing %v: %v", item, depErr.Err),
+					SuggestedFixes: fixes,
 				})
-			}
-			if _, ok := s.isWorkspacePackage(packageID(item)); ok {
-				break
 			}
 		}
 	}
@@ -651,12 +621,17 @@ func (s *snapshot) depsErrors(ctx context.Context, pkg *pkg) ([]*source.Diagnost
 			if err != nil {
 				return nil, err
 			}
+			fixes, err := goGetQuickFixes(s, pm.URI, item)
+			if err != nil {
+				return nil, err
+			}
 			errors = append(errors, &source.Diagnostic{
-				URI:      pm.URI,
-				Range:    rng,
-				Severity: protocol.SeverityError,
-				Source:   source.TypeError,
-				Message:  fmt.Sprintf("error while importing %v: %v", item, depErr.Err),
+				URI:            pm.URI,
+				Range:          rng,
+				Severity:       protocol.SeverityError,
+				Source:         source.TypeError,
+				Message:        fmt.Sprintf("error while importing %v: %v", item, depErr.Err),
+				SuggestedFixes: fixes,
 			})
 			break
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
@@ -1061,7 +1061,7 @@ func (s *snapshot) GetCriticalError(ctx context.Context) *source.CriticalError {
 		return nil
 	}
 
-	if strings.Contains(loadErr.MainError.Error(), "cannot find main module") {
+	if errMsg := loadErr.MainError.Error(); strings.Contains(errMsg, "cannot find main module") || strings.Contains(errMsg, "go.mod file not found") {
 		return s.workspaceLayoutError(ctx)
 	}
 	return loadErr

--- a/cmd/govim/internal/golang_org_x_tools/lsp/code_action.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/code_action.go
@@ -69,7 +69,7 @@ func (s *Server) codeAction(ctx context.Context, params *protocol.CodeActionPara
 			if err != nil {
 				return nil, err
 			}
-			quickFixes, err := quickFixesForDiagnostics(ctx, snapshot, diagnostics, diags)
+			quickFixes, err := codeActionsMatchingDiagnostics(ctx, snapshot, diagnostics, diags)
 			if err != nil {
 				return nil, err
 			}
@@ -128,75 +128,55 @@ func (s *Server) codeAction(ctx context.Context, params *protocol.CodeActionPara
 		if err != nil {
 			return nil, err
 		}
-		if (wanted[protocol.QuickFix] || wanted[protocol.SourceFixAll]) && len(diagnostics) > 0 {
-			analysisDiags, err := source.Analyze(ctx, snapshot, pkg)
+
+		pkgDiagnostics, err := snapshot.DiagnosePackage(ctx, pkg)
+		if err != nil {
+			return nil, err
+		}
+		analysisDiags, err := source.Analyze(ctx, snapshot, pkg, true)
+		if err != nil {
+			return nil, err
+		}
+		fileDiags := append(pkgDiagnostics[uri], analysisDiags[uri]...)
+
+		// Split diagnostics into fixes, which must match incoming diagnostics,
+		// and non-fixes, which must match the requested range. Build actions
+		// for all of them.
+		var fixDiags, nonFixDiags []*source.Diagnostic
+		for _, d := range fileDiags {
+			if len(d.SuggestedFixes) == 0 {
+				continue
+			}
+			kind := protocol.QuickFix
+			if d.Analyzer != nil && d.Analyzer.ActionKind != "" {
+				kind = d.Analyzer.ActionKind
+			}
+			if kind == protocol.QuickFix || kind == protocol.SourceFixAll {
+				fixDiags = append(fixDiags, d)
+			} else {
+				nonFixDiags = append(nonFixDiags, d)
+			}
+		}
+
+		fixActions, err := codeActionsMatchingDiagnostics(ctx, snapshot, diagnostics, fixDiags)
+		if err != nil {
+			return nil, err
+		}
+		codeActions = append(codeActions, fixActions...)
+
+		for _, nonfix := range nonFixDiags {
+			// For now, only show diagnostics for matching lines. Maybe we should
+			// alter this behavior in the future, depending on the user experience.
+			if !protocol.Intersect(nonfix.Range, params.Range) {
+				continue
+			}
+			actions, err := codeActionsForDiagnostic(ctx, snapshot, nonfix, nil)
 			if err != nil {
 				return nil, err
 			}
-
-			if wanted[protocol.QuickFix] {
-				pkgDiagnostics, err := snapshot.DiagnosePackage(ctx, pkg)
-				if err != nil {
-					return nil, err
-				}
-				quickFixDiags := append(pkgDiagnostics[uri], analysisDiags[uri]...)
-				modURI := snapshot.GoModForFile(fh.URI())
-				if modURI != "" {
-					modFH, err := snapshot.GetVersionedFile(ctx, modURI)
-					if err != nil {
-						return nil, err
-					}
-					modDiags, err := mod.DiagnosticsForMod(ctx, snapshot, modFH)
-					if err != nil && !source.IsNonFatalGoModError(err) {
-						// Not a fatal error.
-						event.Error(ctx, "module suggested fixes failed", err, tag.Directory.Of(snapshot.View().Folder()))
-					}
-					quickFixDiags = append(quickFixDiags, modDiags...)
-				}
-				quickFixes, err := quickFixesForDiagnostics(ctx, snapshot, diagnostics, quickFixDiags)
-				if err != nil {
-					return nil, err
-				}
-				codeActions = append(codeActions, quickFixes...)
-
-			}
-			if wanted[protocol.SourceFixAll] {
-				var fixAllEdits []protocol.TextDocumentEdit
-				for _, ad := range analysisDiags[uri] {
-					if ad.Analyzer == nil || !ad.Analyzer.HighConfidence {
-						continue
-					}
-					for _, fix := range ad.SuggestedFixes {
-						edits := fix.Edits[fh.URI()]
-						if len(edits) == 0 {
-							continue
-						}
-						fixAllEdits = append(fixAllEdits, documentChanges(fh, edits)...)
-					}
-
-				}
-				if len(fixAllEdits) != 0 {
-					codeActions = append(codeActions, protocol.CodeAction{
-						Title: "Simplifications",
-						Kind:  protocol.SourceFixAll,
-						Edit: protocol.WorkspaceEdit{
-							DocumentChanges: fixAllEdits,
-						},
-					})
-				}
-			}
+			codeActions = append(codeActions, actions...)
 		}
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		// Add any suggestions that do not necessarily fix any diagnostics.
-		if wanted[protocol.RefactorRewrite] {
-			fixes, err := convenienceFixes(ctx, snapshot, pkg, uri, params.Range)
-			if err != nil {
-				return nil, err
-			}
-			codeActions = append(codeActions, fixes...)
-		}
+
 		if wanted[protocol.RefactorExtract] {
 			fixes, err := extractionFixes(ctx, snapshot, pkg, uri, params.Range)
 			if err != nil {
@@ -217,7 +197,14 @@ func (s *Server) codeAction(ctx context.Context, params *protocol.CodeActionPara
 		// Unsupported file kind for a code action.
 		return nil, nil
 	}
-	return codeActions, nil
+
+	var filtered []protocol.CodeAction
+	for _, action := range codeActions {
+		if wanted[action.Kind] {
+			filtered = append(filtered, action)
+		}
+	}
+	return filtered, nil
 }
 
 func (s *Server) getSupportedCodeActions() []protocol.CodeActionKind {
@@ -276,94 +263,6 @@ func importDiagnostics(fix *imports.ImportFix, diagnostics []protocol.Diagnostic
 		}
 	}
 	return results
-}
-
-// diagnosticToAnalyzer return the analyzer associated with a given diagnostic.
-// It assumes that the diagnostic's source will be the name of the analyzer.
-// If this changes, this approach will need to be reworked.
-func diagnosticToAnalyzer(snapshot source.Snapshot, src, msg string) (analyzer *source.Analyzer) {
-	// Make sure that the analyzer we found is enabled.
-	defer func() {
-		if analyzer != nil && !analyzer.IsEnabled(snapshot.View()) {
-			analyzer = nil
-		}
-	}()
-	if a, ok := snapshot.View().Options().DefaultAnalyzers[src]; ok {
-		return a
-	}
-	if a, ok := snapshot.View().Options().StaticcheckAnalyzers[src]; ok {
-		return a
-	}
-	if a, ok := snapshot.View().Options().ConvenienceAnalyzers[src]; ok {
-		return a
-	}
-	return nil
-}
-
-func convenienceFixes(ctx context.Context, snapshot source.Snapshot, pkg source.Package, uri span.URI, rng protocol.Range) ([]protocol.CodeAction, error) {
-	var analyzers []*source.Analyzer
-	for _, a := range snapshot.View().Options().ConvenienceAnalyzers {
-		if !a.IsEnabled(snapshot.View()) {
-			continue
-		}
-		if a.Fix == "" {
-			event.Error(ctx, "convenienceFixes", fmt.Errorf("no suggested fixes for convenience analyzer %s", a.Analyzer.Name))
-			continue
-		}
-		analyzers = append(analyzers, a)
-	}
-	diagnostics, err := snapshot.Analyze(ctx, pkg.ID(), analyzers)
-	if err != nil {
-		return nil, err
-	}
-	var codeActions []protocol.CodeAction
-	for _, d := range diagnostics {
-		// For now, only show diagnostics for matching lines. Maybe we should
-		// alter this behavior in the future, depending on the user experience.
-		if d.URI != uri {
-			continue
-		}
-
-		if !protocol.Intersect(d.Range, rng) {
-			continue
-		}
-		action, err := diagnosticToCommandCodeAction(ctx, snapshot, d, nil, protocol.RefactorRewrite)
-		if err != nil {
-			return nil, err
-		}
-		codeActions = append(codeActions, *action)
-	}
-	return codeActions, nil
-}
-
-func diagnosticToCommandCodeAction(ctx context.Context, snapshot source.Snapshot, sd *source.Diagnostic, pd *protocol.Diagnostic, kind protocol.CodeActionKind) (*protocol.CodeAction, error) {
-	// The fix depends on the category of the analyzer. The diagnostic may be
-	// nil, so use the error's category.
-	analyzer := diagnosticToAnalyzer(snapshot, string(sd.Source), sd.Message)
-	if analyzer == nil {
-		return nil, fmt.Errorf("no convenience analyzer for source %s", sd.Source)
-	}
-	if analyzer.Fix == "" {
-		return nil, fmt.Errorf("no fix for convenience analyzer %s", analyzer.Analyzer.Name)
-	}
-	cmd, err := command.NewApplyFixCommand(sd.Message, command.ApplyFixArgs{
-		URI:   protocol.URIFromSpanURI(sd.URI),
-		Range: sd.Range,
-		Fix:   analyzer.Fix,
-	})
-	if err != nil {
-		return nil, err
-	}
-	var diagnostics []protocol.Diagnostic
-	if pd != nil {
-		diagnostics = append(diagnostics, *pd)
-	}
-	return &protocol.CodeAction{
-		Title:       sd.Message,
-		Kind:        kind,
-		Diagnostics: diagnostics,
-		Command:     &cmd,
-	}, nil
 }
 
 func extractionFixes(ctx context.Context, snapshot source.Snapshot, pkg source.Package, uri span.URI, rng protocol.Range) ([]protocol.CodeAction, error) {
@@ -431,47 +330,63 @@ func documentChanges(fh source.VersionedFileHandle, edits []protocol.TextEdit) [
 	}
 }
 
-func quickFixesForDiagnostics(ctx context.Context, snapshot source.Snapshot, pdiags []protocol.Diagnostic, sdiags []*source.Diagnostic) ([]protocol.CodeAction, error) {
-	var quickFixes []protocol.CodeAction
-	for _, e := range sdiags {
+func codeActionsMatchingDiagnostics(ctx context.Context, snapshot source.Snapshot, pdiags []protocol.Diagnostic, sdiags []*source.Diagnostic) ([]protocol.CodeAction, error) {
+	var actions []protocol.CodeAction
+	for _, sd := range sdiags {
 		var diag *protocol.Diagnostic
-		for _, d := range pdiags {
-			if sameDiagnostic(d, e) {
-				diag = &d
+		for _, pd := range pdiags {
+			if sameDiagnostic(pd, sd) {
+				diag = &pd
 				break
 			}
 		}
 		if diag == nil {
 			continue
 		}
-		for _, fix := range e.SuggestedFixes {
-			action := protocol.CodeAction{
-				Title:       fix.Title,
-				Kind:        protocol.QuickFix,
-				Diagnostics: []protocol.Diagnostic{*diag},
-				Edit:        protocol.WorkspaceEdit{},
-				Command:     fix.Command,
-			}
-
-			for uri, edits := range fix.Edits {
-				fh, err := snapshot.GetVersionedFile(ctx, uri)
-				if err != nil {
-					return nil, err
-				}
-				action.Edit.DocumentChanges = append(action.Edit.DocumentChanges, protocol.TextDocumentEdit{
-					TextDocument: protocol.OptionalVersionedTextDocumentIdentifier{
-						Version: fh.Version(),
-						TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-							URI: protocol.URIFromSpanURI(uri),
-						},
-					},
-					Edits: edits,
-				})
-			}
-			quickFixes = append(quickFixes, action)
+		diagActions, err := codeActionsForDiagnostic(ctx, snapshot, sd, diag)
+		if err != nil {
+			return nil, err
 		}
+		actions = append(actions, diagActions...)
+
 	}
-	return quickFixes, nil
+	return actions, nil
+}
+
+func codeActionsForDiagnostic(ctx context.Context, snapshot source.Snapshot, sd *source.Diagnostic, pd *protocol.Diagnostic) ([]protocol.CodeAction, error) {
+	var actions []protocol.CodeAction
+	for _, fix := range sd.SuggestedFixes {
+		action := protocol.CodeAction{
+			Title:   fix.Title,
+			Kind:    protocol.QuickFix,
+			Edit:    protocol.WorkspaceEdit{},
+			Command: fix.Command,
+		}
+		if pd != nil {
+			action.Diagnostics = []protocol.Diagnostic{*pd}
+		}
+		if sd.Analyzer != nil && sd.Analyzer.ActionKind != "" {
+			action.Kind = sd.Analyzer.ActionKind
+		}
+
+		for uri, edits := range fix.Edits {
+			fh, err := snapshot.GetVersionedFile(ctx, uri)
+			if err != nil {
+				return nil, err
+			}
+			action.Edit.DocumentChanges = append(action.Edit.DocumentChanges, protocol.TextDocumentEdit{
+				TextDocument: protocol.OptionalVersionedTextDocumentIdentifier{
+					Version: fh.Version(),
+					TextDocumentIdentifier: protocol.TextDocumentIdentifier{
+						URI: protocol.URIFromSpanURI(uri),
+					},
+				},
+				Edits: edits,
+			})
+		}
+		actions = append(actions, action)
+	}
+	return actions, nil
 }
 
 func sameDiagnostic(pd protocol.Diagnostic, sd *source.Diagnostic) bool {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command.go
@@ -683,3 +683,14 @@ func (c *commandHandler) AddImport(ctx context.Context, args command.AddImportAr
 	})
 	return result, err
 }
+
+func (c *commandHandler) WorkspaceMetadata(ctx context.Context) (command.WorkspaceMetadataResult, error) {
+	var result command.WorkspaceMetadataResult
+	for _, view := range c.s.session.Views() {
+		result.Workspaces = append(result.Workspaces, command.Workspace{
+			Name:      view.Name(),
+			ModuleDir: view.TempWorkspace().Filename(),
+		})
+	}
+	return result, nil
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command/command_gen.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command/command_gen.go
@@ -37,6 +37,7 @@ const (
 	UpdateGoSum       Command = "update_go_sum"
 	UpgradeDependency Command = "upgrade_dependency"
 	Vendor            Command = "vendor"
+	WorkspaceMetadata Command = "workspace_metadata"
 )
 
 var Commands = []Command{
@@ -58,6 +59,7 @@ var Commands = []Command{
 	UpdateGoSum,
 	UpgradeDependency,
 	Vendor,
+	WorkspaceMetadata,
 }
 
 func Dispatch(ctx context.Context, params *protocol.ExecuteCommandParams, s Interface) (interface{}, error) {
@@ -172,6 +174,8 @@ func Dispatch(ctx context.Context, params *protocol.ExecuteCommandParams, s Inte
 			return nil, err
 		}
 		return nil, s.Vendor(ctx, a0)
+	case "gopls.workspace_metadata":
+		return s.WorkspaceMetadata(ctx)
 	}
 	return nil, fmt.Errorf("unsupported command %q", params.Command)
 }
@@ -388,6 +392,18 @@ func NewVendorCommand(title string, a0 URIArg) (protocol.Command, error) {
 	return protocol.Command{
 		Title:     title,
 		Command:   "gopls.vendor",
+		Arguments: args,
+	}, nil
+}
+
+func NewWorkspaceMetadataCommand(title string) (protocol.Command, error) {
+	args, err := MarshalArgs()
+	if err != nil {
+		return protocol.Command{}, err
+	}
+	return protocol.Command{
+		Title:     title,
+		Command:   "gopls.workspace_metadata",
 		Arguments: args,
 	}, nil
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command/interface.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command/interface.go
@@ -118,6 +118,8 @@ type Interface interface {
 	ListKnownPackages(context.Context, URIArg) (ListKnownPackagesResult, error)
 
 	AddImport(context.Context, AddImportArgs) (AddImportResult, error)
+
+	WorkspaceMetadata(context.Context) (WorkspaceMetadataResult, error)
 }
 
 type RunTestsArgs struct {
@@ -205,4 +207,16 @@ type AddImportResult struct {
 
 type ListKnownPackagesResult struct {
 	Packages []string
+}
+
+type WorkspaceMetadataArgs struct {
+}
+
+type WorkspaceMetadataResult struct {
+	Workspaces []Workspace
+}
+
+type Workspace struct {
+	Name      string
+	ModuleDir string
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
@@ -265,7 +265,7 @@ func (s *Server) diagnosePkg(ctx context.Context, snapshot source.Snapshot, pkg 
 		s.storeDiagnostics(snapshot, cgf.URI, typeCheckSource, pkgDiagnostics[cgf.URI])
 	}
 	if includeAnalysis && !pkg.HasListOrParseErrors() {
-		reports, err := source.Analyze(ctx, snapshot, pkg)
+		reports, err := source.Analyze(ctx, snapshot, pkg, false)
 		if err != nil {
 			event.Error(ctx, "warning: analyzing package", err, tag.Snapshot.Of(snapshot.ID()), tag.Package.Of(pkg.ID()))
 			return

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
@@ -57,12 +57,12 @@ type CallCounts struct {
 type buffer struct {
 	version int
 	path    string
-	content []string
+	lines   []string
 	dirty   bool
 }
 
 func (b buffer) text() string {
-	return strings.Join(b.content, "\n")
+	return strings.Join(b.lines, "\n")
 }
 
 // EditorConfig configures the editor's LSP session. This is similar to
@@ -334,6 +334,10 @@ func (e *Editor) onFileChanges(ctx context.Context, evts []FileEvent) {
 				if err != nil {
 					continue // A race with some other operation.
 				}
+				// No need to update if the buffer content hasn't changed.
+				if content == strings.Join(buf.lines, "\n") {
+					continue
+				}
 				// During shutdown, this call will fail. Ignore the error.
 				_ = e.setBufferContentLocked(ctx, evt.Path, false, strings.Split(content, "\n"), nil)
 			}
@@ -378,7 +382,7 @@ func (e *Editor) createBuffer(ctx context.Context, path string, dirty bool, cont
 	buf := buffer{
 		version: 1,
 		path:    path,
-		content: strings.Split(content, "\n"),
+		lines:   strings.Split(content, "\n"),
 		dirty:   dirty,
 	}
 	e.mu.Lock()
@@ -640,8 +644,8 @@ func (e *Editor) editBufferLocked(ctx context.Context, path string, edits []Edit
 	if !ok {
 		return fmt.Errorf("unknown buffer %q", path)
 	}
-	content := make([]string, len(buf.content))
-	copy(content, buf.content)
+	content := make([]string, len(buf.lines))
+	copy(content, buf.lines)
 	content, err := editContent(content, edits)
 	if err != nil {
 		return err
@@ -654,7 +658,7 @@ func (e *Editor) setBufferContentLocked(ctx context.Context, path string, dirty 
 	if !ok {
 		return fmt.Errorf("unknown buffer %q", path)
 	}
-	buf.content = content
+	buf.lines = content
 	buf.version++
 	buf.dirty = dirty
 	e.buffers[path] = buf
@@ -908,7 +912,7 @@ func (e *Editor) checkBufferPosition(path string, pos Pos) error {
 	if !ok {
 		return fmt.Errorf("buffer %q is not open", path)
 	}
-	if !inText(pos, buf.content) {
+	if !inText(pos, buf.lines) {
 		return fmt.Errorf("position %v is invalid in buffer %q", pos, path)
 	}
 	return nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/README.md
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/README.md
@@ -23,7 +23,7 @@ containing type definitions, and `tsserver.go`, `tsclient.go` containing API stu
 
 ## Notes
 
-1. `go.ts` and `requests.ts` use the Typescript compiler's API, which is [introduced](https://github.com/Microsoft/TypeScript/wiki/Architectural-Overview) in their wiki.
+1. `code.ts` and `util.ts` use the Typescript compiler's API, which is [introduced](https://github.com/Microsoft/TypeScript/wiki/Architectural-Overview) in their wiki.
 2. Because the Typescript and Go type systems are incompatible, `code.ts` and `util.ts` are filled with heuristics and special cases. Therefore they are tied to a specific commit of `vscode-languageserver-node`. The hash code of the commit is included in the header of
 the generated files and stored in the variable `gitHash` in `go.ts`. It is checked (see `git()` in `util.ts`) on every execution.
 3. Generating the `ts*.go` files is only semi-automated. Please file an issue if the released version is too far behind.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/code.ts
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/code.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-return */
 // read files from vscode-languageserver-node, and generate Go rpc stubs
 // and data definitions. (and maybe someday unmarshaling code)
 
@@ -22,13 +23,15 @@ import * as u from './util';
 import { constName, getComments, goName, loc, strKind } from './util';
 
 var program: ts.Program;
+// eslint-disable-next-line no-unused-vars
+var checker: ts.TypeChecker;
 
 function parse() {
   // this won't complain if some fnames don't exist
   program = ts.createProgram(
     u.fnames,
     { target: ts.ScriptTarget.ES2018, module: ts.ModuleKind.CommonJS });
-  program.getTypeChecker();  // finish type checking and assignment
+  checker = program.getTypeChecker();  // finish type checking and assignment
 }
 
 // ----- collecting information for RPCs
@@ -40,22 +43,22 @@ let rpcTypes = new Set<string>();  // types seen in the rpcs
 
 function findRPCs(node: ts.Node) {
   if (!ts.isModuleDeclaration(node)) {
-    return
+    return;
   }
   if (!ts.isIdentifier(node.name)) {
     throw new Error(
-      `expected Identifier, got ${strKind(node.name)} at ${loc(node)}`)
+      `expected Identifier, got ${strKind(node.name)} at ${loc(node)}`);
   }
-  let reqnot = req
-  let v = node.name.getText()
+  let reqnot = req;
+  let v = node.name.getText();
   if (v.endsWith('Notification')) reqnot = not;
   else if (!v.endsWith('Request')) return;
 
   if (!ts.isModuleBlock(node.body)) {
     throw new Error(
-      `expected ModuleBody got ${strKind(node.body)} at ${loc(node)}`)
+      `expected ModuleBody got ${strKind(node.body)} at ${loc(node)}`);
   }
-  let x: ts.ModuleBlock = node.body
+  let x: ts.ModuleBlock = node.body;
   // The story is to expect const method = 'textDocument/implementation'
   // const type = new ProtocolRequestType<...>(method)
   // but the method may be an explicit string
@@ -68,52 +71,52 @@ function findRPCs(node: ts.Node) {
     if (dl.declarations.length != 1)
       throw new Error(`expected a single decl at ${loc(dl)}`);
     const decl: ts.VariableDeclaration = dl.declarations[0];
-    const name = decl.name.getText()
+    const name = decl.name.getText();
     // we want the initializers
     if (name == 'method') {  // mostly StringLiteral but NoSubstitutionTemplateLiteral in protocol.semanticTokens.ts
       if (!ts.isStringLiteral(decl.initializer)) {
         if (!ts.isNoSubstitutionTemplateLiteral(decl.initializer)) {
-          console.log(`${decl.initializer.getText()}`);
+          console.log(`81: ${decl.initializer.getText()}`);
           throw new Error(`expect StringLiteral at ${loc(decl)} got ${strKind(decl.initializer)}`);
         }
       }
-      rpc = decl.initializer.getText()
+      rpc = decl.initializer.getText();
     }
     else if (name == 'type') {  // NewExpression
       if (!ts.isNewExpression(decl.initializer))
-        throw new Error(`expecte new at ${loc(decl)}`);
-      const nn: ts.NewExpression = decl.initializer
-      newNode = nn
+        throw new Error(`89 expected new at ${loc(decl)}`);
+      const nn: ts.NewExpression = decl.initializer;
+      newNode = nn;
       const mtd = nn.arguments[0];
       if (ts.isStringLiteral(mtd)) rpc = mtd.getText();
       switch (nn.typeArguments.length) {
         case 1:  // exit
-          ptypes.set(rpc, [nn.typeArguments[0], null])
+          ptypes.set(rpc, [nn.typeArguments[0], null]);
           break;
         case 2:  // notifications
-          ptypes.set(rpc, [nn.typeArguments[0], null])
+          ptypes.set(rpc, [nn.typeArguments[0], null]);
           break;
         case 4:  // request with no parameters
-          ptypes.set(rpc, [null, nn.typeArguments[0]])
+          ptypes.set(rpc, [null, nn.typeArguments[0]]);
           break;
         case 5:  // request req, resp, partial(?)
-          ptypes.set(rpc, [nn.typeArguments[0], nn.typeArguments[1]])
+          ptypes.set(rpc, [nn.typeArguments[0], nn.typeArguments[1]]);
           break;
         default:
-          throw new Error(`${nn.typeArguments.length} at ${loc(nn)}`)
+          throw new Error(`${nn.typeArguments.length} at ${loc(nn)}`);
       }
     }
   }
-  if (rpc == '') throw new Error(`no name found at ${loc(x)}`);
+  if (rpc == '') throw new Error(`112 no name found at ${loc(x)}`);
   // remember the implied types
   const [a, b] = ptypes.get(rpc);
   const add = function (n: ts.Node) {
-    rpcTypes.add(goName(n.getText()))
+    rpcTypes.add(goName(n.getText()));
   };
   underlying(a, add);
   underlying(b, add);
   rpc = rpc.substring(1, rpc.length - 1);  // 'exit'
-  reqnot.set(rpc, newNode)
+  reqnot.set(rpc, newNode);
 }
 
 function setReceives() {
@@ -121,8 +124,8 @@ function setReceives() {
   // it would be nice to have some independent check on this
   // (this logic fails if the server ever sends $/canceRequest
   //  or $/progress)
-  req.forEach((_, k) => { receives.set(k, 'server') });
-  not.forEach((_, k) => { receives.set(k, 'server') });
+  req.forEach((_, k) => { receives.set(k, 'server'); });
+  not.forEach((_, k) => { receives.set(k, 'server'); });
   receives.set('window/showMessage', 'client');
   receives.set('window/showMessageRequest', 'client');
   receives.set('window/logMessage', 'client');
@@ -137,18 +140,22 @@ function setReceives() {
   receives.set('$/progress', 'client');
   // a small check
   receives.forEach((_, k) => {
-    if (!req.get(k) && !not.get(k)) throw new Error(`missing ${k}}`);
-    if (req.get(k) && not.get(k)) throw new Error(`dup ${k}`);
-  })
+    if (!req.get(k) && !not.get(k)) throw new Error(`145 missing ${k}}`);
+    if (req.get(k) && not.get(k)) throw new Error(`146 dup ${k}`);
+  });
 }
 
+type DataKind = 'module' | 'interface' | 'alias' | 'enum' | 'class';
+
 interface Data {
+  kind: DataKind;
   me: ts.Node;   // root node for this type
   name: string;  // Go name
+  origname: string; // their name
   generics: ts.NodeArray<ts.TypeParameterDeclaration>;
   as: ts.NodeArray<ts.HeritageClause>;  // inheritance
   // Interface
-  properties: ts.NodeArray<ts.TypeElement>;  // ts.PropertySignature
+  properties: ts.NodeArray<ts.PropertySignature>
   alias: ts.TypeNode;                        // type alias
   // module
   statements: ts.NodeArray<ts.Statement>;
@@ -156,28 +163,72 @@ interface Data {
   // class
   members: ts.NodeArray<ts.PropertyDeclaration>;
 }
-function newData(n: ts.Node, nm: string): Data {
+function newData(n: ts.Node, nm: string, k: DataKind, origname: string): Data {
   return {
-    me: n, name: goName(nm),
-    generics: ts.createNodeArray<ts.TypeParameterDeclaration>(), as: ts.createNodeArray<ts.HeritageClause>(),
-    properties: ts.createNodeArray<ts.TypeElement>(), alias: undefined,
-    statements: ts.createNodeArray<ts.Statement>(),
-    enums: ts.createNodeArray<ts.EnumMember>(),
-    members: ts.createNodeArray<ts.PropertyDeclaration>(),
-  }
+    kind: k,
+    me: n, name: goName(nm), origname: origname,
+    generics: ts.factory.createNodeArray<ts.TypeParameterDeclaration>(),
+    as: ts.factory.createNodeArray<ts.HeritageClause>(),
+    properties: ts.factory.createNodeArray<ts.PropertySignature>(), alias: undefined,
+    statements: ts.factory.createNodeArray<ts.Statement>(),
+    enums: ts.factory.createNodeArray<ts.EnumMember>(),
+    members: ts.factory.createNodeArray<ts.PropertyDeclaration>(),
+  };
 }
 
 // for debugging, produce a skeleton description
 function strData(d: Data): string {
+  if (!d) { return 'nil'; }
   const f = function (na: ts.NodeArray<any>): number {
-    return na.length
+    return na.length;
   };
-  return `D(${d.name}) g;${f(d.generics)} a:${f(d.as)} p:${f(d.properties)} s:${f(d.statements)} e:${f(d.enums)} m:${f(d.members)} ${d.alias != undefined}`
+  const nm = d.name == d.origname ? `${d.name}` : `${d.name}/${d.origname}`;
+  return `g:${f(d.generics)} a:${f(d.as)} p:${f(d.properties)} s:${f(d.statements)} e:${f(d.enums)} m:${f(d.members)} a:${d.alias !== undefined} D(${nm}) k:${d.kind}`;
 }
 
 let data = new Map<string, Data>();            // parsed data types
 let seenTypes = new Map<string, Data>();       // type names we've seen
 let extraTypes = new Map<string, string[]>();  // to avoid struct params
+
+function setData(nm: string, d: Data) {
+  const v = data.get(nm);
+  if (!v) {
+    data.set(nm, d);
+    return;
+  }
+  // if there are multiple definitions of the same name, decide what to do.
+  // For now the choices are only aliases and modules
+  // alias is preferred unless the constant values are needed
+  if (nm === 'PrepareSupportDefaultBehavior') {
+    // want the alias, as we're going to change the type and can't afford a constant
+    if (d.kind === 'alias') data.set(nm, d);
+    else if (v.kind == 'alias') data.set(nm, v);
+    else throw new Error(`208 ${d.kind} ${v.kind}`);
+    return;
+  }
+  if (nm === 'CodeActionKind') {
+    // want the module, need the constants
+    if (d.kind === 'module') data.set(nm, d);
+    else if (v.kind === 'module') data.set(nm, v);
+    else throw new Error(`215 ${d.kind} ${v.kind}`);
+  }
+  if (v.kind === 'alias' && d.kind !== 'alias') return;
+  if (d.kind === 'alias' && v.kind !== 'alias') {
+    data.set(nm, d);
+    return;
+  }
+  if (v.kind === 'alias' && d.kind === 'alias') return;
+  // protocol/src/common/protocol.foldingRange.ts 44: 1 (39: 2) and
+  // types/src/main.ts 397: 1 (392: 2)
+  // for FoldingRangeKind
+  if (d.me.getText() === v.me.getText()) return;
+  // error messages for an unexpected case
+  console.log(`228 ${strData(v)} ${loc(v.me)} for`);
+  console.log(`229 ${v.me.getText().replace(/\n/g, '\\n')}`);
+  console.log(`230 ${strData(d)} ${loc(d.me)}`);
+  console.log(`231 ${d.me.getText().replace(/\n/g, '\\n')}`);
+  throw new Error(`232 setData found ${v.kind} for ${d.kind}`);
+}
 
 // look at top level data definitions
 function genTypes(node: ts.Node) {
@@ -192,7 +243,7 @@ function genTypes(node: ts.Node) {
   if (ts.isInterfaceDeclaration(node)) {
     const v: ts.InterfaceDeclaration = node;
     // need to check the members, many of which are disruptive
-    let mems: ts.TypeElement[] = [];
+    let mems: ts.PropertySignature[] = [];
     const f = function (t: ts.TypeElement) {
       if (ts.isPropertySignature(t)) {
         mems.push(t);
@@ -203,29 +254,29 @@ function genTypes(node: ts.Node) {
         // [key: string]: boolean | number | string | undefined;
         // and InitializeResult: [custom: string]: any;]
       } else
-        throw new Error(`206 unexpected ${strKind(t)}`);
+        throw new Error(`259 unexpected ${strKind(t)}`);
     };
     v.members.forEach(f);
     if (mems.length == 0 && !v.heritageClauses &&
       v.name.getText() != 'InitializedParams') {
-      return  // Don't seem to need any of these [Logger, PipTransport, ...]
+      return;  // Don't seem to need any of these [Logger, PipTransport, ...]
     }
     // Found one we want
-    let x = newData(v, goName(v.name.getText()));
-    x.properties = ts.createNodeArray<ts.TypeElement>(mems);
+    let x = newData(v, goName(v.name.getText()), 'interface', v.name.getText());
+    x.properties = ts.factory.createNodeArray<ts.PropertySignature>(mems);
     if (v.typeParameters) x.generics = v.typeParameters;
     if (v.heritageClauses) x.as = v.heritageClauses;
     if (x.generics.length > 1) {  // Unneeded
       // Item interface Item<K, V>...
-      return
-    };
-    if (data.has(x.name)) {  // modifying one we've seen
-      x = dataMerge(x, data.get(x.name));
+      return;
     }
-    data.set(x.name, x);
+    if (data.has(x.name)) {  // modifying one we've seen
+      x = dataChoose(x, data.get(x.name));
+    }
+    setData(x.name, x);
   } else if (ts.isTypeAliasDeclaration(node)) {
     const v: ts.TypeAliasDeclaration = node;
-    let x = newData(v, v.name.getText());
+    let x = newData(v, v.name.getText(), 'alias', v.name.getText());
     x.alias = v.type;
     // if type is a union of constants, we (mostly) don't want it
     // (at the top level)
@@ -237,105 +288,104 @@ function genTypes(node: ts.Node) {
     if (v.typeParameters) {
       x.generics = v.typeParameters;
     }
-    if (data.has(x.name)) x = dataMerge(x, data.get(x.name));
+    if (data.has(x.name)) x = dataChoose(x, data.get(x.name));
     if (x.generics.length > 1) {
-      return
-    };
-    data.set(x.name, x);
+      return;
+    }
+    setData(x.name, x);
   } else if (ts.isModuleDeclaration(node)) {
     const v: ts.ModuleDeclaration = node;
     if (!ts.isModuleBlock(v.body)) {
-      throw new Error(`${loc(v)} not ModuleBlock, but ${strKind(v.body)}`)
+      throw new Error(`${loc(v)} not ModuleBlock, but ${strKind(v.body)}`);
     }
     const b: ts.ModuleBlock = v.body;
     var s: ts.Statement[] = [];
     // we don't want most of these
     const fx = function (x: ts.Statement) {
       if (ts.isFunctionDeclaration(x)) {
-        return
-      };
+        return;
+      }
       if (ts.isTypeAliasDeclaration(x) || ts.isModuleDeclaration(x)) {
-        return
+        return;
       }
       if (!ts.isVariableStatement(x))
         throw new Error(
-          `expected VariableStatment ${loc(x)} ${strKind(x)} ${x.getText()}`);
+          `315 expected VariableStatment ${loc(x)} ${strKind(x)} ${x.getText()}`);
       if (hasNewExpression(x)) {
-        return
-      };
+        return;
+      }
       s.push(x);
     };
-    b.statements.forEach(fx)
+    b.statements.forEach(fx);
     if (s.length == 0) {
-      return
-    };
-    let m = newData(node, v.name.getText());
-    m.statements = ts.createNodeArray<ts.Statement>(s);
-    if (data.has(m.name)) m = dataMerge(m, data.get(m.name));
-    data.set(m.name, m);
+      return;
+    }
+    let m = newData(node, v.name.getText(), 'module', v.name.getText());
+    m.statements = ts.factory.createNodeArray<ts.Statement>(s);
+    if (data.has(m.name)) m = dataChoose(m, data.get(m.name));
+    setData(m.name, m);
   } else if (ts.isEnumDeclaration(node)) {
     const nm = node.name.getText();
-    let v = newData(node, nm);
+    let v = newData(node, nm, 'enum', node.name.getText());
     v.enums = node.members;
     if (data.has(nm)) {
-      v = dataMerge(v, data.get(nm));
+      v = dataChoose(v, data.get(nm));
     }
-    data.set(nm, v);
+    setData(nm, v);
   } else if (ts.isClassDeclaration(node)) {
     const v: ts.ClassDeclaration = node;
     var d: ts.PropertyDeclaration[] = [];
     const wanted = function (c: ts.ClassElement): string {
       if (ts.isConstructorDeclaration(c)) {
-        return ''
-      };
+        return '';
+      }
       if (ts.isMethodDeclaration(c)) {
-        return ''
-      };
+        return '';
+      }
       if (ts.isGetAccessor(c)) {
-        return ''
-      };
+        return '';
+      }
       if (ts.isSetAccessor(c)) {
-        return ''
-      };
+        return '';
+      }
       if (ts.isPropertyDeclaration(c)) {
         d.push(c);
-        return strKind(c)
-      };
-      throw new Error(`Class decl ${strKind(c)} `)
+        return strKind(c);
+      }
+      throw new Error(`Class decl ${strKind(c)} `);
     };
     v.members.forEach((c) => wanted(c));
     if (d.length == 0) {
-      return
+      return;
     }  // don't need it
-    let c = newData(v, v.name.getText());
-    c.members = ts.createNodeArray<ts.PropertyDeclaration>(d);
+    let c = newData(v, v.name.getText(), 'class', v.name.getText());
+    c.members = ts.factory.createNodeArray<ts.PropertyDeclaration>(d);
     if (v.typeParameters) {
-      c.generics = v.typeParameters
+      c.generics = v.typeParameters;
     }
     if (c.generics.length > 1) {
-      return
+      return;
     }
     if (v.heritageClauses) {
-      c.as = v.heritageClauses
+      c.as = v.heritageClauses;
     }
     if (data.has(c.name))
       throw new Error(`Class dup ${loc(c.me)} and ${loc(data.get(c.name).me)}`);
-    data.set(c.name, c);
+    setData(c.name, c);
   } else {
-    throw new Error(`325 unexpected ${strKind(node)} ${loc(node)} `)
+    throw new Error(`378 unexpected ${strKind(node)} ${loc(node)} `);
   }
 }
 
-// Typescript can accumulate
-function dataMerge(a: Data, b: Data): Data {
-  // maybe they are textually identical? (it happens)
+// Typescript can accumulate, but this chooses one or the other
+function dataChoose(a: Data, b: Data): Data {
+  // maybe they are textually identical? (e.g., FoldingRangeKind)
   const [at, bt] = [a.me.getText(), b.me.getText()];
   if (at == bt) {
     return a;
   }
   switch (a.name) {
     case 'InitializeError':
-    case 'MessageType':
     case 'CompletionItemTag':
     case 'SymbolTag':
     case 'CodeActionKind':
@@ -354,8 +404,8 @@ function dataMerge(a: Data, b: Data): Data {
       return a;
   }
   console.log(
-    `357 ${strKind(a.me)} ${strKind(b.me)} ${a.name} ${loc(a.me)} ${loc(b.me)}`)
-  throw new Error(`Fix dataMerge for ${a.name}`);
+    `409 ${strKind(a.me)} ${strKind(b.me)} ${a.name} ${loc(a.me)} ${loc(b.me)}`);
+  throw new Error(`410 Fix dataChoose for ${a.name}`);
 }
 
 // is a node an ancestor of a NewExpression
@@ -363,25 +413,26 @@ function hasNewExpression(n: ts.Node): boolean {
   let ans = false;
   n.forEachChild((n: ts.Node) => {
     if (ts.isNewExpression(n)) ans = true;
-  })
-  return ans
+  });
+  return ans;
 }
 
 function checkOnce() {
   // Data for all the rpc types?
   rpcTypes.forEach(s => {
-    if (!data.has(s)) throw new Error(`checkOnce, ${s}?`)
+    if (!data.has(s)) throw new Error(`checkOnce, ${s}?`);
   });
 }
 
 // helper function to find underlying types
+// eslint-disable-next-line no-unused-vars
 function underlying(n: ts.Node, f: (n: ts.Node) => void) {
   if (!n) return;
   const ff = function (n: ts.Node) {
-    underlying(n, f)
+    underlying(n, f);
   };
   if (ts.isIdentifier(n)) {
-    f(n)
+    f(n);
   } else if (
     n.kind == ts.SyntaxKind.StringKeyword ||
     n.kind == ts.SyntaxKind.NumberKeyword ||
@@ -393,32 +444,32 @@ function underlying(n: ts.Node, f: (n: ts.Node) => void) {
     n.kind == ts.SyntaxKind.VoidKeyword) {
     // nothing to do
   } else if (ts.isTypeReferenceNode(n)) {
-    f(n.typeName)
+    f(n.typeName);
   } else if (ts.isArrayTypeNode(n)) {
-    underlying(n.elementType, f)
+    underlying(n.elementType, f);
   } else if (ts.isHeritageClause(n)) {
     n.types.forEach(ff);
   } else if (ts.isExpressionWithTypeArguments(n)) {
-    underlying(n.expression, f)
+    underlying(n.expression, f);
   } else if (ts.isPropertySignature(n)) {
-    underlying(n.type, f)
+    underlying(n.type, f);
   } else if (ts.isTypeLiteralNode(n)) {
-    n.members.forEach(ff)
+    n.members.forEach(ff);
   } else if (ts.isUnionTypeNode(n) || ts.isIntersectionTypeNode(n)) {
-    n.types.forEach(ff)
+    n.types.forEach(ff);
   } else if (ts.isIndexSignatureDeclaration(n)) {
-    underlying(n.type, f)
+    underlying(n.type, f);
   } else if (ts.isParenthesizedTypeNode(n)) {
-    underlying(n.type, f)
+    underlying(n.type, f);
   } else if (
     ts.isLiteralTypeNode(n) || ts.isVariableStatement(n) ||
     ts.isTupleTypeNode(n)) {
     // we only see these in moreTypes, but they are handled elsewhere
   } else if (ts.isEnumMember(n)) {
     if (ts.isStringLiteral(n.initializer)) return;
-    throw new Error(`419 EnumMember ${strKind(n.initializer)} ${n.name.getText()}`)
+    throw new Error(`472 EnumMember ${strKind(n.initializer)} ${n.name.getText()}`);
   } else {
-    throw new Error(`421 saw ${strKind(n)} in underlying. ${n.getText()} at ${loc(n)}`)
+    throw new Error(`474 saw ${strKind(n)} in underlying. ${n.getText()} at ${loc(n)}`);
   }
 }
 
@@ -428,48 +479,188 @@ function underlying(n: ts.Node, f: (n: ts.Node) => void) {
 function moreTypes() {
   const extra = function (s: string) {
     if (!data.has(s)) throw new Error(`moreTypes needs ${s}`);
-    seenTypes.set(s, data.get(s))
+    seenTypes.set(s, data.get(s));
   };
   rpcTypes.forEach(extra);  // all the types needed by the rpcs
   // needed in enums.go (or elsewhere)
-  extra('InitializeError')
-  extra('WatchKind')
-  extra('FoldingRangeKind')
+  extra('InitializeError');
+  extra('WatchKind');
+  extra('FoldingRangeKind');
   // not sure why these weren't picked up
-  extra('FileSystemWatcher')
-  extra('DidChangeWatchedFilesRegistrationOptions')
-  extra('WorkDoneProgressBegin')
-  extra('WorkDoneProgressReport')
-  extra('WorkDoneProgressEnd')
-  let old = 0
+  extra('DidChangeWatchedFilesRegistrationOptions');
+  extra('WorkDoneProgressBegin');
+  extra('WorkDoneProgressReport');
+  extra('WorkDoneProgressEnd');
+  let old = 0;
   do {
-    old = seenTypes.size
+    old = seenTypes.size;
 
     const m = new Map<string, Data>();
     const add = function (n: ts.Node) {
       const nm = goName(n.getText());
       if (seenTypes.has(nm) || m.has(nm)) return;
-      // For generic parameters, this might set it to undefined
-      m.set(nm, data.get(nm));
+      if (data.get(nm)) {
+        m.set(nm, data.get(nm));
+      }
     };
     // expect all the heritage clauses have single Identifiers
     const h = function (n: ts.Node) {
       underlying(n, add);
     };
     const f = function (x: ts.NodeArray<ts.Node>) {
-      x.forEach(h)
+      x.forEach(h);
     };
-    seenTypes.forEach((d: Data) => d && f(d.as))
+    seenTypes.forEach((d: Data) => d && f(d.as));
     // find the types in the properties
-    seenTypes.forEach((d: Data) => d && f(d.properties))
+    seenTypes.forEach((d: Data) => d && f(d.properties));
     // and in the alias and in the statements and in the enums
-    seenTypes.forEach((d: Data) => d && underlying(d.alias, add))
-    seenTypes.forEach((d: Data) => d && f(d.statements))
-    seenTypes.forEach((d: Data) => d && f(d.enums))
-    m.forEach((d, k) => seenTypes.set(k, d))
+    seenTypes.forEach((d: Data) => d && underlying(d.alias, add));
+    seenTypes.forEach((d: Data) => d && f(d.statements));
+    seenTypes.forEach((d: Data) => d && f(d.enums));
+    m.forEach((d, k) => seenTypes.set(k, d));
   }
   while (seenTypes.size != old)
     ;
+}
+
+function cleanData() { // middle pass
+  // seenTypes contains all the top-level types.
+  seenTypes.forEach((d) => {
+    if (d.kind == 'alias') mergeAlias(d);
+  });
+}
+
+function sameType(a: ts.TypeNode, b: ts.TypeNode): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === ts.SyntaxKind.BooleanKeyword) return true;
+  if (ts.isTypeReferenceNode(a) && ts.isTypeReferenceNode(b) &&
+    a.typeName.getText() === b.typeName.getText()) return true;
+  if (ts.isArrayTypeNode(a) && ts.isArrayTypeNode(b)) return sameType(a.elementType, b.elementType);
+  if (ts.isTypeLiteralNode(a) && ts.isTypeLiteralNode(b)) {
+    if (a.members.length !== b.members.length) return false;
+    if (a.members.length === 1) return a.members[0].name.getText() === b.members[0].name.getText();
+    if (loc(a) === loc(b)) return true;
+  }
+  throw new Error(`546 sameType? ${strKind(a)} ${strKind(b)}`);
+}
+
+type propMap = Map<string, ts.PropertySignature>;
+function propMapSet(pm: propMap, name: string, v: ts.PropertySignature) {
+  if (!pm.get(name)) {
+    try { getComments(v); } catch (e) { console.log(`552 ${name} ${e}`); }
+    pm.set(name, v);
+    return;
+  }
+  const a = pm.get(name).type;
+  const b = v.type;
+  if (sameType(a, b)) {
+    return;
+  }
+  if (ts.isTypeReferenceNode(a) && ts.isTypeLiteralNode(b)) {
+    const x = mergeTypeRefLit(name, a, b);
+    const fake: Object = v;
+    fake['type'] = x;
+    check(fake as ts.PropertySignature, '565');
+    pm.set(name, fake as ts.PropertySignature);
+    return;
+  }
+  if (ts.isTypeLiteralNode(a) && ts.isTypeLiteralNode(b)) {
+    const x = mergeTypeLitLit(name, a, b);
+    const fake: Object = v;
+    fake['type'] = x;
+    check(fake as ts.PropertySignature, '578');
+    pm.set(name, fake as ts.PropertySignature);
+    return;
+  }
+  console.log(`577 ${pm.get(name).getText()}\n${v.getText()}`);
+  throw new Error(`578 should merge ${strKind(a)} and ${strKind(b)} for ${name}`);
+}
+function addToProperties(pm: propMap, tn: ts.TypeNode, prefix = '') {
+  if (ts.isTypeReferenceNode(tn)) {
+    const d = seenTypes.get(goName(tn.typeName.getText()));
+    if (tn.typeName.getText() === 'T') return;
+    if (!d) throw new Error(`584 ${tn.typeName.getText()} not found`);
+    if (d.properties.length === 0 && d.alias === undefined) return;
+    if (d.alias !== undefined) {
+      if (ts.isIntersectionTypeNode(d.alias)) {
+        d.alias.types.forEach((tn) => addToProperties(pm, tn, prefix)); // prefix?
+        return;
+      }
+    }
+    d.properties.forEach((ps) => {
+      const name = `${prefix}.${ps.name.getText()}`;
+      propMapSet(pm, name, ps);
+      addToProperties(pm, ps.type, name);
+    });
+  } else if (strKind(tn) === 'TypeLiteral') {
+    if (!ts.isTypeLiteralNode(tn)) new Error(`598 ${strKind(tn)}`);
+    tn.forEachChild((child: ts.Node) => {
+      if (!ts.isPropertySignature(child)) throw new Error(`600 ${strKind(child)}`);
+      const name = `${prefix}.${child.name.getText()}`;
+      propMapSet(pm, name, child);
+      addToProperties(pm, child.type, name);
+    });
+  }
+}
+function deepProperties(d: Data): propMap {
+  let properties: propMap = new Map<string, ts.PropertySignature>();
+  if (!d.alias || !ts.isIntersectionTypeNode(d.alias)) return;
+  d.alias.types.forEach((ts) => addToProperties(properties, ts));
+  return properties;
+}
+
+function mergeAlias(d: Data) {
+  const props = deepProperties(d);
+  if (!props) return; // nothing merged
+  // now each element of props should have length 1
+  // change d to merged, toss its alias field, fill in its properties
+  const v: ts.PropertySignature[] = [];
+  props.forEach((ps, nm) => {
+    const xlen = nm.split('.').length;
+    if (xlen !== 2) return; // not top-level
+    v.push(ps);
+  });
+  d.kind = 'interface';
+  d.alias = undefined;
+  d.properties = ts.factory.createNodeArray(v);
+}
+
+function mergeTypeLitLit(name: string, a: ts.TypeLiteralNode, b: ts.TypeLiteralNode): ts.TypeLiteralNode {
+  const v = new Map<string, ts.TypeElement>(); // avoid duplicates
+  a.members.forEach((te) => v.set(te.name.getText(), te));
+  b.members.forEach((te) => v.set(te.name.getText(), te));
+  const x: ts.TypeElement[] = [];
+  v.forEach((te) => x.push(te));
+  const fake: Object = a;
+  fake['members'] = x;
+  check(fake as ts.TypeLiteralNode, '643');
+  return fake as ts.TypeLiteralNode;
+}
+
+function mergeTypeRefLit(name: string, a: ts.TypeReferenceNode, b: ts.TypeLiteralNode): ts.TypeLiteralNode {
+  const d = seenTypes.get(goName(a.typeName.getText()));
+  if (!d) throw new Error(`644 name ${a.typeName.getText()} not found`);
+  const typ = d.me;
+  if (!ts.isInterfaceDeclaration(typ)) throw new Error(`646 got ${strKind(typ)} not InterfaceDecl`);
+  const v = new Map<string, ts.TypeElement>(); // avoid duplicates
+  typ.members.forEach((te) => v.set(te.name.getText(), te));
+  b.members.forEach((te) => v.set(te.name.getText(), te));
+  const x: ts.TypeElement[] = [];
+  v.forEach((te) => x.push(te));
+
+  const w = ts.factory.createNodeArray(x);
+  const fk: Object = b;
+  fk['members'] = w;
+  fk['members']['pos'] = b.members.pos;
+  fk['members']['end'] = b.members.end;
+  check(fk as ts.TypeLiteralNode, '662');
+  return fk as ts.TypeLiteralNode;
+}
+
+// check that constructed nodes still have associated text
+function check(n: ts.Node, loc: string) {
+  try { getComments(n); } catch (e) { console.log(`check at ${loc} ${e}`); }
+  try { n.getText(); } catch (e) { console.log(`text check at ${loc}`); }
 }
 
 let typesOut = new Array<string>();
@@ -478,36 +669,22 @@ let constsOut = new Array<string>();
 // generate Go types
 function toGo(d: Data, nm: string) {
   if (!d) return;  // this is probably a generic T
-  if (d.alias) {
-    goTypeAlias(d, nm);
-  } else if (d.statements.length > 0) {
-    goModule(d, nm);
-  } else if (d.enums.length > 0) {
-    goEnum(d, nm);
-  } else if (
-    d.properties.length > 0 || d.as.length > 0 || nm == 'InitializedParams') {
-    goInterface(d, nm);
-  } else
-    throw new Error(
-      `492 more cases in toGo ${nm} ${d.as.length} ${d.generics.length} `)
+  if (d.name.startsWith('Inner') || d.name === 'WindowClientCapabilities') return; // removed by alias processing
+  if (d.name === 'Integer' || d.name === 'Uinteger') return; // unneeded
+  switch (d.kind) {
+    case 'alias':
+      goTypeAlias(d, nm); break;
+    case 'module': goModule(d, nm); break;
+    case 'enum': goEnum(d, nm); break;
+    case 'interface': goInterface(d, nm); break;
+    default:
+      throw new Error(
+        `672: more cases in toGo ${nm} ${d.kind}`);
+  }
 }
 
-// these fields need a *. (making every optional struct indirect led to very
-// complex literals in gopls.)
-// As of Jan 2021 (3.16.0) consider (sent by server)
-// LocationLink.originSelectionRange // unused by gopls
-// Diagnostics.codeDescription
-// CreateFile.createFileOptions and .annotationID // unused by gopls
-// same for RenameFile and DeleteFile
-// InitializeResult.serverInfo // gopls always sets
-// InnerServerCapabilites.completionProvider, .signatureHelpProvider, .documentLinkProvider,
-//   .executeCommandProvider, .Workspace  // always set
-// InnerserverCapabilities.codeLensProvier, .DocumentOnTypeFormattingProvider // unused(?)
-// FileOperationPattern.options // unused
-// CompletionItem.command
-// Hover.Range (?)
-// CodeAction.disabled, .command
-// CodeLens.command
+// these fields need a * and are not covered by the code
+// that calls isStructType.
 var starred: [string, string][] = [
   ['TextDocumentContentChangeEvent', 'range'], ['CodeAction', 'command'],
   ['CodeAction', 'disabled'],
@@ -520,42 +697,42 @@ function goInterface(d: Data, nm: string) {
   let ans = `type ${goName(nm)} struct {\n`;
 
   // generate the code for each member
-  const g = function (n: ts.TypeElement) {
+  const g = function (n: ts.PropertySignature) {
     if (!ts.isPropertySignature(n))
       throw new Error(`expected PropertySignature got ${strKind(n)} `);
     ans = ans.concat(getComments(n));
     const json = u.JSON(n);
-    // SelectionRange is a recursive type
     let gt = goType(n.type, n.name.getText());
     if (gt == d.name) gt = '*' + gt; // avoid recursive types (SelectionRange)
     // there are several cases where a * is needed
+    // (putting * in front of too many things breaks uses of CodeActionKind)
     starred.forEach(([a, b]) => {
       if (d.name == a && n.name.getText() == b) {
         gt = '*' + gt;
       }
-    })
+    });
     ans = ans.concat(`${goName(n.name.getText())} ${gt}`, json, '\n');
   };
-  d.properties.forEach(g)
+  d.properties.forEach(g);
   // heritage clauses become embedded types
   // check they are all Identifiers
   const f = function (n: ts.ExpressionWithTypeArguments) {
     if (!ts.isIdentifier(n.expression))
       throw new Error(`Interface ${nm} heritage ${strKind(n.expression)} `);
-    ans = ans.concat(goName(n.expression.getText()), '\n')
+    ans = ans.concat(goName(n.expression.getText()), '\n');
   };
-  d.as.forEach((n: ts.HeritageClause) => n.types.forEach(f))
-  ans = ans.concat('}\n')
-  typesOut.push(getComments(d.me))
-  typesOut.push(ans)
+  d.as.forEach((n: ts.HeritageClause) => n.types.forEach(f));
+  ans = ans.concat('}\n');
+  typesOut.push(getComments(d.me));
+  typesOut.push(ans);
 }
 
 // generate Go code for a module (const declarations)
 // Generates type definitions, and named constants
 function goModule(d: Data, nm: string) {
   if (d.generics.length > 0 || d.as.length > 0) {
-    throw new Error(`557 goModule: unexpected for ${nm}
-  `)
+    throw new Error(`743 goModule: unexpected for ${nm}
+  `);
   }
   // all the statements should be export const <id>: value
   //   or value = value
@@ -564,45 +741,45 @@ function goModule(d: Data, nm: string) {
   let isNumeric = false;
   const f = function (n: ts.Statement, i: number) {
     if (!ts.isVariableStatement(n)) {
-      throw new Error(`567 ${nm} ${i} expected VariableStatement,
+      throw new Error(`753 ${nm} ${i} expected VariableStatement,
       got ${strKind(n)}`);
     }
-    const c = getComments(n)
+    const c = getComments(n);
     const v = n.declarationList.declarations[0];  // only one
 
     if (!v.initializer)
-      throw new Error(`574 no initializer ${nm} ${i} ${v.name.getText()}`)
+      throw new Error(`760 no initializer ${nm} ${i} ${v.name.getText()}`);
     isNumeric = strKind(v.initializer) == 'NumericLiteral';
     if (c != '') constsOut.push(c);  // no point if there are no comments
     // There are duplicates.
     const cname = constName(goName(v.name.getText()), nm);
-    let val = v.initializer.getText()
-    val = val.split('\'').join('"')  // useless work for numbers
-    constsOut.push(`${cname} ${nm} = ${val}`)
+    let val = v.initializer.getText();
+    val = val.split('\'').join('"');  // useless work for numbers
+    constsOut.push(`${cname} ${nm} = ${val}`);
   };
-  d.statements.forEach(f)
-  typesOut.push(getComments(d.me))
+  d.statements.forEach(f);
+  typesOut.push(getComments(d.me));
   // Or should they be type aliases?
-  typesOut.push(`type ${nm} ${isNumeric ? 'float64' : 'string'}`) // PJW: superfluous Integer and Uinteger
+  typesOut.push(`type ${nm} ${isNumeric ? 'float64' : 'string'}`);
 }
 
 // generate Go code for an enum. Both types and named constants
 function goEnum(d: Data, nm: string) {
-  let isNumeric = false
+  let isNumeric = false;
   const f = function (v: ts.EnumMember, j: number) {  // same as goModule
     if (!v.initializer)
       throw new Error(`goEnum no initializer ${nm} ${j} ${v.name.getText()}`);
     isNumeric = strKind(v.initializer) == 'NumericLiteral';
     const c = getComments(v);
     const cname = constName(goName(v.name.getText()), nm);
-    let val = v.initializer.getText()
-    val = val.split('\'').join('"')  // replace quotes. useless work for numbers
-    constsOut.push(`${c}${cname} ${nm} = ${val}`)
+    let val = v.initializer.getText();
+    val = val.split('\'').join('"');  // replace quotes. useless work for numbers
+    constsOut.push(`${c}${cname} ${nm} = ${val}`);
   };
-  d.enums.forEach(f)
-  typesOut.push(getComments(d.me))
+  d.enums.forEach(f);
+  typesOut.push(getComments(d.me));
   // Or should they be type aliases?
-  typesOut.push(`type ${nm} ${isNumeric ? 'float64' : 'string'}`)
+  typesOut.push(`type ${nm} ${isNumeric ? 'float64' : 'string'}`);
 }
 
 // generate code for a type alias
@@ -615,12 +792,12 @@ function goTypeAlias(d: Data, nm: string) {
   // d.alias doesn't seem to have comments
   let aliasStr = goName(nm) == 'DocumentURI' ? ' ' : ' = ';
   if (nm == 'PrepareSupportDefaultBehavior') {
-    // code-insiders is sending a bool, not a number. PJW: check this after Jan/2021
+    // code-insiders is sending a bool, not a number. PJW: check this after Feb/2021
     // (and gopls never looks at it anyway)
     typesOut.push(`type ${goName(nm)}${aliasStr}interface{}\n`);
     return;
   }
-  typesOut.push(`type ${goName(nm)}${aliasStr}${goType(d.alias, nm)}\n`)
+  typesOut.push(`type ${goName(nm)}${aliasStr}${goType(d.alias, nm)}\n`);
 }
 
 // return a go type and maybe an assocated javascript tag
@@ -645,37 +822,37 @@ function goType(n: ts.TypeNode, nm: string): string {
   } else if (strKind(n) == 'AnyKeyword' || strKind(n) == 'UnknownKeyword') {
     return 'interface{}';
   } else if (strKind(n) == 'NullKeyword') {
-    return 'nil'
+    return 'nil';
   } else if (strKind(n) == 'VoidKeyword' || strKind(n) == 'NeverKeyword') {
-    return 'void'
+    return 'void';
   } else if (strKind(n) == 'ObjectKeyword') {
-    return 'interface{}'
+    return 'interface{}';
   } else if (ts.isArrayTypeNode(n)) {
     if (nm === 'arguments') {
       // Command and ExecuteCommandParams
       return '[]json.RawMessage';
     }
-    return `[]${goType(n.elementType, nm)}`
+    return `[]${goType(n.elementType, nm)}`;
   } else if (ts.isParenthesizedTypeNode(n)) {
-    return goType(n.type, nm)
+    return goType(n.type, nm);
   } else if (ts.isLiteralTypeNode(n)) {
     return strKind(n.literal) == 'StringLiteral' ? 'string' : 'float64';
   } else if (ts.isTypeLiteralNode(n)) {
     // these are anonymous structs
     const v = goTypeLiteral(n, nm);
-    return v
+    return v;
   } else if (ts.isTupleTypeNode(n)) {
     if (n.getText() == '[number, number]') return '[]float64';
-    throw new Error(`goType unexpected Tuple ${n.getText()}`)
+    throw new Error(`goType unexpected Tuple ${n.getText()}`);
   }
-  throw new Error(`${strKind(n)} goType unexpected ${n.getText()} for ${nm}`)
+  throw new Error(`${strKind(n)} goType unexpected ${n.getText()} for ${nm}`);
 }
 
 // The choice is uniform interface{}, or some heuristically assigned choice,
 // or some better sytematic idea I haven't thought of. Using interface{}
 // is, in practice, impossibly complex in the existing code.
 function goUnionType(n: ts.UnionTypeNode, nm: string): string {
-  let help = `/*${n.getText()}*/`  // show the original as a comment
+  let help = `/*${n.getText()}*/`;  // show the original as a comment
   // There are some bad cases with newlines:
   // range?: boolean | {\n	};
   // full?: boolean | {\n		/**\n		 * The server supports deltas for full documents.\n		 */\n		delta?: boolean;\n	}
@@ -687,25 +864,27 @@ function goUnionType(n: ts.UnionTypeNode, nm: string): string {
   // handle all the special cases
   switch (n.types.length) {
     case 2: {
-      const a = strKind(n.types[0])
-      const b = strKind(n.types[1])
+      const a = strKind(n.types[0]);
+      const b = strKind(n.types[1]);
       if (a == 'NumberKeyword' && b == 'StringKeyword') {  // ID
-        return `interface{} ${help}`
+        return `interface{} ${help}`;
       }
-      if (b == 'NullKeyword') {
+      if (b == 'NullKeyword' || n.types[1].getText() === 'null') {
+        // PJW: fix this. it looks like 'null' is now being parsed as LiteralType
+        // and check the other keyword cases
         if (nm == 'textDocument/codeAction') {
           // (Command | CodeAction)[] | null
-          return `[]CodeAction ${help}`
+          return `[]CodeAction ${help}`;
         }
-        let v = goType(n.types[0], 'a')
-        return `${v} ${help}`
+        let v = goType(n.types[0], 'a');
+        return `${v} ${help}`;
       }
       if (a == 'BooleanKeyword') {  // usually want bool
         if (nm == 'codeActionProvider') return `interface{} ${help}`;
         if (nm == 'renameProvider') return `interface{} ${help}`;
         if (nm == 'full') return `interface{} ${help}`; // there's a struct
         if (nm == 'save') return `${goType(n.types[1], '680')} ${help}`;
-        return `${goType(n.types[0], 'b')} ${help}`
+        return `${goType(n.types[0], 'b')} ${help}`;
       }
       if (b == 'ArrayType') return `${goType(n.types[1], 'c')} ${help}`;
       if (help.includes('InsertReplaceEdit') && n.types[0].getText() == 'TextEdit') {
@@ -718,32 +897,33 @@ function goUnionType(n: ts.UnionTypeNode, nm: string): string {
       }
       if (a == 'StringKeyword') return `string ${help}`;
       if (a == 'TypeLiteral' && nm == 'TextDocumentContentChangeEvent') {
-        return `${goType(n.types[0], nm)}`
+        return `${goType(n.types[0], nm)}`;
       }
-      throw new Error(`709 ${a} ${b} ${n.getText()} ${loc(n)}`);
+      console.log(`911 ${n.types[1].getText()} ${loc(n.types[1])}`);
+      throw new Error(`912 ${nm}: a:${a} b:${b} ${n.getText()} ${loc(n)}`);
     }
     case 3: {
-      const aa = strKind(n.types[0])
-      const bb = strKind(n.types[1])
-      const cc = strKind(n.types[2])
+      const aa = strKind(n.types[0]);
+      const bb = strKind(n.types[1]);
+      const cc = strKind(n.types[2]);
       if (nm == 'DocumentFilter') {
         // not really a union. the first is enough, up to a missing
         // omitempty but avoid repetitious comments
-        return `${goType(n.types[0], 'g')}`
+        return `${goType(n.types[0], 'g')}`;
       }
       if (nm == 'textDocument/documentSymbol') {
         return `[]interface{} ${help}`;
       }
       if (aa == 'TypeReference' && bb == 'ArrayType' && cc == 'NullKeyword') {
-        return `${goType(n.types[0], 'd')} ${help}`
+        return `${goType(n.types[0], 'd')} ${help}`;
       }
       if (aa == 'TypeReference' && bb == aa && cc == 'ArrayType') {
         // should check that this is Hover.Contents
-        return `${goType(n.types[0], 'e')} ${help}`
+        return `${goType(n.types[0], 'e')} ${help}`;
       }
       if (aa == 'ArrayType' && bb == 'TypeReference' && cc == 'NullKeyword') {
         // check this is nm == 'textDocument/completion'
-        return `${goType(n.types[1], 'f')} ${help}`
+        return `${goType(n.types[1], 'f')} ${help}`;
       }
       if (aa == 'LiteralType' && bb == aa && cc == aa) return `string ${help}`;
       break;
@@ -751,6 +931,7 @@ function goUnionType(n: ts.UnionTypeNode, nm: string): string {
     case 4:
       if (nm == 'documentChanges') return `TextDocumentEdit ${help} `;
       if (nm == 'textDocument/prepareRename') return `Range ${help} `;
+    // eslint-disable-next-line no-fallthrough
     default:
       throw new Error(`goUnionType len=${n.types.length} nm=${nm}`);
   }
@@ -758,7 +939,7 @@ function goUnionType(n: ts.UnionTypeNode, nm: string): string {
   // Result will be interface{} with a comment
   let isLiteral = true;
   let literal = 'string';
-  let res = `interface{} /* `
+  let res = 'interface{} /* ';
   n.types.forEach((v: ts.TypeNode, i: number) => {
     // might get an interface inside:
     //  (Command | CodeAction)[] | null
@@ -767,8 +948,8 @@ function goUnionType(n: ts.UnionTypeNode, nm: string): string {
       // avoid nested comments
       m = m.split(' ')[0];
     }
-    m = m.split('\n').join('; ')  // sloppy: struct{;
-    res = res.concat(`${i == 0 ? '' : ' | '}`, m)
+    m = m.split('\n').join('; ');  // sloppy: struct{;
+    res = res.concat(`${i == 0 ? '' : ' | '}`, m);
     if (!ts.isLiteralTypeNode(v)) isLiteral = false;
     else literal = strKind(v.literal) == 'StringLiteral' ? 'string' : 'number';
   });
@@ -777,7 +958,7 @@ function goUnionType(n: ts.UnionTypeNode, nm: string): string {
   }
   // I don't think we get here
   // trace?: 'off' | 'messages' | 'verbose' should get string
-  return `${literal} /* ${n.getText()} */`
+  return `${literal} /* ${n.getText()} */`;
 }
 
 // some of the intersection types A&B are ok as struct{A;B;} and some
@@ -789,8 +970,8 @@ function goIntersectionType(n: ts.IntersectionTypeNode, nm: string): string {
   //if (nm == 'ServerCapabilities') return expandIntersection(n); // save for later consideration
   let inner = '';
   n.types.forEach(
-    (t: ts.TypeNode) => { inner = inner.concat(goType(t, nm), '\n'); })
-  return `struct{ \n${inner}} `
+    (t: ts.TypeNode) => { inner = inner.concat(goType(t, nm), '\n'); });
+  return `struct{ \n${inner}} `;
 }
 
 // for each of the intersected types, extract its components (each will
@@ -799,7 +980,7 @@ function goIntersectionType(n: ts.IntersectionTypeNode, nm: string): string {
 // that occur more than once need to be combined.
 function expandIntersection(n: ts.IntersectionTypeNode): string {
   const bad = function (n: ts.Node, s: string) {
-    return new Error(`expandIntersection ${strKind(n)} ${s}`)
+    return new Error(`expandIntersection ${strKind(n)} ${s}`);
   };
   let props = new Map<string, ts.PropertySignature[]>();
   for (const tp of n.types) {
@@ -817,14 +998,14 @@ function expandIntersection(n: ts.IntersectionTypeNode): string {
     if (v.length == 1) {
       const a = v[0];
       ans = ans.concat(getComments(a));
-      ans = ans.concat(`${goName(k)} ${goType(a.type, k)} ${u.JSON(a)}\n`)
-      continue
+      ans = ans.concat(`${goName(k)} ${goType(a.type, k)} ${u.JSON(a)}\n`);
+      continue;
     }
-    ans = ans.concat(`${goName(k)} struct {\n`)
+    ans = ans.concat(`${goName(k)} struct {\n`);
     for (let i = 0; i < v.length; i++) {
       const a = v[i];
       if (ts.isTypeReferenceNode(a.type)) {
-        ans = ans.concat(getComments(a))
+        ans = ans.concat(getComments(a));
         ans = ans.concat(goName(a.type.typeName.getText()), '\n');
       } else if (ts.isTypeLiteralNode(a.type)) {
         if (a.type.members.length != 1) throw bad(a.type, 'C');
@@ -832,15 +1013,38 @@ function expandIntersection(n: ts.IntersectionTypeNode): string {
         if (!ts.isPropertySignature(b)) throw bad(b, 'D');
         ans = ans.concat(getComments(b));
         ans = ans.concat(
-          goName(b.name.getText()), ' ', goType(b.type, 'a'), u.JSON(b), '\n')
+          goName(b.name.getText()), ' ', goType(b.type, 'a'), u.JSON(b), '\n');
       } else {
-        throw bad(a.type, `E ${a.getText()} in ${goName(k)} at ${loc(a)}`)
+        throw bad(a.type, `E ${a.getText()} in ${goName(k)} at ${loc(a)}`);
       }
     }
     ans = ans.concat('}\n');
   }
   ans = ans.concat('}\n');
-  return ans
+  return ans;
+}
+
+// Does it make sense to use a pointer?
+function isStructType(te: ts.TypeNode): boolean {
+  switch (strKind(te)) {
+    case 'UnionType': // really need to know which type will be chosen
+    case 'BooleanKeyword':
+    case 'StringKeyword':
+    case 'ArrayType':
+      return false;
+    case 'TypeLiteral': return false; // true makes for difficult compound constants
+    // but think more carefully to understands why starred is needed.
+    case 'TypeReference': {
+      if (!ts.isTypeReferenceNode(te)) throw new Error(`1047 impossible ${strKind(te)}`);
+      const d = seenTypes.get(goName(te.typeName.getText()));
+      if (d.properties.length > 1) return true;
+      // alias or interface with a single property (The alias is Uinteger, which we ignore later)
+      if (d.alias) return false;
+      const x = d.properties[0].type;
+      return isStructType(x);
+    }
+    default: throw new Error(`1055 indirectable> ${strKind(te)}`);
+  }
 }
 
 function goTypeLiteral(n: ts.TypeLiteralNode, nm: string): string {
@@ -850,38 +1054,41 @@ function goTypeLiteral(n: ts.TypeLiteralNode, nm: string): string {
     // add the json, as in goInterface(). Strange inside union types.
     if (ts.isPropertySignature(nx)) {
       let json = u.JSON(nx);
-      let typ = goType(nx.type, nx.name.getText())
+      let typ = goType(nx.type, nx.name.getText());
       const v = getComments(nx) || '';
       starred.forEach(([a, b]) => {
         if (a != nm || b != typ.toLowerCase()) return;
         typ = '*' + typ;
-        json = json.substring(0, json.length - 2) + ',omitempty"`'
-      })
-      res = res.concat(`${v} ${goName(nx.name.getText())} ${typ}`, json, '\n')
-      ans.push(`${v}${goName(nx.name.getText())} ${typ} ${json}\n`)
+        json = json.substring(0, json.length - 2) + ',omitempty"`';
+      });
+      if (typ[0] !== '*' && isStructType(nx.type)) typ = '*' + typ;
+      res = res.concat(`${v} ${goName(nx.name.getText())} ${typ}`, json, '\n');
+      ans.push(`${v}${goName(nx.name.getText())} ${typ} ${json}\n`);
     } else if (ts.isIndexSignatureDeclaration(nx)) {
       if (nx.getText() == '[uri: string]: TextEdit[];') {
         res = 'map[string][]TextEdit';
-        ans.push(`map[string][]TextEdit`);  // this is never used
+        ans.push('map[string][]TextEdit');  // this is never used
         return;
       }
       if (nx.getText() == '[id: string /* ChangeAnnotationIdentifier */]: ChangeAnnotation;') {
         res = 'map[string]ChangeAnnotationIdentifier';
         ans.push(res);
-        return
+        return;
       }
-      throw new Error(`873 handle ${nx.getText()} ${loc(nx)}`);
+      throw new Error(`1087 handle ${nx.getText()} ${loc(nx)}`);
     } else
-      throw new Error(`TypeLiteral had ${strKind(nx)}`)
+      throw new Error(`TypeLiteral had ${strKind(nx)}`);
   };
   n.members.forEach(g);
   // for some the generated type is wanted, for others it's not needed
   if (!nm.startsWith('workspace')) {
     if (res.startsWith('struct')) return res + '}';  // map[] is special
-    return res
+    return res;
   }
-  extraTypes.set(goName(nm) + 'Gn', ans)
-  return goName(nm) + 'Gn'
+  // these names have to be made unique
+  const genName = `${goName(nm)}${extraTypes.size}Gn`;
+  extraTypes.set(genName, ans);
+  return genName;
 }
 
 // print all the types and constants and extra types
@@ -889,29 +1096,29 @@ function outputTypes() {
   // generate go types alphabeticaly
   let v = Array.from(seenTypes.keys());
   v.sort();
-  v.forEach((x) => toGo(seenTypes.get(x), x))
-  u.prgo(u.computeHeader(true))
+  v.forEach((x) => toGo(seenTypes.get(x), x));
+  u.prgo(u.computeHeader(true));
   u.prgo('import "encoding/json"\n\n');
   typesOut.forEach((s) => {
     u.prgo(s);
     // it's more convenient not to have to think about trailing newlines
     // when generating types, but doc comments can't have an extra \n
     if (s.indexOf('/**') < 0) u.prgo('\n');
-  })
+  });
   u.prgo('\nconst (\n');
   constsOut.forEach((s) => {
     u.prgo(s);
-    u.prgo('\n')
-  })
+    u.prgo('\n');
+  });
   u.prgo(')\n');
-  u.prgo('// Types created to name formal parameters and embedded structs\n')
+  u.prgo('// Types created to name formal parameters and embedded structs\n');
   extraTypes.forEach((v, k) => {
-    u.prgo(` type ${k} struct {\n`)
+    u.prgo(` type ${k} struct {\n`);
     v.forEach((s) => {
       u.prgo(s);
-      u.prgo('\n')
+      u.prgo('\n');
     });
-    u.prgo('}\n')
+    u.prgo('}\n');
   });
 }
 
@@ -962,7 +1169,7 @@ function goNot(side: side, m: string) {
       return true, sendParseError(ctx, reply, err)
     }
     err:= ${side.name}.${nm}(ctx, &params)
-    return true, reply(ctx, nil, err)`
+    return true, reply(ctx, nil, err)`;
   } else {
     case1 = `err := ${side.name}.${nm}(ctx)
     return true, reply(ctx, nil, err)`;
@@ -986,20 +1193,21 @@ function goReq(side: side, m: string) {
     b = a;
     a = '';  // workspace/workspaceFolders and shutdown
   }
-  u.prb(`${side.name} req ${a != ''}, ${b != ''} ${nm} ${m} ${loc(n)} `)
+  u.prb(`${side.name} req ${a != ''}, ${b != ''} ${nm} ${m} ${loc(n)} `);
   side.methods.push(sig(nm, a, b));
 
   const caseHdr = `case "${m}": // req`;
   let case1 = notNil;
   if (a != '') {
-    if (extraTypes.has('Param' + nm)) a = 'Param' + nm
+    if (extraTypes.has('Param' + nm)) a = 'Param' + nm;
     case1 = `var params ${a}
     if err := json.Unmarshal(r.Params(), &params); err != nil {
       return true, sendParseError(ctx, reply, err)
     }`;
   }
   const arg2 = a == '' ? '' : ', &params';
-  let case2 = `if err := ${side.name}.${nm}(ctx${arg2}); err != nil {
+  // if case2 is not explicitly typed string, typescript makes it a union of strings
+  let case2: string = `if err := ${side.name}.${nm}(ctx${arg2}); err != nil {
     event.Error(ctx, "", err)
   }`;
   if (b != '' && b != 'void') {
@@ -1007,7 +1215,7 @@ function goReq(side: side, m: string) {
     return true, reply(ctx, resp, err)`;
   } else {  // response is nil
     case2 = `err := ${side.name}.${nm}(ctx${arg2})
-    return true, reply(ctx, nil, err)`
+    return true, reply(ctx, nil, err)`;
   }
 
   side.cases.push(`${caseHdr}\n${case1}\n${case2}`);
@@ -1025,7 +1233,7 @@ function goReq(side: side, m: string) {
     }`;
   } else if (a != '') {
     callBody = `return Call(ctx, s.Conn, "${m}", params, nil) // Call, not Notify
-  }`
+  }`;
   }
   side.calls.push(`${callHdr}\n${callBody}\n`);
 }
@@ -1037,15 +1245,15 @@ function methodName(m: string): string {
   let s = m.substring(i + 1);
   let x = s[0].toUpperCase() + s.substring(1);
   for (let j = x.indexOf('/'); j >= 0; j = x.indexOf('/')) {
-    let suffix = x.substring(j + 1)
-    suffix = suffix[0].toUpperCase() + suffix.substring(1)
-    let prefix = x.substring(0, j)
-    x = prefix + suffix
+    let suffix = x.substring(j + 1);
+    suffix = suffix[0].toUpperCase() + suffix.substring(1);
+    let prefix = x.substring(0, j);
+    x = prefix + suffix;
   }
   if (seenNames.has(x)) {
     // Resolve, ResolveCodeLens, ResolveDocumentLink
-    if (!x.startsWith('Resolve')) throw new Error(`expected Resolve, not ${x}`)
-    x += m[0].toUpperCase() + m.substring(1, i)
+    if (!x.startsWith('Resolve')) throw new Error(`expected Resolve, not ${x}`);
+    x += m[0].toUpperCase() + m.substring(1, i);
   }
   seenNames.add(x);
   return x;
@@ -1058,15 +1266,15 @@ function indirect(s: string): boolean {
   if (skip('[]') || skip('interface') || skip('Declaration') ||
     skip('Definition') || skip('DocumentSelector'))
     return false;
-  return true
+  return true;
 }
 
 // Go signatures for methods.
 function sig(nm: string, a: string, b: string, names?: boolean): string {
   if (a.indexOf('struct') != -1) {
-    const v = a.split('\n')
-    extraTypes.set(`Param${nm}`, v.slice(1, v.length - 1))
-    a = 'Param' + nm
+    const v = a.split('\n');
+    extraTypes.set(`Param${nm}`, v.slice(1, v.length - 1));
+    a = 'Param' + nm;
   }
   if (a == 'void')
     a = '';
@@ -1110,25 +1318,25 @@ function output(side: side) {
           errors "golang.org/x/xerrors"
         )
         `);
-  const a = side.name[0].toUpperCase() + side.name.substring(1)
+  const a = side.name[0].toUpperCase() + side.name.substring(1);
   f(`type ${a} interface {`);
-  side.methods.forEach((v) => { f(v) })
+  side.methods.forEach((v) => { f(v); });
   f('}\n');
   f(`func ${side.name}Dispatch(ctx context.Context, ${side.name} ${a}, reply jsonrpc2.Replier, r jsonrpc2.Request) (bool, error) {
           switch r.Method() {`);
-  side.cases.forEach((v) => { f(v) })
+  side.cases.forEach((v) => { f(v); });
   f(`
         default:
           return false, nil
         }
       }`);
-  side.calls.forEach((v) => { f(v) });
+  side.calls.forEach((v) => { f(v); });
 }
 
 // Handling of non-standard requests, so we can add gopls-specific calls.
 function nonstandardRequests() {
   server.methods.push(
-    'NonstandardRequest(ctx context.Context, method string, params interface{}) (interface{}, error)')
+    'NonstandardRequest(ctx context.Context, method string, params interface{}) (interface{}, error)');
   server.calls.push(
     `func (s *serverDispatcher) NonstandardRequest(ctx context.Context, method string, params interface{}) (interface{}, error) {
       var result interface{}
@@ -1137,7 +1345,7 @@ function nonstandardRequests() {
       }
       return result, nil
     }
-  `)
+  `);
 }
 
 // ----- remember it's a scripting language
@@ -1146,13 +1354,13 @@ function main() {
     throw new Error(
       `git hash mismatch, wanted\n${u.gitHash} but source is at\n${u.git()}`);
   }
-  u.createOutputFiles()
-  parse()
-  u.printAST(program)
+  u.createOutputFiles();
+  parse();
+  u.printAST(program);
   // find the Requests and Nofificatations
   for (const sourceFile of program.getSourceFiles()) {
     if (!sourceFile.isDeclarationFile) {
-      ts.forEachChild(sourceFile, findRPCs)
+      ts.forEachChild(sourceFile, findRPCs);
     }
   }
   // separate RPCs into client and server
@@ -1160,7 +1368,7 @@ function main() {
   // visit every sourceFile collecting top-level type definitions
   for (const sourceFile of program.getSourceFiles()) {
     if (!sourceFile.isDeclarationFile) {
-      ts.forEachChild(sourceFile, genTypes)
+      ts.forEachChild(sourceFile, genTypes);
     }
   }
   // check that each thing occurs exactly once, and put pointers into
@@ -1172,21 +1380,23 @@ function main() {
   // 3. func (x *xDispatcher) Method(ctx, parm)
   not.forEach(  // notifications
     (v, k) => {
-      receives.get(k) == 'client' ? goNot(client, k) : goNot(server, k)
+      receives.get(k) == 'client' ? goNot(client, k) : goNot(server, k);
     });
   req.forEach(  // requests
     (v, k) => {
-      receives.get(k) == 'client' ? goReq(client, k) : goReq(server, k)
+      receives.get(k) == 'client' ? goReq(client, k) : goReq(server, k);
     });
   nonstandardRequests();
   // find all the types implied by seenTypes and rpcs to try to avoid
   // generating types that aren't used
   moreTypes();
+  // do merging
+  cleanData();
   // and print the Go code
-  outputTypes()
-  console.log(`seen ${seenTypes.size + extraTypes.size}`)
+  outputTypes();
+  console.log(`seen ${seenTypes.size + extraTypes.size}`);
   output(client);
   output(server);
 }
 
-main()
+main();

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/util.ts
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/util.ts
@@ -1,6 +1,7 @@
 
 // for us typescript ignorati, having an import makes this file a module
 import * as fs from 'fs';
+import * as process from 'process';
 import * as ts from 'typescript';
 
 // This file contains various utilities having to do with producing strings
@@ -8,29 +9,29 @@ import * as ts from 'typescript';
 
 // ------ create files
 let dir = process.env['HOME'];
-const srcDir = '/vscode-languageserver-node'
+const srcDir = '/vscode-languageserver-node';
 export const fnames = [
   `${dir}${srcDir}/protocol/src/common/protocol.ts`,
   `${dir}/${srcDir}/protocol/src/browser/main.ts`, `${dir}${srcDir}/types/src/main.ts`,
   `${dir}${srcDir}/jsonrpc/src/node/main.ts`
 ];
-export const gitHash = 'dae62de921d25964e8732411ca09e532dde992f5'
+export const gitHash = 'dae62de921d25964e8732411ca09e532dde992f5';
 let outFname = 'tsprotocol.go';
 let fda: number, fdb: number, fde: number;  // file descriptors
 
 export function createOutputFiles() {
-  fda = fs.openSync('/tmp/ts-a', 'w')  // dump of AST
-  fdb = fs.openSync('/tmp/ts-b', 'w')  // unused, for debugging
-  fde = fs.openSync(outFname, 'w')     // generated Go
+  fda = fs.openSync('/tmp/ts-a', 'w');  // dump of AST
+  fdb = fs.openSync('/tmp/ts-b', 'w');  // unused, for debugging
+  fde = fs.openSync(outFname, 'w');     // generated Go
 }
 export function pra(s: string) {
-  return (fs.writeSync(fda, s))
+  return (fs.writeSync(fda, s));
 }
 export function prb(s: string) {
-  return (fs.writeSync(fdb, s))
+  return (fs.writeSync(fdb, s));
 }
 export function prgo(s: string) {
-  return (fs.writeSync(fde, s))
+  return (fs.writeSync(fde, s));
 }
 
 // Get the hash value of the git commit
@@ -42,66 +43,66 @@ export function git(): string {
     a = a.substring(0, a.length - 1);
   }
   if (a.length == 40) {
-    return a  // a hash
+    return a;  // a hash
   }
   if (a.substring(0, 5) == 'ref: ') {
     const fname = `${dir}${srcDir}/.git/` + a.substring(5);
-    let b = fs.readFileSync(fname).toString()
+    let b = fs.readFileSync(fname).toString();
     if (b.length == 41) {
       return b.substring(0, 40);
     }
   }
-  throw new Error('failed to find the git commit hash')
+  throw new Error('failed to find the git commit hash');
 }
 
 // Produce a header for Go output files
 export function computeHeader(pkgDoc: boolean): string {
-  let lastMod = 0
-  let lastDate: Date
+  let lastMod = 0;
+  let lastDate: Date;
   for (const f of fnames) {
-    const st = fs.statSync(f)
+    const st = fs.statSync(f);
     if (st.mtimeMs > lastMod) {
-      lastMod = st.mtimeMs
-      lastDate = st.mtime
+      lastMod = st.mtimeMs;
+      lastDate = st.mtime;
     }
   }
   const cp = `// Copyright 2019 The Go Authors. All rights reserved.
   // Use of this source code is governed by a BSD-style
   // license that can be found in the LICENSE file.
 
-  `
+  `;
   const a =
-    `// Package protocol contains data types and code for LSP jsonrpcs\n` +
-    `// generated automatically from vscode-languageserver-node\n` +
+    '// Package protocol contains data types and code for LSP jsonrpcs\n' +
+    '// generated automatically from vscode-languageserver-node\n' +
     `// commit: ${gitHash}\n` +
-    `// last fetched ${lastDate}\n`
-  const b = 'package protocol\n'
-  const c = `\n// Code generated (see typescript/README.md) DO NOT EDIT.\n\n`
+    `// last fetched ${lastDate}\n`;
+  const b = 'package protocol\n';
+  const c = '\n// Code generated (see typescript/README.md) DO NOT EDIT.\n\n';
   if (pkgDoc) {
-    return cp + a + b + c
+    return cp + a + b + c;
   }
   else {
-    return cp + b + a + c
+    return cp + b + a + c;
   }
-};
+}
 
 // Turn a typescript name into an exportable Go name, and appease lint
 export function goName(s: string): string {
-  let ans = s
+  let ans = s;
   if (s.charAt(0) == '_') {
-    ans = 'Inner' + s.substring(1)
+    ans = 'Inner' + s.substring(1);
   }
-  else { ans = s.substring(0, 1).toUpperCase() + s.substring(1) };
-  ans = ans.replace(/Uri$/, 'URI')
-  ans = ans.replace(/Id$/, 'ID')
-  return ans
+  else { ans = s.substring(0, 1).toUpperCase() + s.substring(1); }
+  ans = ans.replace(/Uri$/, 'URI');
+  ans = ans.replace(/Id$/, 'ID');
+  return ans;
 }
 
 // Generate JSON tag for a struct field
 export function JSON(n: ts.PropertySignature): string {
   const json = `\`json:"${n.name.getText()}${
     n.questionToken != undefined ? ',omitempty' : ''}"\``;
-  return json
+  return json;
 }
 
 // Generate modifying prefixes and suffixes to ensure
@@ -112,24 +113,24 @@ export function constName(nm: string, type: string): string {
     ['DiagnosticSeverity', 'Severity'], ['WatchKind', 'Watch'],
     ['SignatureHelpTriggerKind', 'Sig'], ['CompletionItemTag', 'Compl'],
     ['Integer', 'INT_'], ['Uinteger', 'UINT_']
-  ])  // typeName->prefix
+  ]);  // typeName->prefix
   let suff = new Map<string, string>([
     ['CompletionItemKind', 'Completion'], ['InsertTextFormat', 'TextFormat'],
     ['SymbolTag', 'Symbol'], ['FileOperationPatternKind', 'Op'],
-  ])
+  ]);
   let ans = nm;
   if (pref.get(type)) ans = pref.get(type) + ans;
-  if (suff.has(type)) ans = ans + suff.get(type)
-  return ans
+  if (suff.has(type)) ans = ans + suff.get(type);
+  return ans;
 }
 
 // Find the comments associated with an AST node
 export function getComments(node: ts.Node): string {
   const sf = node.getSourceFile();
-  const start = node.getStart(sf, false)
-  const starta = node.getStart(sf, true)
-  const x = sf.text.substring(starta, start)
-  return x
+  const start = node.getStart(sf, false);
+  const starta = node.getStart(sf, true);
+  const x = sf.text.substring(starta, start);
+  return x;
 }
 
 
@@ -138,7 +139,7 @@ export function getComments(node: ts.Node): string {
 export function printAST(program: ts.Program) {
   // dump the ast, for debugging
   const f = function (n: ts.Node) {
-    describe(n, pra)
+    describe(n, pra);
   };
   for (const sourceFile of program.getSourceFiles()) {
     if (!sourceFile.isDeclarationFile) {
@@ -146,60 +147,61 @@ export function printAST(program: ts.Program) {
       ts.forEachChild(sourceFile, f);
     }
   }
-  pra('\n')
+  pra('\n');
   for (const key of Object.keys(seenThings).sort()) {
-    pra(`${key}: ${seenThings[key]} \n`)
+    pra(`${key}: ${seenThings[key]} \n`);
   }
 }
 
 // Used in printing the AST
 let seenThings = new Map<string, number>();
 function seenAdd(x: string) {
-  seenThings[x] = (seenThings[x] === undefined ? 1 : seenThings[x] + 1)
+  seenThings[x] = (seenThings[x] === undefined ? 1 : seenThings[x] + 1);
 }
 
+// eslint-disable-next-line no-unused-vars
 function describe(node: ts.Node, pr: (s: string) => any) {
   if (node === undefined) {
-    return
+    return;
   }
   let indent = '';
 
   function f(n: ts.Node) {
-    seenAdd(kinds(n))
+    seenAdd(kinds(n));
     if (ts.isIdentifier(n)) {
-      pr(`${indent} ${loc(n)} ${strKind(n)} ${n.text} \n`)
+      pr(`${indent} ${loc(n)} ${strKind(n)} ${n.text} \n`);
     }
     else if (ts.isPropertySignature(n) || ts.isEnumMember(n)) {
-      pra(`${indent} ${loc(n)} ${strKind(n)} \n`)
+      pra(`${indent} ${loc(n)} ${strKind(n)} \n`);
     }
     else if (ts.isTypeLiteralNode(n)) {
-      let m = n.members
-      pr(`${indent} ${loc(n)} ${strKind(n)} ${m.length} \n`)
+      let m = n.members;
+      pr(`${indent} ${loc(n)} ${strKind(n)} ${m.length} \n`);
     }
     else if (ts.isStringLiteral(n)) {
-      pr(`${indent} ${loc(n)} ${strKind(n)} ${n.text} \n`)
+      pr(`${indent} ${loc(n)} ${strKind(n)} ${n.text} \n`);
     }
-    else { pr(`${indent} ${loc(n)} ${strKind(n)} \n`) };
-    indent += ' .'
-    ts.forEachChild(n, f)
-    indent = indent.slice(0, indent.length - 2)
+    else { pr(`${indent} ${loc(n)} ${strKind(n)} \n`); }
+    indent += ' .';
+    ts.forEachChild(n, f);
+    indent = indent.slice(0, indent.length - 2);
   }
-  f(node)
+  f(node);
 }
 
 
 // For debugging, say where an AST node is in a file
 export function loc(node: ts.Node): string {
   const sf = node.getSourceFile();
-  const start = node.getStart()
-  const x = sf.getLineAndCharacterOfPosition(start)
-  const full = node.getFullStart()
-  const y = sf.getLineAndCharacterOfPosition(full)
-  let fn = sf.fileName
-  const n = fn.search(/-node./)
-  fn = fn.substring(n + 6)
+  const start = node.getStart();
+  const x = sf.getLineAndCharacterOfPosition(start);
+  const full = node.getFullStart();
+  const y = sf.getLineAndCharacterOfPosition(full);
+  let fn = sf.fileName;
+  const n = fn.search(/-node./);
+  fn = fn.substring(n + 6);
   return `${fn} ${x.line + 1}: ${x.character + 1} (${y.line + 1}: ${
-    y.character + 1})`
+    y.character + 1})`;
 }
 // --- various string stuff
 
@@ -207,9 +209,9 @@ export function loc(node: ts.Node): string {
 // as part of printing the AST tree
 function kinds(n: ts.Node): string {
   let res = 'Seen ' + strKind(n);
-  function f(n: ts.Node): void { res += ' ' + strKind(n) };
-  ts.forEachChild(n, f)
-  return res
+  function f(n: ts.Node): void { res += ' ' + strKind(n); }
+  ts.forEachChild(n, f);
+  return res;
 }
 
 // What kind of AST node is it? This would just be typescript's
@@ -217,9 +219,14 @@ function kinds(n: ts.Node): string {
 // are misleading
 export function strKind(n: ts.Node): string {
   if (n == null || n == undefined) {
-    return 'null'
+    return 'null';
   }
-  const x = ts.SyntaxKind[n.kind];
+   return kindToStr(n.kind);
+}
+
+export function kindToStr(k: ts.SyntaxKind): string {
+  if (k === undefined) return 'unDefined';
+  const x = ts.SyntaxKind[k];
   // some of these have two names
   switch (x) {
     default:

--- a/cmd/govim/internal/golang_org_x_tools/lsp/server.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/server.go
@@ -64,12 +64,12 @@ type Server struct {
 
 	stateMu sync.Mutex
 	state   serverState
-
-	session   source.Session
-	clientPID int
-
 	// notifications generated before serverInitialized
 	notifications []*protocol.ShowMessageParams
+
+	session source.Session
+
+	tempDir string
 
 	// changedFiles tracks files for which there has been a textDocument/didChange.
 	changedFilesMu sync.Mutex

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -392,6 +392,11 @@ var GeneratedAPIJSON = &APIJSON{
 							Default: "true",
 						},
 						{
+							Name:    "\"nilness\"",
+							Doc:     "check for redundant or impossible nil comparisons\n\nThe nilness checker inspects the control-flow graph of each function in\na package and reports nil pointer dereferences, degenerate nil\npointers, and panics with nil values. A degenerate comparison is of the form\nx==nil or x!=nil where x is statically known to be nil or non-nil. These are\noften a mistake, especially in control flow related to errors. Panics with nil\nvalues are checked because they are not detectable by\n\n\tif r := recover(); r != nil {\n\nThis check reports conditions such as:\n\n\tif f == nil { // impossible condition (f is a function)\n\t}\n\nand:\n\n\tp := &v\n\t...\n\tif p != nil { // tautological condition\n\t}\n\nand:\n\n\tif p == nil {\n\t\tprint(*p) // nil dereference\n\t}\n\nand:\n\n\tif p == nil {\n\t\tpanic(p)\n\t}\n",
+							Default: "false",
+						},
+						{
 							Name:    "\"printf\"",
 							Doc:     "check consistency of Printf format strings and arguments\n\nThe check applies to known functions (for example, those in package fmt)\nas well as any detected wrappers of known functions.\n\nA function that wants to avail itself of printf checking but is not\nfound by this analyzer's heuristics (for example, due to use of\ndynamic calls) can insert a bogus call:\n\n\tif false {\n\t\t_ = fmt.Sprintf(format, args...) // enable printf checking\n\t}\n\nThe -funcs flag specifies a comma-separated list of names of additional\nknown formatting functions or methods. If the name contains a period,\nit must denote a specific function using one of the following forms:\n\n\tdir/pkg.Function\n\tdir/pkg.Type.Method\n\t(*dir/pkg.Type).Method\n\nOtherwise the name is interpreted as a case-insensitive unqualified\nidentifier such as \"errorf\". Either way, if a listed name ends in f, the\nfunction is assumed to be Printf-like, taking a format string before the\nargument list. Otherwise it is assumed to be Print-like, taking a list\nof arguments with no format string.\n",
 							Default: "true",
@@ -785,6 +790,12 @@ var GeneratedAPIJSON = &APIJSON{
 			Doc:     "Runs `go mod vendor` for a module.",
 			ArgDoc:  "{\n\t// The file URI.\n\t\"URI\": string,\n}",
 		},
+		{
+			Command: "gopls.workspace_metadata",
+			Title:   "",
+			Doc:     "",
+			ArgDoc:  "",
+		},
 	},
 	Lenses: []*LensJSON{
 		{
@@ -908,6 +919,11 @@ var GeneratedAPIJSON = &APIJSON{
 			Name:    "nilfunc",
 			Doc:     "check for useless comparisons between functions and nil\n\nA useless comparison is one like f == nil as opposed to f() == nil.",
 			Default: true,
+		},
+		{
+			Name:    "nilness",
+			Doc:     "check for redundant or impossible nil comparisons\n\nThe nilness checker inspects the control-flow graph of each function in\na package and reports nil pointer dereferences, degenerate nil\npointers, and panics with nil values. A degenerate comparison is of the form\nx==nil or x!=nil where x is statically known to be nil or non-nil. These are\noften a mistake, especially in control flow related to errors. Panics with nil\nvalues are checked because they are not detectable by\n\n\tif r := recover(); r != nil {\n\nThis check reports conditions such as:\n\n\tif f == nil { // impossible condition (f is a function)\n\t}\n\nand:\n\n\tp := &v\n\t...\n\tif p != nil { // tautological condition\n\t}\n\nand:\n\n\tif p == nil {\n\t\tprint(*p) // nil dereference\n\t}\n\nand:\n\n\tif p == nil {\n\t\tpanic(p)\n\t}\n",
+			Default: false,
 		},
 		{
 			Name:    "printf",

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
@@ -95,6 +95,7 @@ type completionOptions struct {
 	fullDocumentation bool
 	placeholders      bool
 	literal           bool
+	snippets          bool
 	matcher           source.Matcher
 	budget            time.Duration
 }
@@ -519,6 +520,7 @@ func Completion(ctx context.Context, snapshot source.Snapshot, fh source.FileHan
 			placeholders:      opts.UsePlaceholders,
 			literal:           opts.LiteralCompletions && opts.InsertTextFormat == protocol.SnippetTextFormat,
 			budget:            opts.CompletionBudget,
+			snippets:          opts.InsertTextFormat == protocol.SnippetTextFormat,
 		},
 		// default to a matcher that always matches
 		matcher:        prefixMatcher(""),

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/format.go
@@ -150,9 +150,8 @@ func (c *completer) item(ctx context.Context, cand candidate) (CompletionItem, e
 		prefix = typeName + "(" + prefix
 		suffix = ")"
 	}
-
-	// Add variadic "..." if we are filling in a variadic param.
-	if cand.variadic {
+	// Add variadic "..." only if snippets if enabled or cand is not a function
+	if cand.variadic && (c.opts.snippets || !cand.expandFuncCall) {
 		suffix += "..."
 	}
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
@@ -241,7 +241,7 @@ func objectString(obj types.Object, qf types.Qualifier) string {
 			break
 		}
 		pkg := typ.Obj().Pkg()
-		if pkg.Path() == "time" && pkg.Scope().Lookup("Duration") != nil {
+		if pkg.Path() == "time" && typ.Obj().Name() == "Duration" {
 			if d, ok := constant.Int64Val(obj.Val()); ok {
 				str += " // " + time.Duration(d).String()
 			}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/tools/go/analysis/passes/loopclosure"
 	"golang.org/x/tools/go/analysis/passes/lostcancel"
 	"golang.org/x/tools/go/analysis/passes/nilfunc"
+	"golang.org/x/tools/go/analysis/passes/nilness"
 	"golang.org/x/tools/go/analysis/passes/printf"
 	"golang.org/x/tools/go/analysis/passes/shadow"
 	"golang.org/x/tools/go/analysis/passes/shift"
@@ -96,6 +97,7 @@ func DefaultOptions() *Options {
 					},
 					Mod: {
 						protocol.SourceOrganizeImports: true,
+						protocol.QuickFix:              true,
 					},
 					Sum: {},
 				},
@@ -1077,9 +1079,9 @@ func EnabledAnalyzers(snapshot Snapshot) (analyzers []*Analyzer) {
 func typeErrorAnalyzers() map[string]*Analyzer {
 	return map[string]*Analyzer{
 		fillreturns.Analyzer.Name: {
-			Analyzer:       fillreturns.Analyzer,
-			HighConfidence: true,
-			Enabled:        true,
+			Analyzer:   fillreturns.Analyzer,
+			ActionKind: protocol.SourceFixAll,
+			Enabled:    true,
 		},
 		nonewvars.Analyzer.Name: {
 			Analyzer: nonewvars.Analyzer,
@@ -1100,9 +1102,10 @@ func typeErrorAnalyzers() map[string]*Analyzer {
 func convenienceAnalyzers() map[string]*Analyzer {
 	return map[string]*Analyzer{
 		fillstruct.Analyzer.Name: {
-			Analyzer: fillstruct.Analyzer,
-			Fix:      FillStruct,
-			Enabled:  true,
+			Analyzer:   fillstruct.Analyzer,
+			Fix:        FillStruct,
+			Enabled:    true,
+			ActionKind: protocol.RefactorRewrite,
 		},
 	}
 }
@@ -1139,6 +1142,7 @@ func defaultAnalyzers() map[string]*Analyzer {
 		atomicalign.Analyzer.Name:      {Analyzer: atomicalign.Analyzer, Enabled: true},
 		deepequalerrors.Analyzer.Name:  {Analyzer: deepequalerrors.Analyzer, Enabled: true},
 		fieldalignment.Analyzer.Name:   {Analyzer: fieldalignment.Analyzer, Enabled: false},
+		nilness.Analyzer.Name:          {Analyzer: nilness.Analyzer, Enabled: false},
 		shadow.Analyzer.Name:           {Analyzer: shadow.Analyzer, Enabled: false},
 		sortslice.Analyzer.Name:        {Analyzer: sortslice.Analyzer, Enabled: true},
 		testinggoroutine.Analyzer.Name: {Analyzer: testinggoroutine.Analyzer, Enabled: true},
@@ -1146,9 +1150,9 @@ func defaultAnalyzers() map[string]*Analyzer {
 		unusedwrite.Analyzer.Name:      {Analyzer: unusedwrite.Analyzer, Enabled: false},
 
 		// gofmt -s suite:
-		simplifycompositelit.Analyzer.Name: {Analyzer: simplifycompositelit.Analyzer, Enabled: true, HighConfidence: true},
-		simplifyrange.Analyzer.Name:        {Analyzer: simplifyrange.Analyzer, Enabled: true, HighConfidence: true},
-		simplifyslice.Analyzer.Name:        {Analyzer: simplifyslice.Analyzer, Enabled: true, HighConfidence: true},
+		simplifycompositelit.Analyzer.Name: {Analyzer: simplifycompositelit.Analyzer, Enabled: true, ActionKind: protocol.SourceFixAll},
+		simplifyrange.Analyzer.Name:        {Analyzer: simplifyrange.Analyzer, Enabled: true, ActionKind: protocol.SourceFixAll},
+		simplifyslice.Analyzer.Name:        {Analyzer: simplifyslice.Analyzer, Enabled: true, ActionKind: protocol.SourceFixAll},
 	}
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -215,6 +215,10 @@ type View interface {
 	// Folder returns the folder with which this view was created.
 	Folder() span.URI
 
+	// TempWorkspace returns the folder this view uses for its temporary
+	// workspace module.
+	TempWorkspace() span.URI
+
 	// Shutdown closes this view, and detaches it from its session.
 	Shutdown(ctx context.Context)
 
@@ -291,8 +295,13 @@ type TidiedModule struct {
 // of the client.
 // A session may have many active views at any given time.
 type Session interface {
-	// NewView creates a new View, returning it and its first snapshot.
-	NewView(ctx context.Context, name string, folder, tempWorkspaceDir span.URI, options *Options) (View, Snapshot, func(), error)
+	// ID returns the unique identifier for this session on this server.
+	ID() string
+	// NewView creates a new View, returning it and its first snapshot. If a
+	// non-empty tempWorkspace directory is provided, the View will record a copy
+	// of its gopls workspace module in that directory, so that client tooling
+	// can execute in the same main module.
+	NewView(ctx context.Context, name string, folder, tempWorkspace span.URI, options *Options) (View, Snapshot, func(), error)
 
 	// Cache returns the cache that created this session, for debugging only.
 	Cache() interface{}
@@ -520,9 +529,9 @@ type Analyzer struct {
 	// the analyzer's suggested fixes through a Command, not a TextEdit.
 	Fix string
 
-	// If this is true, then we can apply the suggested fixes
-	// as part of a source.FixAll codeaction.
-	HighConfidence bool
+	// ActionKind is the kind of code action this analyzer produces. If
+	// unspecified the type defaults to quickfix.
+	ActionKind protocol.CodeActionKind
 }
 
 func (a Analyzer) IsEnabled(view View) bool {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/workspace.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/workspace.go
@@ -6,7 +6,12 @@ package lsp
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
@@ -26,7 +31,9 @@ func (s *Server) didChangeWorkspaceFolders(ctx context.Context, params *protocol
 	return s.addFolders(ctx, event.Added)
 }
 
-func (s *Server) addView(ctx context.Context, name string, uri, tempWorkspace span.URI) (source.Snapshot, func(), error) {
+var wsIndex int64
+
+func (s *Server) addView(ctx context.Context, name string, uri span.URI) (source.Snapshot, func(), error) {
 	s.stateMu.Lock()
 	state := s.state
 	s.stateMu.Unlock()
@@ -36,6 +43,18 @@ func (s *Server) addView(ctx context.Context, name string, uri, tempWorkspace sp
 	options := s.session.Options().Clone()
 	if err := s.fetchConfig(ctx, name, uri, options); err != nil {
 		return nil, func() {}, err
+	}
+	// Try to assign a persistent temp directory for tracking this view's
+	// temporary workspace.
+	var tempWorkspace span.URI
+	if s.tempDir != "" {
+		index := atomic.AddInt64(&wsIndex, 1)
+		wsDir := filepath.Join(s.tempDir, fmt.Sprintf("workspace.%d", index))
+		if err := os.Mkdir(wsDir, 0700); err == nil {
+			tempWorkspace = span.URIFromPath(wsDir)
+		} else {
+			event.Error(ctx, "making workspace dir", err)
+		}
 	}
 	_, snapshot, release, err := s.session.NewView(ctx, name, uri, tempWorkspace, options)
 	return snapshot, release, err

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.1
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
-	golang.org/x/tools v0.1.1-0.20210303215420-376db57240db
-	golang.org/x/tools/gopls v0.0.0-20210303215420-376db57240db
+	golang.org/x/tools v0.1.1-0.20210319205745-d7a25adab0d9
+	golang.org/x/tools/gopls v0.0.0-20210319205745-d7a25adab0d9
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1-0.20210303215420-376db57240db h1:vRASVXCk4fZnCcCvGb6xrhQE1Zd5PMfESAvrIagpWDg=
-golang.org/x/tools v0.1.1-0.20210303215420-376db57240db/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
-golang.org/x/tools/gopls v0.0.0-20210303215420-376db57240db h1:1xwGDHrFatYhzIjP1ZnQ4C2LQeOAkPwmRUQiXdhhehg=
-golang.org/x/tools/gopls v0.0.0-20210303215420-376db57240db/go.mod h1:q2ebn/wWEF1eM4RLz1NFKDK1JvIzDUrKvKw5RRfW+rI=
+golang.org/x/tools v0.1.1-0.20210319205745-d7a25adab0d9 h1:S0O67fPB+KeyU1h1cXu0HQnfqV1uiZn4Juf7LNM34Ic=
+golang.org/x/tools v0.1.1-0.20210319205745-d7a25adab0d9/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
+golang.org/x/tools/gopls v0.0.0-20210319205745-d7a25adab0d9 h1:X68KyAH2Rx0eQDQQgaATerAC7AzP+h4c+Rc8Uaq8sdw=
+golang.org/x/tools/gopls v0.0.0-20210319205745-d7a25adab0d9/go.mod h1:q2ebn/wWEF1eM4RLz1NFKDK1JvIzDUrKvKw5RRfW+rI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* gopls/integration: remove obsolete code d7a25ada
* gopls/internal: add coverage command to compute test coverage 9bdb4197
* present: don't drop commands that immediately follow text d2e11a2b
* cmd/present2md: allow comments to be retained in translated document 695b1675
* present: retain complete caption command when parsing captions a14ff98a
* Update emacs.md - add .dir-locals.el example 1aac171f
* internal/lsp: remove module diagnostics from code actions 2c4a8865
* internal/lsp/cache: tolerate analysis panics better 9b614f5d
* gopls/internal/regtest: fix race when printing regtest state on falure 9e9211a9
* internal/lsp: add a temp workspace per folder, and a helper command 6d45e3d9
* internal/lsp: add snippet completion for t.Fatal errs e409f121
* godoc: delete GoogleCN logic 8e4f4c86
* internal/lsp: only load by view when there are no go.mod files 44abc2a7
* internal/lsp: refactor codeAction 11e8f6b8
* internal/lsp: fix time.Duration hover name check 1523bb47
* internal/lsp: fix bad completion for variadic functions bcb2d7b2
* internal/lsp/cache: refactor and improve go get quick fixes 7ee29554
* internal/lsp/source: add the nilness analyzer 1e524e26
* internal/lsp/source: return nil for foldingRange in case of parse error d34cf35d
* gopls/doc: clarify how to set remote.listen.timeout c5f5f4be
* internal/lsp/source: correct workspace symbol logic for unpacking receivers 3e1cb952
* internal/lsp/protocol/typescript: fix lint errors in .ts code 397283d2
* internal/lsp/protocol/typecript: fix type merging d19d8cff
* all: recognize new error from go command when no go.mod is found 50ca8d00
* internal/lsp: remove redundant didChange notifications 2cde57b5