### PR TITLE
cmd/govim: workaround golang/go#45377

### DIFF
--- a/cmd/govim/gopls.go
+++ b/cmd/govim/gopls.go
@@ -32,6 +32,8 @@ func (g *govimplugin) startGopls() error {
 
 		g.ChannelExf("let s:gopls_logfile=%q", logfile.Name())
 		goplsArgs = append(goplsArgs, "-logfile", logfile.Name())
+	} else {
+		goplsArgs = append(goplsArgs, "-logfile", os.DevNull)
 	}
 
 	if flags, err := util.Split(os.Getenv(string(config.EnvVarGoplsFlags))); err != nil {


### PR DESCRIPTION
Workaround golang/go#45377 by having gopls log to os.DevNull in case we
don't need gopls logging from a govim perspective.