### PR TITLE
deps: update x/tools and gopls to 0243799c

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
@@ -200,14 +200,10 @@ func (s *snapshot) config(ctx context.Context, inv *gocommand.Invocation) *packa
 	verboseOutput := s.view.options.VerboseOutput
 	s.view.optionsMu.Unlock()
 
-	// Forcibly disable GOPACKAGESDRIVER. It's incompatible with the
-	// packagesinternal APIs we use, and we really only support the go command
-	// anyway.
-	env := append(append([]string{}, inv.Env...), "GOPACKAGESDRIVER=off")
 	cfg := &packages.Config{
 		Context:    ctx,
 		Dir:        inv.WorkingDir,
-		Env:        env,
+		Env:        inv.Env,
 		BuildFlags: inv.BuildFlags,
 		Mode: packages.NeedName |
 			packages.NeedFiles |

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
@@ -1094,3 +1094,17 @@ func (e *Editor) DocumentLink(ctx context.Context, path string) ([]protocol.Docu
 	params.TextDocument.URI = e.sandbox.Workdir.URI(path)
 	return e.Server.DocumentLink(ctx, params)
 }
+
+func (e *Editor) DocumentHighlight(ctx context.Context, path string, pos Pos) ([]protocol.DocumentHighlight, error) {
+	if e.Server == nil {
+		return nil, nil
+	}
+	if err := e.checkBufferPosition(path, pos); err != nil {
+		return nil, err
+	}
+	params := &protocol.DocumentHighlightParams{}
+	params.TextDocument.URI = e.sandbox.Workdir.URI(path)
+	params.Position = pos.ToProtocolPosition()
+
+	return e.Server.DocumentHighlight(ctx, params)
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/code_lens.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/code_lens.go
@@ -50,7 +50,7 @@ func upgradeLenses(ctx context.Context, snapshot source.Snapshot, fh source.File
 	upgradeTransitive, err := command.NewUpgradeDependencyCommand("Upgrade transitive dependencies", command.DependencyArgs{
 		URI:        uri,
 		AddRequire: false,
-		GoCmdArgs:  []string{"-u", "all"},
+		GoCmdArgs:  []string{"-d", "-u", "-t", "./..."},
 	})
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func upgradeLenses(ctx context.Context, snapshot source.Snapshot, fh source.File
 	upgradeDirect, err := command.NewUpgradeDependencyCommand("Upgrade direct dependencies", command.DependencyArgs{
 		URI:        uri,
 		AddRequire: false,
-		GoCmdArgs:  requires,
+		GoCmdArgs:  append([]string{"-d"}, requires...),
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -34,7 +34,7 @@ var GeneratedAPIJSON = &APIJSON{
 			{
 				Name: "directoryFilters",
 				Type: "[]string",
-				Doc:  "directoryFilters can be used to exclude unwanted directories from the\nworkspace. By default, all directories are included. Filters are an\noperator, `+` to include and `-` to exclude, followed by a path prefix\nrelative to the workspace folder. They are evaluated in order, and\nthe last filter that applies to a path controls whether it is included.\nThe path prefix can be empty, so an initial `-` excludes everything.\n\nExamples:\nExclude node_modules: `-node_modules`\nInclude only project_a: `-` (exclude everything), `+project_a`\nInclude only project_a, but not node_modules inside it: `-`, `+project_a`, `-project_a/node_modules`\n",
+				Doc:  "directoryFilters can be used to exclude unwanted directories from the\nworkspace. By default, all directories are included. Filters are an\noperator, `+` to include and `-` to exclude, followed by a path prefix\nrelative to the workspace folder. They are evaluated in order, and\nthe last filter that applies to a path controls whether it is included.\nThe path prefix can be empty, so an initial `-` excludes everything.\n\nExamples:\n\nExclude node_modules: `-node_modules`\n\nInclude only project_a: `-` (exclude everything), `+project_a`\n\nInclude only project_a, but not node_modules inside it: `-`, `+project_a`, `-project_a/node_modules`\n",
 				EnumKeys: EnumKeys{
 					ValueType: "",
 					Keys:      nil,

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
@@ -213,8 +213,11 @@ type BuildOptions struct {
 	// The path prefix can be empty, so an initial `-` excludes everything.
 	//
 	// Examples:
+	//
 	// Exclude node_modules: `-node_modules`
+	//
 	// Include only project_a: `-` (exclude everything), `+project_a`
+	//
 	// Include only project_a, but not node_modules inside it: `-`, `+project_a`, `-project_a/node_modules`
 	DirectoryFilters []string
 
@@ -747,7 +750,7 @@ func (o *Options) set(name string, value interface{}, seen map[string]struct{}) 
 				result.errorf("invalid filter %q, must start with + or -", filter)
 				return result
 			}
-			filters = append(filters, filepath.FromSlash(filter))
+			filters = append(filters, strings.TrimRight(filepath.FromSlash(filter), "/"))
 		}
 		o.DirectoryFilters = filters
 	case "completionDocumentation":

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.1
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
-	golang.org/x/tools v0.1.1-0.20210330233337-8c34cc9cafff
-	golang.org/x/tools/gopls v0.0.0-20210330233337-8c34cc9cafff
+	golang.org/x/tools v0.1.1-0.20210408205559-0243799cfe6b
+	golang.org/x/tools/gopls v0.0.0-20210408205559-0243799cfe6b
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1-0.20210330233337-8c34cc9cafff h1:JjeR58X9u2XmSjp9AW/45UKXYvyUGcx9g21YORznUgI=
-golang.org/x/tools v0.1.1-0.20210330233337-8c34cc9cafff/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
-golang.org/x/tools/gopls v0.0.0-20210330233337-8c34cc9cafff h1:3ioCP1CTlltHQJGCG0EfqGnAwBSnKHVI3jZRVueJXQE=
-golang.org/x/tools/gopls v0.0.0-20210330233337-8c34cc9cafff/go.mod h1:irFua8x32R9RfrLUCEiXS9IGJrvAs7Mjrm6i7Tdk0Mo=
+golang.org/x/tools v0.1.1-0.20210408205559-0243799cfe6b h1:EmO+TGkhdmxqn7FVvBthGraOJZ7AzSyLnVXbXKrUqyQ=
+golang.org/x/tools v0.1.1-0.20210408205559-0243799cfe6b/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
+golang.org/x/tools/gopls v0.0.0-20210408205559-0243799cfe6b h1:ohsQ0/aZy+3Zp5XCG4LX8dIhvEArfgVA7rpDNYe35zU=
+golang.org/x/tools/gopls v0.0.0-20210408205559-0243799cfe6b/go.mod h1:irFua8x32R9RfrLUCEiXS9IGJrvAs7Mjrm6i7Tdk0Mo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* gopls/internal/coverage: apply gofmt to the build tag syntax 0243799c
* internal/lsp/source: small fixes to directory filters be791d07
* go/tools: add vet check for direct comparion of reflect.Values b261fe96
* internal/lsp: switch to 'go get -u ./...' for transitive upgrades e78b40c7
* gopls/internal/coverage: better error messages and output 3ac76b8b
* Revert "internal/lsp/cache: disable GOPACKAGESDRIVER" c6024661
* go/internal/gcimporter: ensure that imported floats are of float kind 35a91593
* go/internal/gcimporter: merge go1.11 tests back into gcimporter_test.go 5d334387
* internal/lsp/source: fix Highlight for std and 3rd-party packages 11c3f835