### PR TITLE
general: fix gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-cmd/govim/internal/golang_org_x_tools/* linguist-generated
+cmd/govim/internal/golang_org_x_tools/**/* linguist-generated


### PR DESCRIPTION
Per https://github.com/github/linguist/issues/5288 we were not using the
recursive form of a pattern to specify that everything under
cmd/govim/internal/golang_org_x_tools should be considered generated.