### PR TITLE
cmd/govim: extend GOVIM_LOG to accept multiple commaseparated values

### DIFF
--- a/cmd/govim/gopls.go
+++ b/cmd/govim/gopls.go
@@ -21,8 +21,8 @@ import (
 
 func (g *govimplugin) startGopls() error {
 	goplsArgs := []string{"-rpc.trace"}
-	if getEnvVal(g.goplsEnv, config.EnvLog, "on") == "on" {
 
+	if g.logging["on"] {
 		logfile, err := g.createLogFile("gopls")
 		if err != nil {
 			return err

--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -26,7 +26,7 @@ let s:tmpdir = $TMPDIR
 if s:tmpdir == ""
   let s:tmpdir = "/tmp"
 endif
-if system("echo -n ${GOVIM_LOG-on}") == "on"
+if index(split(system("echo -n ${GOVIM_LOG-on}"), ","), "on") >= 0
   let s:filetmpl = $GOVIM_LOGFILE_TMPL
   if s:filetmpl == ""
     let s:filetmpl = "%v_%v_%v"


### PR DESCRIPTION
This change adds the possibility to set multiple values when using
`GOVIM_LOG`. It is mainly a preparation for the upcoming file watcher
refactoring where the intention is to add opt-in for more verbose
logging.