### PR TITLE
deps: update x/tools and gopls to 8c34cc9c

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/event/label/label.go
+++ b/cmd/govim/internal/golang_org_x_tools/event/label/label.go
@@ -96,6 +96,8 @@ func Of64(k Key, v uint64) Label { return Label{key: k, packed: v} }
 // access should be done with the From method of the key.
 func (t Label) Unpack64() uint64 { return t.packed }
 
+type stringptr unsafe.Pointer
+
 // OfString creates a new label from a key and a string.
 // This method is for implementing new key types, label creation should
 // normally be done with the Of method of the key.
@@ -104,7 +106,7 @@ func OfString(k Key, v string) Label {
 	return Label{
 		key:     k,
 		packed:  uint64(hdr.Len),
-		untyped: unsafe.Pointer(hdr.Data),
+		untyped: stringptr(hdr.Data),
 	}
 }
 
@@ -115,9 +117,9 @@ func OfString(k Key, v string) Label {
 func (t Label) UnpackString() string {
 	var v string
 	hdr := (*reflect.StringHeader)(unsafe.Pointer(&v))
-	hdr.Data = uintptr(t.untyped.(unsafe.Pointer))
+	hdr.Data = uintptr(t.untyped.(stringptr))
 	hdr.Len = int(t.packed)
-	return *(*string)(unsafe.Pointer(hdr))
+	return v
 }
 
 // Valid returns true if the Label is a valid one (it has a key).

--- a/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2/jsonrpc2.go
+++ b/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2/jsonrpc2.go
@@ -68,6 +68,15 @@ func (a *async) done() {
 	close(a.ready)
 }
 
+func (a *async) isDone() bool {
+	select {
+	case <-a.ready:
+		return true
+	default:
+		return false
+	}
+}
+
 func (a *async) wait() error {
 	<-a.ready
 	err := <-a.errBox

--- a/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2/serve.go
+++ b/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2/serve.go
@@ -7,9 +7,9 @@ package jsonrpc2
 import (
 	"context"
 	"io"
+	"sync"
 	"time"
 
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	errors "golang.org/x/xerrors"
 )
 
@@ -39,15 +39,7 @@ type Dialer interface {
 type Server struct {
 	listener Listener
 	binder   Binder
-	options  ServeOptions // a copy of the config that started this server
 	async    async
-}
-
-// ServeOptions holds the options to the Serve function.
-//TODO: kill ServeOptions and push timeout into the listener
-type ServeOptions struct {
-	// IdleTimeout is the maximum amount of time to remain idle and running.
-	IdleTimeout time.Duration
 }
 
 // Dial uses the dialer to make a new connection, wraps the returned
@@ -69,11 +61,10 @@ func Dial(ctx context.Context, dialer Dialer, binder Binder) (*Connection, error
 // You can call Wait to block on the server, or Shutdown to get the sever to
 // terminate gracefully.
 // To notice incoming connections, use an intercepting Binder.
-func Serve(ctx context.Context, listener Listener, binder Binder, options ServeOptions) (*Server, error) {
+func Serve(ctx context.Context, listener Listener, binder Binder) (*Server, error) {
 	server := &Server{
 		listener: listener,
 		binder:   binder,
-		options:  options,
 	}
 	server.async.init()
 	go server.run(ctx)
@@ -90,94 +81,49 @@ func (s *Server) Wait() error {
 // duration, otherwise it exits only on error.
 func (s *Server) run(ctx context.Context) {
 	defer s.async.done()
-	// Max duration: ~290 years; surely that's long enough.
-	const forever = 1<<63 - 1
-	idleTimeout := s.options.IdleTimeout
-	if idleTimeout <= 0 {
-		idleTimeout = forever
-	}
-	idleTimer := time.NewTimer(idleTimeout)
-
-	// run a goroutine that listens for incoming connections and posts them
-	// back to the worker
-	newStreams := make(chan io.ReadWriteCloser)
-	go func() {
-		for {
-			// we never close the accepted connection, we rely on the other end
-			// closing or the socket closing itself naturally
-			rwc, err := s.listener.Accept(ctx)
-			if err != nil {
-				if !isClosingError(err) {
-					event.Error(ctx, "Accept", err)
-				}
-				// signal we are done generating new connections for good
-				close(newStreams)
-				return
-			}
-			newStreams <- rwc
-		}
-	}()
-
-	closedConns := make(chan struct{})
-	activeConns := 0
-	lnClosed := false
+	var activeConns []*Connection
 	for {
-		select {
-		case rwc := <-newStreams:
-			// whatever happes we are not idle anymore
-			idleTimer.Stop()
-			if rwc == nil {
-				// the net listener has been closed
-				lnClosed = true
-				if activeConns == 0 {
-					// accept is done and there are no active connections, so just stop now
-					return
-				}
-				// replace the channel with one that will never trigger
-				// this is save because the only writer has already quit
-				newStreams = nil
-				// and then wait for all active connections to stop
-				continue
+		// we never close the accepted connection, we rely on the other end
+		// closing or the socket closing itself naturally
+		rwc, err := s.listener.Accept(ctx)
+		if err != nil {
+			if !isClosingError(err) {
+				s.async.setError(err)
 			}
-			// a new inbound connection,
-			conn, err := newConnection(ctx, rwc, s.binder)
-			if err != nil {
-				if !isClosingError(err) {
-					event.Error(ctx, "NewConn", err)
-				}
-				continue
+			// we are done generating new connections for good
+			break
+		}
+
+		// see if any connections were closed while we were waiting
+		activeConns = onlyActive(activeConns)
+
+		// a new inbound connection,
+		conn, err := newConnection(ctx, rwc, s.binder)
+		if err != nil {
+			if !isClosingError(err) {
+				s.async.setError(err)
 			}
-			// register the new conn as active
-			activeConns++
-			// wrap the conn in a close monitor
-			//TODO: we do this to maintain our active count correctly, is there a better way?
-			go func() {
-				err := conn.Wait()
-				if err != nil && !isClosingError(err) {
-					event.Error(ctx, "closed a connection", err)
-				}
-				closedConns <- struct{}{}
-			}()
-		case <-closedConns:
-			activeConns--
-			if activeConns == 0 {
-				// no more active connections, restart the idle timer
-				if lnClosed {
-					// we can never get a new connection, so we are done
-					return
-				}
-				// we are idle, but might get a new connection still
-				idleTimer.Reset(idleTimeout)
-			}
-		case <-idleTimer.C:
-			// no activity for a while, time to stop serving
-			s.async.setError(ErrIdleTimeout)
-			return
-		case <-ctx.Done():
-			s.async.setError(ctx.Err())
-			return
+			continue
+		}
+		activeConns = append(activeConns, conn)
+	}
+
+	// wait for all active conns to finish
+	for _, c := range activeConns {
+		c.Wait()
+	}
+}
+
+func onlyActive(conns []*Connection) []*Connection {
+	i := 0
+	for _, c := range conns {
+		if !c.async.isDone() {
+			conns[i] = c
+			i++
 		}
 	}
+	// trim the slice down
+	return conns[:i]
 }
 
 // isClosingError reports if the error occurs normally during the process of
@@ -205,4 +151,115 @@ func isClosingError(err error) bool {
 	}
 
 	return false
+}
+
+// NewIdleListener wraps a listener with an idle timeout.
+// When there are no active connections for at least the timeout duration a
+// call to accept will fail with ErrIdleTimeout.
+func NewIdleListener(timeout time.Duration, wrap Listener) Listener {
+	l := &idleListener{
+		timeout:    timeout,
+		wrapped:    wrap,
+		newConns:   make(chan *idleCloser),
+		closed:     make(chan struct{}),
+		wasTimeout: make(chan struct{}),
+	}
+	go l.run()
+	return l
+}
+
+type idleListener struct {
+	wrapped    Listener
+	timeout    time.Duration
+	newConns   chan *idleCloser
+	closed     chan struct{}
+	wasTimeout chan struct{}
+	closeOnce  sync.Once
+}
+
+type idleCloser struct {
+	wrapped   io.ReadWriteCloser
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func (c *idleCloser) Read(p []byte) (int, error) {
+	n, err := c.wrapped.Read(p)
+	if err != nil && isClosingError(err) {
+		c.closeOnce.Do(func() { close(c.closed) })
+	}
+	return n, err
+}
+
+func (c *idleCloser) Write(p []byte) (int, error) {
+	// we do not close on write failure, we rely on the wrapped writer to do that
+	// if it is appropriate, which we will detect in the next read.
+	return c.wrapped.Write(p)
+}
+
+func (c *idleCloser) Close() error {
+	// we rely on closing the wrapped stream to signal to the next read that we
+	// are closed, rather than triggering the closed signal directly
+	return c.wrapped.Close()
+}
+
+func (l *idleListener) Accept(ctx context.Context) (io.ReadWriteCloser, error) {
+	rwc, err := l.wrapped.Accept(ctx)
+	if err != nil {
+		if isClosingError(err) {
+			// underlying listener was closed
+			l.closeOnce.Do(func() { close(l.closed) })
+			// was it closed because of the idle timeout?
+			select {
+			case <-l.wasTimeout:
+				err = ErrIdleTimeout
+			default:
+			}
+		}
+		return nil, err
+	}
+	conn := &idleCloser{
+		wrapped: rwc,
+		closed:  make(chan struct{}),
+	}
+	l.newConns <- conn
+	return conn, err
+}
+
+func (l *idleListener) Close() error {
+	defer l.closeOnce.Do(func() { close(l.closed) })
+	return l.wrapped.Close()
+}
+
+func (l *idleListener) Dialer() Dialer {
+	return l.wrapped.Dialer()
+}
+
+func (l *idleListener) run() {
+	var conns []*idleCloser
+	for {
+		var firstClosed chan struct{} // left at nil if there are no active conns
+		var timeout <-chan time.Time  // left at nil if there are  active conns
+		if len(conns) > 0 {
+			firstClosed = conns[0].closed
+		} else {
+			timeout = time.After(l.timeout)
+		}
+		select {
+		case <-l.closed:
+			// the main listener closed, no need to keep going
+			return
+		case conn := <-l.newConns:
+			// a new conn arrived, add it to the list
+			conns = append(conns, conn)
+		case <-timeout:
+			// we timed out, only happens when there are no active conns
+			// close the underlying listener, and allow the normal closing process to happen
+			close(l.wasTimeout)
+			l.wrapped.Close()
+		case <-firstClosed:
+			// a conn closed, remove it from the active list
+			conns = conns[:copy(conns, conns[1:])]
+		}
+	}
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
@@ -55,6 +55,26 @@ func (ph *packageHandle) packageKey() packageKey {
 	}
 }
 
+func (ph *packageHandle) imports(ctx context.Context, s source.Snapshot) (result []string) {
+	for _, pgh := range ph.goFiles {
+		f, err := s.ParseGo(ctx, pgh.file, source.ParseHeader)
+		if err != nil {
+			continue
+		}
+		seen := map[string]struct{}{}
+		for _, impSpec := range f.File.Imports {
+			imp := strings.Trim(impSpec.Path.Value, `"`)
+			if _, ok := seen[imp]; !ok {
+				seen[imp] = struct{}{}
+				result = append(result, imp)
+			}
+		}
+	}
+
+	sort.Strings(result)
+	return result
+}
+
 // packageData contains the data produced by type-checking a package.
 type packageData struct {
 	pkg *pkg

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
@@ -275,6 +275,8 @@ func (e *Editor) initialize(ctx context.Context, workspaceFolders []string) erro
 		params.ProcessID = int32(os.Getpid())
 	}
 
+	params.Capabilities.TextDocument.Completion.CompletionItem.SnippetSupport = true
+
 	// This is a bit of a hack, since the fake editor doesn't actually support
 	// watching changed files that match a specific glob pattern. However, the
 	// editor does send didChangeWatchedFiles notifications, so set this to

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/README.md
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/README.md
@@ -16,7 +16,7 @@ If you want to reproduce the existing files you need to be on a branch with the 
 
 Code is generated and normalized by
 
-`tsc code.ts && node code.js && gofmt -w ts*.go`
+`tsc && node code.js && gofmt -w ts*.go`
 
 (`code.ts` imports `util.ts`.) This generates 3 files in the current directory, `tsprotocol.go`
 containing type definitions, and `tsserver.go`, `tsclient.go` containing API stubs.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/tsconfig.json
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "isolatedModules": true,
+        "moduleResolution": "node",
+        "lib":["ES2020"],
+        "sourceMap": true, // sourceMap or inlineSourceMap? and see inlineSources
+        "target": "ES5",
+
+        "noFallthroughCasesInSwitch": false, // there is one legitimate on
+        "noImplicitReturns": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUncheckedIndexedAccess": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": false,
+        "noEmitOnError": true,
+
+        // "extendedDiagnostics": true, // for occasional amusement
+
+        // "strict": true, // too many undefineds in types, etc
+        "alwaysStrict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictBindCallApply": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": false, // doesn't like arrray access, among other things.
+        //"strictPropertyInitialization": true, // needs strictNullChecks
+    },
+    "files": ["./code.ts", "./util.ts"]
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/semantic.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/semantic.go
@@ -451,6 +451,15 @@ func (e *encoded) definitionFor(x *ast.Ident) (tokenType, []string) {
 		case *ast.InterfaceType:
 			return tokMember, mods
 		case *ast.TypeSpec:
+			// GenDecl/Typespec/FuncType/FieldList/Field/Ident
+			// (type A func(b uint64)) (err error)
+			// b and err should not be tokType, but tokVaraible
+			// and in GenDecl/TpeSpec/StructType/FieldList/Field/Ident
+			// (type A struct{b uint64})
+			fldm := e.stack[len(e.stack)-2]
+			if _, ok := fldm.(*ast.Field); ok {
+				return tokVariable, mods
+			}
 			return tokType, mods
 		}
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/snippet/snippet_builder.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/snippet/snippet_builder.go
@@ -46,6 +46,10 @@ func (b *Builder) PrependText(s string) {
 	b.sb.WriteString(rawSnip)
 }
 
+func (b *Builder) Write(data []byte) (int, error) {
+	return b.sb.Write(data)
+}
+
 // WritePlaceholder writes a tab stop and placeholder value to the Builder.
 // The callback style allows for creating nested placeholders. To write an
 // empty tab stop, provide a nil callback.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -222,6 +222,19 @@ var GeneratedAPIJSON = &APIJSON{
 				Hierarchy: "ui.completion",
 			},
 			{
+				Name: "experimentalPostfixCompletions",
+				Type: "bool",
+				Doc:  "experimentalPostfixCompletions enables artifical method snippets\nsuch as \"someSlice.sort!\".\n",
+				EnumKeys: EnumKeys{
+					ValueType: "",
+					Keys:      nil,
+				},
+				EnumValues: nil,
+				Default:    "false",
+				Status:     "experimental",
+				Hierarchy:  "ui.completion",
+			},
+			{
 				Name: "importShortcut",
 				Type: "enum",
 				Doc:  "importShortcut specifies whether import statements should link to\ndocumentation or go to definitions.\n",

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
@@ -96,6 +96,7 @@ type completionOptions struct {
 	placeholders      bool
 	literal           bool
 	snippets          bool
+	postfix           bool
 	matcher           source.Matcher
 	budget            time.Duration
 }
@@ -521,6 +522,7 @@ func Completion(ctx context.Context, snapshot source.Snapshot, fh source.FileHan
 			literal:           opts.LiteralCompletions && opts.InsertTextFormat == protocol.SnippetTextFormat,
 			budget:            opts.CompletionBudget,
 			snippets:          opts.InsertTextFormat == protocol.SnippetTextFormat,
+			postfix:           opts.ExperimentalPostfixCompletions,
 		},
 		// default to a matcher that always matches
 		matcher:        prefixMatcher(""),
@@ -1104,6 +1106,9 @@ func (c *completer) selector(ctx context.Context, sel *ast.SelectorExpr) error {
 		for _, cand := range candidates {
 			c.deepState.enqueue(cand)
 		}
+
+		c.addPostfixSnippetCandidates(ctx, sel)
+
 		return nil
 	}
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/format.go
@@ -158,7 +158,7 @@ func (c *completer) item(ctx context.Context, cand candidate) (CompletionItem, e
 	if prefix != "" {
 		// If we are in a selector, add an edit to place prefix before selector.
 		if sel := enclosingSelector(c.path, c.pos); sel != nil {
-			edits, err := prependEdit(c.snapshot.FileSet(), c.mapper, sel, prefix)
+			edits, err := c.editText(sel.Pos(), sel.Pos(), prefix)
 			if err != nil {
 				return CompletionItem{}, err
 			}
@@ -229,7 +229,7 @@ func (c *completer) item(ctx context.Context, cand candidate) (CompletionItem, e
 		return item, nil
 	}
 
-	hover, err := source.HoverInfo(ctx, pkg, obj, decl)
+	hover, err := source.HoverInfo(ctx, c.snapshot, pkg, obj, decl)
 	if err != nil {
 		event.Error(ctx, "failed to find Hover", err, tag.URI.Of(uri))
 		return item, nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/literal.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/literal.go
@@ -7,14 +7,11 @@ package completion
 import (
 	"context"
 	"fmt"
-	"go/ast"
-	"go/token"
 	"go/types"
 	"strings"
 	"unicode"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
-	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/diff"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/snippet"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
@@ -111,7 +108,7 @@ func (c *completer) literal(ctx context.Context, literalType types.Type, imp *im
 				// If we are in a selector we must place the "&" before the selector.
 				// For example, "foo.B<>" must complete to "&foo.Bar{}", not
 				// "foo.&Bar{}".
-				edits, err := prependEdit(c.snapshot.FileSet(), c.mapper, sel, "&")
+				edits, err := c.editText(sel.Pos(), sel.Pos(), "&")
 				if err != nil {
 					event.Error(ctx, "error making edit for literal pointer completion", err)
 					return
@@ -166,20 +163,6 @@ func (c *completer) literal(ctx context.Context, literalType types.Type, imp *im
 			c.functionLiteral(ctx, t, float64(score))
 		}
 	}
-}
-
-// prependEdit produces text edits that preprend the specified prefix
-// to the specified node.
-func prependEdit(fset *token.FileSet, m *protocol.ColumnMapper, node ast.Node, prefix string) ([]protocol.TextEdit, error) {
-	rng := source.NewMappedRange(fset, m, node.Pos(), node.Pos())
-	spn, err := rng.Span()
-	if err != nil {
-		return nil, err
-	}
-	return source.ToProtocolEdits(m, []diff.TextEdit{{
-		Span:    spn,
-		NewText: prefix,
-	}})
 }
 
 // literalCandidateScore is the base score for literal candidates.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/postfix_snippets.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/postfix_snippets.go
@@ -1,0 +1,436 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package completion
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"log"
+	"reflect"
+	"strings"
+	"sync"
+	"text/template"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/imports"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/snippet"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	errors "golang.org/x/xerrors"
+)
+
+// Postfix snippets are artificial methods that allow the user to
+// compose common operations in an "argument oriented" fashion. For
+// example, instead of "sort.Slice(someSlice, ...)" a user can expand
+// "someSlice.sort!".
+
+// postfixTmpl represents a postfix snippet completion candidate.
+type postfixTmpl struct {
+	// label is the completion candidate's label presented to the user.
+	label string
+
+	// details is passed along to the client as the candidate's details.
+	details string
+
+	// body is the template text. See postfixTmplArgs for details on the
+	// facilities available to the template.
+	body string
+
+	tmpl *template.Template
+}
+
+// postfixTmplArgs are the template execution arguments available to
+// the postfix snippet templates.
+type postfixTmplArgs struct {
+	// StmtOK is true if it is valid to replace the selector with a
+	// statement. For example:
+	//
+	//    func foo() {
+	//      bar.sort! // statement okay
+	//
+	//      someMethod(bar.sort!) // statement not okay
+	//    }
+	StmtOK bool
+
+	// X is the textual SelectorExpr.X. For example, when completing
+	// "foo.bar.print!", "X" is "foo.bar".
+	X string
+
+	// Obj is the types.Object of SelectorExpr.X, if any.
+	Obj types.Object
+
+	// Type is the type of "foo.bar" in "foo.bar.print!".
+	Type types.Type
+
+	scope          *types.Scope
+	snip           snippet.Builder
+	importIfNeeded func(pkgPath string, scope *types.Scope) (name string, edits []protocol.TextEdit, err error)
+	edits          []protocol.TextEdit
+	qf             types.Qualifier
+	varNames       map[string]bool
+}
+
+var postfixTmpls = []postfixTmpl{{
+	label:   "sort",
+	details: "sort.Slice()",
+	body: `{{if and (eq .Kind "slice") .StmtOK -}}
+{{.Import "sort"}}.Slice({{.X}}, func({{.VarName nil "i"}}, {{.VarName nil "j"}} int) bool {
+	{{.Cursor}}
+})
+{{- end}}`,
+}, {
+	label:   "last",
+	details: "s[len(s)-1]",
+	body: `{{if and (eq .Kind "slice") .Obj -}}
+{{.X}}[len({{.X}})-1]
+{{- end}}`,
+}, {
+	label:   "reverse",
+	details: "reverse slice",
+	body: `{{if and (eq .Kind "slice") .StmtOK -}}
+{{$i := .VarName nil "i"}}{{$j := .VarName nil "j" -}}
+for {{$i}}, {{$j}} := 0, len({{.X}})-1; {{$i}} < {{$j}}; {{$i}}, {{$j}} = {{$i}}+1, {{$j}}-1 {
+	{{.X}}[{{$i}}], {{.X}}[{{$j}}] = {{.X}}[{{$j}}], {{.X}}[{{$i}}]
+}
+{{end}}`,
+}, {
+	label:   "range",
+	details: "range over slice",
+	body: `{{if and (eq .Kind "slice") .StmtOK -}}
+for {{.VarName nil "i"}}, {{.VarName .ElemType "v"}} := range {{.X}} {
+	{{.Cursor}}
+}
+{{- end}}`,
+}, {
+	label:   "append",
+	details: "append and re-assign slice",
+	body: `{{if and (eq .Kind "slice") .StmtOK .Obj -}}
+{{.X}} = append({{.X}}, {{.Cursor}})
+{{- end}}`,
+}, {
+	label:   "append",
+	details: "append to slice",
+	body: `{{if and (eq .Kind "slice") (not .StmtOK) -}}
+append({{.X}}, {{.Cursor}})
+{{- end}}`,
+}, {
+	label:   "copy",
+	details: "duplicate slice",
+	body: `{{if and (eq .Kind "slice") .StmtOK .Obj -}}
+{{$v := (.VarName nil (printf "%sCopy" .X))}}{{$v}} := make([]{{.TypeName .ElemType}}, len({{.X}}))
+copy({{$v}}, {{.X}})
+{{end}}`,
+}, {
+	label:   "range",
+	details: "range over map",
+	body: `{{if and (eq .Kind "map") .StmtOK -}}
+for {{.VarName .KeyType "k"}}, {{.VarName .ElemType "v"}} := range {{.X}} {
+	{{.Cursor}}
+}
+{{- end}}`,
+}, {
+	label:   "clear",
+	details: "clear map contents",
+	body: `{{if and (eq .Kind "map") .StmtOK -}}
+{{$k := (.VarName .KeyType "k")}}for {{$k}} := range {{.X}} {
+	delete({{.X}}, {{$k}})
+}
+{{end}}`,
+}, {
+	label:   "keys",
+	details: "create slice of keys",
+	body: `{{if and (eq .Kind "map") .StmtOK -}}
+{{$keysVar := (.VarName nil "keys")}}{{$keysVar}} := make([]{{.TypeName .KeyType}}, 0, len({{.X}}))
+{{$k := (.VarName .KeyType "k")}}for {{$k}} := range {{.X}} {
+	{{$keysVar}} = append({{$keysVar}}, {{$k}})
+}
+{{end}}`,
+}, {
+	label:   "var",
+	details: "assign to variables",
+	body: `{{if and (eq .Kind "tuple") .StmtOK -}}
+{{$a := .}}{{range $i, $v := .Tuple}}{{if $i}}, {{end}}{{$a.VarName $v.Type $v.Name}}{{end}} := {{.X}}
+{{- end}}`,
+}, {
+	label:   "var",
+	details: "assign to variable",
+	body: `{{if and (ne .Kind "tuple") .StmtOK -}}
+{{.VarName .Type ""}} := {{.X}}
+{{- end}}`,
+}, {
+	label:   "print",
+	details: "print to stdout",
+	body: `{{if and (ne .Kind "tuple") .StmtOK -}}
+{{.Import "fmt"}}.Printf("{{.EscapeQuotes .X}}: %v\n", {{.X}})
+{{- end}}`,
+}, {
+	label:   "print",
+	details: "print to stdout",
+	body: `{{if and (eq .Kind "tuple") .StmtOK -}}
+{{.Import "fmt"}}.Println({{.X}})
+{{- end}}`,
+}}
+
+// Cursor indicates where the client's cursor should end up after the
+// snippet is done.
+func (a *postfixTmplArgs) Cursor() string {
+	a.snip.WriteFinalTabstop()
+	return ""
+}
+
+// Import makes sure the package corresponding to path is imported,
+// returning the identifier to use to refer to the package.
+func (a *postfixTmplArgs) Import(path string) (string, error) {
+	name, edits, err := a.importIfNeeded(path, a.scope)
+	if err != nil {
+		return "", errors.Errorf("couldn't import %q: %w", path, err)
+	}
+	a.edits = append(a.edits, edits...)
+	return name, nil
+}
+
+func (a *postfixTmplArgs) EscapeQuotes(v string) string {
+	return strings.ReplaceAll(v, `"`, `\\"`)
+}
+
+// ElemType returns the Elem() type of xType, if applicable.
+func (a *postfixTmplArgs) ElemType() types.Type {
+	if e, _ := a.Type.(interface{ Elem() types.Type }); e != nil {
+		return e.Elem()
+	}
+	return nil
+}
+
+// Kind returns the underlying kind of type, e.g. "slice", "struct",
+// etc.
+func (a *postfixTmplArgs) Kind() string {
+	t := reflect.TypeOf(a.Type.Underlying())
+	return strings.ToLower(strings.TrimPrefix(t.String(), "*types."))
+}
+
+// KeyType returns the type of X's key. KeyType panics if X is not a
+// map.
+func (a *postfixTmplArgs) KeyType() types.Type {
+	return a.Type.Underlying().(*types.Map).Key()
+}
+
+// Tuple returns the tuple result vars if X is a call expression.
+func (a *postfixTmplArgs) Tuple() []*types.Var {
+	tuple, _ := a.Type.(*types.Tuple)
+	if tuple == nil {
+		return nil
+	}
+
+	typs := make([]*types.Var, 0, tuple.Len())
+	for i := 0; i < tuple.Len(); i++ {
+		typs = append(typs, tuple.At(i))
+	}
+	return typs
+}
+
+// TypeName returns the textual representation of type t.
+func (a *postfixTmplArgs) TypeName(t types.Type) (string, error) {
+	if t == nil || t == types.Typ[types.Invalid] {
+		return "", fmt.Errorf("invalid type: %v", t)
+	}
+	return types.TypeString(t, a.qf), nil
+}
+
+// VarName returns a suitable variable name for the type t. If t
+// implements the error interface, "err" is used. If t is not a named
+// type then nonNamedDefault is used. Otherwise a name is made by
+// abbreviating the type name. If the resultant name is already in
+// scope, an integer is appended to make a unique name.
+func (a *postfixTmplArgs) VarName(t types.Type, nonNamedDefault string) string {
+	if t == nil {
+		t = types.Typ[types.Invalid]
+	}
+
+	var name string
+	if types.Implements(t, errorIntf) {
+		name = "err"
+	} else if _, isNamed := source.Deref(t).(*types.Named); !isNamed {
+		name = nonNamedDefault
+	}
+
+	if name == "" {
+		name = types.TypeString(t, func(p *types.Package) string {
+			return ""
+		})
+		name = abbreviateTypeName(name)
+	}
+
+	if dot := strings.LastIndex(name, "."); dot > -1 {
+		name = name[dot+1:]
+	}
+
+	uniqueName := name
+	for i := 2; ; i++ {
+		if s, _ := a.scope.LookupParent(uniqueName, token.NoPos); s == nil && !a.varNames[uniqueName] {
+			break
+		}
+		uniqueName = fmt.Sprintf("%s%d", name, i)
+	}
+
+	a.varNames[uniqueName] = true
+
+	return uniqueName
+}
+
+func (c *completer) addPostfixSnippetCandidates(ctx context.Context, sel *ast.SelectorExpr) {
+	if !c.opts.postfix {
+		return
+	}
+
+	initPostfixRules()
+
+	if sel == nil || sel.Sel == nil {
+		return
+	}
+
+	selType := c.pkg.GetTypesInfo().TypeOf(sel.X)
+	if selType == nil {
+		return
+	}
+
+	// Skip empty tuples since there is no value to operate on.
+	if tuple, ok := selType.Underlying().(*types.Tuple); ok && tuple == nil {
+		return
+	}
+
+	// Only replace sel with a statement if sel is already a statement.
+	var stmtOK bool
+	for i, n := range c.path {
+		if n == sel && i < len(c.path)-1 {
+			_, stmtOK = c.path[i+1].(*ast.ExprStmt)
+			break
+		}
+	}
+
+	scope := c.pkg.GetTypes().Scope().Innermost(c.pos)
+	if scope == nil {
+		return
+	}
+
+	// afterDot is the position after selector dot, e.g. "|" in
+	// "foo.|print".
+	afterDot := sel.Sel.Pos()
+
+	// We must detect dangling selectors such as:
+	//
+	//    foo.<>
+	//    bar
+	//
+	// and adjust afterDot so that we don't mistakenly delete the
+	// newline thinking "bar" is part of our selector.
+	tokFile := c.snapshot.FileSet().File(c.pos)
+	if startLine := tokFile.Line(sel.Pos()); startLine != tokFile.Line(afterDot) {
+		if tokFile.Line(c.pos) != startLine {
+			return
+		}
+		afterDot = c.pos
+	}
+
+	for _, rule := range postfixTmpls {
+		// When completing foo.print<>, "print" is naturally overwritten,
+		// but we need to also remove "foo." so the snippet has a clean
+		// slate.
+		edits, err := c.editText(sel.Pos(), afterDot, "")
+		if err != nil {
+			event.Error(ctx, "error calculating postfix edits", err)
+			return
+		}
+
+		tmplArgs := postfixTmplArgs{
+			X:              source.FormatNode(c.snapshot.FileSet(), sel.X),
+			StmtOK:         stmtOK,
+			Obj:            exprObj(c.pkg.GetTypesInfo(), sel.X),
+			Type:           selType,
+			qf:             c.qf,
+			importIfNeeded: c.importIfNeeded,
+			scope:          scope,
+			varNames:       make(map[string]bool),
+		}
+
+		// Feed the template straight into the snippet builder. This
+		// allows templates to build snippets as they are executed.
+		err = rule.tmpl.Execute(&tmplArgs.snip, &tmplArgs)
+		if err != nil {
+			event.Error(ctx, "error executing postfix template", err)
+			continue
+		}
+
+		if strings.TrimSpace(tmplArgs.snip.String()) == "" {
+			continue
+		}
+
+		score := c.matcher.Score(rule.label)
+		if score <= 0 {
+			continue
+		}
+
+		c.items = append(c.items, CompletionItem{
+			Label:               rule.label + "!",
+			Detail:              rule.details,
+			Score:               float64(score) * 0.01,
+			Kind:                protocol.SnippetCompletion,
+			snippet:             &tmplArgs.snip,
+			AdditionalTextEdits: append(edits, tmplArgs.edits...),
+		})
+	}
+}
+
+var postfixRulesOnce sync.Once
+
+func initPostfixRules() {
+	postfixRulesOnce.Do(func() {
+		var idx int
+		for _, rule := range postfixTmpls {
+			var err error
+			rule.tmpl, err = template.New("postfix_snippet").Parse(rule.body)
+			if err != nil {
+				log.Panicf("error parsing postfix snippet template: %v", err)
+			}
+			postfixTmpls[idx] = rule
+			idx++
+		}
+		postfixTmpls = postfixTmpls[:idx]
+	})
+}
+
+// importIfNeeded returns the package identifier and any necessary
+// edits to import package pkgPath.
+func (c *completer) importIfNeeded(pkgPath string, scope *types.Scope) (string, []protocol.TextEdit, error) {
+	defaultName := imports.ImportPathToAssumedName(pkgPath)
+
+	// Check if file already imports pkgPath.
+	for _, s := range c.file.Imports {
+		if source.ImportPath(s) == pkgPath {
+			if s.Name == nil {
+				return defaultName, nil, nil
+			}
+			if s.Name.Name != "_" {
+				return s.Name.Name, nil, nil
+			}
+		}
+	}
+
+	// Give up if the package's name is already in use by another object.
+	if _, obj := scope.LookupParent(defaultName, token.NoPos); obj != nil {
+		return "", nil, fmt.Errorf("import name %q of %q already in use", defaultName, pkgPath)
+	}
+
+	edits, err := c.importEdits(&importInfo{
+		importPath: pkgPath,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
+	return defaultName, edits, nil
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/util.go
@@ -9,6 +9,8 @@ import (
 	"go/token"
 	"go/types"
 
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/diff"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 )
 
@@ -309,4 +311,16 @@ func formatZeroValue(T types.Type, qf types.Qualifier) string {
 func isBasicKind(t types.Type, k types.BasicInfo) bool {
 	b, _ := t.Underlying().(*types.Basic)
 	return b != nil && b.Info()&k > 0
+}
+
+func (c *completer) editText(from, to token.Pos, newText string) ([]protocol.TextEdit, error) {
+	rng := source.NewMappedRange(c.snapshot.FileSet(), c.mapper, from, to)
+	spn, err := rng.Span()
+	if err != nil {
+		return nil, err
+	}
+	return source.ToProtocolEdits(c.mapper, []diff.TextEdit{{
+		Span:    spn,
+		NewText: newText,
+	}})
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/extract.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/extract.go
@@ -276,6 +276,10 @@ func extractFunction(fset *token.FileSet, rng span.Range, src []byte, file *ast.
 		if _, ok := seenVars[v.obj]; ok {
 			continue
 		}
+		if v.obj.Name() == "_" {
+			// The blank identifier is always a local variable
+			continue
+		}
 		typ := analysisinternal.TypeExpr(fset, file, pkg, v.obj.Type())
 		if typ == nil {
 			return nil, fmt.Errorf("nil AST expression for type: %v", v.obj.Name())

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/hover.go
@@ -12,12 +12,14 @@ import (
 	"go/constant"
 	"go/doc"
 	"go/format"
+	"go/token"
 	"go/types"
 	"strings"
 	"time"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	errors "golang.org/x/xerrors"
 )
 
@@ -93,7 +95,7 @@ func HoverIdentifier(ctx context.Context, i *IdentifierInfo) (*HoverInformation,
 	defer done()
 
 	fset := i.Snapshot.FileSet()
-	h, err := HoverInfo(ctx, i.pkg, i.Declaration.obj, i.Declaration.node)
+	h, err := HoverInfo(ctx, i.Snapshot, i.pkg, i.Declaration.obj, i.Declaration.node)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +254,7 @@ func objectString(obj types.Object, qf types.Qualifier) string {
 
 // HoverInfo returns a HoverInformation struct for an ast node and its type
 // object.
-func HoverInfo(ctx context.Context, pkg Package, obj types.Object, node ast.Node) (*HoverInformation, error) {
+func HoverInfo(ctx context.Context, s Snapshot, pkg Package, obj types.Object, node ast.Node) (*HoverInformation, error) {
 	var info *HoverInformation
 
 	switch node := node.(type) {
@@ -304,6 +306,35 @@ func HoverInfo(ctx context.Context, pkg Package, obj types.Object, node ast.Node
 			info = &HoverInformation{source: obj, comment: node.Doc}
 		case *types.Builtin:
 			info = &HoverInformation{source: node.Type, comment: node.Doc}
+		case *types.Var:
+			// Object is a function param or the field of an anonymous struct
+			// declared with ':='. Skip the first one because only fields
+			// can have docs.
+			if isFunctionParam(obj, node) {
+				break
+			}
+
+			f := s.FileSet().File(obj.Pos())
+			if f == nil {
+				break
+			}
+
+			pgf, err := pkg.File(span.URIFromPath(f.Name()))
+			if err != nil {
+				return nil, err
+			}
+			posToField, err := s.PosToField(ctx, pgf)
+			if err != nil {
+				return nil, err
+			}
+
+			if field := posToField[obj.Pos()]; field != nil {
+				comment := field.Doc
+				if comment.Text() == "" {
+					comment = field.Comment
+				}
+				info = &HoverInformation{source: obj, comment: comment}
+			}
 		}
 	}
 
@@ -317,6 +348,24 @@ func HoverInfo(ctx context.Context, pkg Package, obj types.Object, node ast.Node
 	}
 
 	return info, nil
+}
+
+// isFunctionParam returns true if the passed object is either an incoming
+// or an outgoing function param
+func isFunctionParam(obj types.Object, node *ast.FuncDecl) bool {
+	for _, f := range node.Type.Params.List {
+		if f.Pos() == obj.Pos() {
+			return true
+		}
+	}
+	if node.Type.Results != nil {
+		for _, f := range node.Type.Results.List {
+			if f.Pos() == obj.Pos() {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func formatGenDecl(node *ast.GenDecl, obj types.Object, typ types.Type) (*HoverInformation, error) {
@@ -370,6 +419,11 @@ func formatVar(node ast.Spec, obj types.Object, decl *ast.GenDecl) *HoverInforma
 			fieldList = t.Methods
 		}
 	case *ast.ValueSpec:
+		// Try to extract the field list of an anonymous struct
+		if fieldList = extractFieldList(spec.Type); fieldList != nil {
+			break
+		}
+
 		comment := spec.Doc
 		if comment == nil {
 			comment = decl.Doc
@@ -379,20 +433,55 @@ func formatVar(node ast.Spec, obj types.Object, decl *ast.GenDecl) *HoverInforma
 		}
 		return &HoverInformation{source: obj, comment: comment}
 	}
-	// If we have a struct or interface declaration,
-	// we need to match the object to the corresponding field or method.
+
 	if fieldList != nil {
-		for i := 0; i < len(fieldList.List); i++ {
-			field := fieldList.List[i]
-			if field.Pos() <= obj.Pos() && obj.Pos() <= field.End() {
-				if field.Doc.Text() != "" {
-					return &HoverInformation{source: obj, comment: field.Doc}
-				}
-				return &HoverInformation{source: obj, comment: field.Comment}
+		comment := findFieldComment(obj.Pos(), fieldList)
+		return &HoverInformation{source: obj, comment: comment}
+	}
+	return &HoverInformation{source: obj, comment: decl.Doc}
+}
+
+// extractFieldList recursively tries to extract a field list.
+// If it is not found, nil is returned.
+func extractFieldList(specType ast.Expr) *ast.FieldList {
+	switch t := specType.(type) {
+	case *ast.StructType:
+		return t.Fields
+	case *ast.InterfaceType:
+		return t.Methods
+	case *ast.ArrayType:
+		return extractFieldList(t.Elt)
+	case *ast.MapType:
+		// Map value has a greater chance to be a struct
+		if fields := extractFieldList(t.Value); fields != nil {
+			return fields
+		}
+		return extractFieldList(t.Key)
+	case *ast.ChanType:
+		return extractFieldList(t.Value)
+	}
+	return nil
+}
+
+// findFieldComment visits all fields in depth-first order and returns
+// the comment of a field with passed position. If no comment is found,
+// nil is returned.
+func findFieldComment(pos token.Pos, fieldList *ast.FieldList) *ast.CommentGroup {
+	for _, field := range fieldList.List {
+		if field.Pos() == pos {
+			if field.Doc.Text() != "" {
+				return field.Doc
+			}
+			return field.Comment
+		}
+
+		if nestedFieldList := extractFieldList(field.Type); nestedFieldList != nil {
+			if c := findFieldComment(pos, nestedFieldList); c != nil {
+				return c
 			}
 		}
 	}
-	return &HoverInformation{source: obj, comment: decl.Doc}
+	return nil
 }
 
 func FormatHover(h *HoverInformation, options *Options) (string, error) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/identifier.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/identifier.go
@@ -323,6 +323,12 @@ func typeToObject(typ types.Type) types.Object {
 		return typ.Obj()
 	case *types.Pointer:
 		return typeToObject(typ.Elem())
+	case *types.Array:
+		return typeToObject(typ.Elem())
+	case *types.Slice:
+		return typeToObject(typ.Elem())
+	case *types.Chan:
+		return typeToObject(typ.Elem())
 	default:
 		return nil
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
@@ -129,8 +129,9 @@ func DefaultOptions() *Options {
 						SymbolStyle:    DynamicSymbols,
 					},
 					CompletionOptions: CompletionOptions{
-						Matcher:          Fuzzy,
-						CompletionBudget: 100 * time.Millisecond,
+						Matcher:                        Fuzzy,
+						CompletionBudget:               100 * time.Millisecond,
+						ExperimentalPostfixCompletions: false,
 					},
 					Codelenses: map[string]bool{
 						string(command.Generate):          true,
@@ -293,6 +294,10 @@ type CompletionOptions struct {
 	// Matcher sets the algorithm that is used when calculating completion
 	// candidates.
 	Matcher Matcher `status:"advanced"`
+
+	// ExperimentalPostfixCompletions enables artifical method snippets
+	// such as "someSlice.sort!".
+	ExperimentalPostfixCompletions bool `status:"experimental"`
 }
 
 type DocumentationOptions struct {
@@ -681,6 +686,7 @@ func (o *Options) AddStaticcheckAnalyzer(a *analysis.Analyzer) {
 // should be enabled in enableAllExperimentMaps.
 func (o *Options) enableAllExperiments() {
 	o.SemanticTokens = true
+	o.ExperimentalPostfixCompletions = true
 }
 
 func (o *Options) enableAllExperimentMaps() {
@@ -851,6 +857,9 @@ func (o *Options) set(name string, value interface{}, seen map[string]struct{}) 
 
 	case "expandWorkspaceToModule":
 		result.setBool(&o.ExpandWorkspaceToModule)
+
+	case "experimentalPostfixCompletions":
+		result.setBool(&o.ExperimentalPostfixCompletions)
 
 	case "experimentalWorkspaceModule":
 		result.setBool(&o.ExperimentalWorkspaceModule)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/signature_help.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/signature_help.go
@@ -106,7 +106,7 @@ FindCall:
 			node: node,
 		}
 		decl.MappedRange = append(decl.MappedRange, rng)
-		d, err := HoverInfo(ctx, pkg, decl.obj, decl.node)
+		d, err := HoverInfo(ctx, snapshot, pkg, decl.obj, decl.node)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/tests/README.md
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/tests/README.md
@@ -52,7 +52,7 @@ path and heading into a -run argument:
 
 ```bash
 cd /path/to/tools
-go test ./internal/lsp -v -run TestLSP/Modules/SuggestedFix/bar_11_21
+go test ./internal/lsp/... -v -run TestLSP/Modules/SuggestedFix/bar_11_21
 ```
 
 ## Resetting marker tests

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.1
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
-	golang.org/x/tools v0.1.1-0.20210325171239-63ea654b4772
-	golang.org/x/tools/gopls v0.0.0-20210325171239-63ea654b4772
+	golang.org/x/tools v0.1.1-0.20210330233337-8c34cc9cafff
+	golang.org/x/tools/gopls v0.0.0-20210330233337-8c34cc9cafff
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1-0.20210325171239-63ea654b4772 h1:N6R6eoOZwoN0PGgMQ90Fo4UBoBB9gDV6VCrNRd4dpU4=
-golang.org/x/tools v0.1.1-0.20210325171239-63ea654b4772/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
-golang.org/x/tools/gopls v0.0.0-20210325171239-63ea654b4772 h1:iyzmFHxfibKeR9LYpv5r+Z2D3SYQNbuf7bBvCyRFzvo=
-golang.org/x/tools/gopls v0.0.0-20210325171239-63ea654b4772/go.mod h1:irFua8x32R9RfrLUCEiXS9IGJrvAs7Mjrm6i7Tdk0Mo=
+golang.org/x/tools v0.1.1-0.20210330233337-8c34cc9cafff h1:JjeR58X9u2XmSjp9AW/45UKXYvyUGcx9g21YORznUgI=
+golang.org/x/tools v0.1.1-0.20210330233337-8c34cc9cafff/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
+golang.org/x/tools/gopls v0.0.0-20210330233337-8c34cc9cafff h1:3ioCP1CTlltHQJGCG0EfqGnAwBSnKHVI3jZRVueJXQE=
+golang.org/x/tools/gopls v0.0.0-20210330233337-8c34cc9cafff/go.mod h1:irFua8x32R9RfrLUCEiXS9IGJrvAs7Mjrm6i7Tdk0Mo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/lsp/cache: fix race condition in snapshot's initializedErr 8c34cc9c
* gopls/internal/regtest: re-enable the gc_details regtest for -short 0deaffd2
* internal/lsp/source: respond with the underlying type to Type Definition requests for composite types af364066
* godoc/static: link to golang.org for content moved out of Go root 682c7e60
* internal/lsp/semantic: fix some type definitions ca627f83
* internal/lsp/protocol/typescript: small cleanups and add tsconfig.json 04595890
* internal/jsonrpc2_v2: move the idle timeout handling out of the server b0e994dc
* internal/lsp: remove unnecessary call to WorkspacePackages in mod tidy 95535753
* internal/lsp/source: fix docs for fields of anonymous structs/interfaces 769264cf
* internal/lsp/source: skip blank identifiers during the function extraction cb7d5993
* internal/lsp/completion: move postfix completions behind option 94a19427
* internal/lsp/source/completion: add postfix snippet completions 09058ab0
* internal/event/label: prevent unsafe get of non-string 2c039f7f
* go/analysis/passes/inspect: fix typo in comment 4c8e4a8b