### PR TITLE
cmd/govim: do not watch file system when there is no module root

### DIFF
--- a/cmd/govim/gopls.go
+++ b/cmd/govim/gopls.go
@@ -183,7 +183,9 @@ func (g *govimplugin) startGopls() error {
 		return fmt.Errorf("failed to derive go.mod path: %v", err)
 	}
 
-	if gomodpath != "" {
+	// "go env GOMOD" might return an empty string (not module mode) or os.DevNull (in module
+	// mode but without a module root).
+	if gomodpath != "" && gomodpath != os.DevNull {
 		// i.e. we are in a module
 		mw, err := newModWatcher(g, gomodpath)
 		if err != nil {


### PR DESCRIPTION
If we are using module mode but isn't inside a module "go env GOMOD"
will return os.DevNull (e.g. /dev/null in linux).

That did incorrectly add a file watcher to /dev since govim thought
/dev/null was the go.mod file.

Now we skip creating a fs watcher if we can't find the module root.

Fixes #1067