### PR TITLE
deps: update x/tools & gopls to c0140e85

### DIFF
--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -40,6 +40,11 @@ const (
 
 var _ protocol.Client = (*govimplugin)(nil)
 
+func (g *govimplugin) ShowDocument(context.Context, *protocol.ShowDocumentParams) (*protocol.ShowDocumentResult, error) {
+	defer absorbShutdownErr()
+	panic("ShowDocument not implemented yet")
+}
+
 func (g *govimplugin) ShowMessage(ctxt context.Context, params *protocol.ShowMessageParams) error {
 	defer absorbShutdownErr()
 	g.logGoplsClientf("ShowMessage callback: %v", pretty.Sprint(params))

--- a/cmd/govim/gopls_server.go
+++ b/cmd/govim/gopls_server.go
@@ -427,13 +427,6 @@ func (l loggingGoplsServer) LinkedEditingRange(ctxt context.Context, params *pro
 	return res, err
 }
 
-func (l loggingGoplsServer) ShowDocument(ctxt context.Context, params *protocol.ShowDocumentParams) (*protocol.ShowDocumentResult, error) {
-	l.Logf("gopls.ShowDocument() call; params:\n%v", pretty.Sprint(params))
-	res, err := l.u.ShowDocument(ctxt, params)
-	l.Logf("gopls.ShowDocument() return; err: %v; res\n%v", err, pretty.Sprint(res))
-	return res, err
-}
-
 func (l loggingGoplsServer) WillCreateFiles(ctxt context.Context, params *protocol.CreateFilesParams) (*protocol.WorkspaceEdit, error) {
 	l.Logf("gopls.WillCreateFiles() call; params:\n%v", pretty.Sprint(params))
 	res, err := l.u.WillCreateFiles(ctxt, params)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
@@ -148,9 +148,10 @@ func (s *snapshot) load(ctx context.Context, allowNetwork bool, scopes ...interf
 		}
 		// Special case for the builtin package, as it has no dependencies.
 		if pkg.PkgPath == "builtin" {
-			if err := s.buildBuiltinPackage(ctx, pkg.GoFiles); err != nil {
-				return err
+			if len(pkg.GoFiles) != 1 {
+				return errors.Errorf("only expected 1 file for builtin, got %v", len(pkg.GoFiles))
 			}
+			s.setBuiltin(pkg.GoFiles[0])
 			continue
 		}
 		// Skip test main packages.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
@@ -151,11 +151,6 @@ type builtinPackageHandle struct {
 	handle *memoize.Handle
 }
 
-type builtinPackageData struct {
-	parsed *source.BuiltinPackage
-	err    error
-}
-
 // fileBase holds the common functionality for all files.
 // It is intended to be embedded in the file implementations
 type fileBase struct {
@@ -335,6 +330,37 @@ func (s *snapshot) WriteEnv(ctx context.Context, w io.Writer) error {
 
 func (s *snapshot) RunProcessEnvFunc(ctx context.Context, fn func(*imports.Options) error) error {
 	return s.view.importsState.runProcessEnvFunc(ctx, s, fn)
+}
+
+func (s *snapshot) locateTemplateFiles(ctx context.Context) {
+	if !s.view.Options().ExperimentalTemplateSupport {
+		return
+	}
+	dir := s.workspace.root.Filename()
+	searched := 0
+	// Change to WalkDir when we move up to 1.16
+	err := filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if strings.HasSuffix(filepath.Ext(path), "tmpl") && !pathExcludedByFilter(path, s.view.options) &&
+			!fi.IsDir() {
+			k := span.URIFromPath(path)
+			fh, err := s.GetVersionedFile(ctx, k)
+			if err != nil {
+				return nil
+			}
+			s.files[k] = fh
+		}
+		searched++
+		if fileLimit > 0 && searched > fileLimit {
+			return errExhausted
+		}
+		return nil
+	})
+	if err != nil {
+		event.Error(ctx, "searching for template files failed", err)
+	}
 }
 
 func (v *View) contains(uri span.URI) bool {
@@ -553,6 +579,7 @@ func (s *snapshot) loadWorkspace(ctx context.Context, firstAttempt bool) {
 			Message:  err.Error(),
 		})
 	}
+	s.locateTemplateFiles(ctx)
 	if len(s.workspace.getActiveModFiles()) > 0 {
 		for modURI := range s.workspace.getActiveModFiles() {
 			fh, err := s.GetFile(ctx, modURI)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/cmd.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/cmd.go
@@ -443,6 +443,10 @@ func (c *cmdClient) Progress(context.Context, *protocol.ProgressParams) error {
 	return nil
 }
 
+func (c *cmdClient) ShowDocument(context.Context, *protocol.ShowDocumentParams) (*protocol.ShowDocumentResult, error) {
+	return nil, nil
+}
+
 func (c *cmdClient) WorkDoneProgressCreate(context.Context, *protocol.WorkDoneProgressCreateParams) error {
 	return nil
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/code_action.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/code_action.go
@@ -54,6 +54,9 @@ func (s *Server) codeAction(ctx context.Context, params *protocol.CodeActionPara
 			wanted[only] = supportedCodeActions[only] || explicit[only]
 		}
 	}
+	if len(supportedCodeActions) == 0 {
+		return nil, nil // not an error if there are none supported
+	}
 	if len(wanted) == 0 {
 		return nil, fmt.Errorf("no supported code action to execute for %s, wanted %v", uri, params.Context.Only)
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/completion.go
@@ -15,6 +15,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source/completion"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/template"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 )
 
@@ -31,6 +32,8 @@ func (s *Server) completion(ctx context.Context, params *protocol.CompletionPara
 		candidates, surrounding, err = completion.Completion(ctx, snapshot, fh, params.Position, params.Context)
 	case source.Mod:
 		candidates, surrounding = nil, nil
+	case source.Tmpl:
+		candidates, surrounding, err = template.Completion(ctx, snapshot, fh, params.Position, params.Context)
 	}
 	if err != nil {
 		event.Error(ctx, "no completions found", err, tag.Position.Of(params.Position))
@@ -154,6 +157,8 @@ func toProtocolCompletionItems(candidates []completion.CompletionItem, rng proto
 
 			Preselect:     i == 0,
 			Documentation: candidate.Documentation,
+			Tags:          candidate.Tags,
+			Deprecated:    candidate.Deprecated,
 		}
 		items = append(items, item)
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
@@ -19,6 +19,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/mod"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/template"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/xcontext"
 	errors "golang.org/x/xerrors"
@@ -208,6 +209,12 @@ func (s *Server) diagnose(ctx context.Context, snapshot source.Snapshot, forceAn
 	// will still be shown as a ShowMessage. If there is no error, any running
 	// error progress reports will be closed.
 	s.showCriticalErrorStatus(ctx, snapshot, criticalErr)
+
+	// There may be .tmpl files.
+	for _, f := range snapshot.Templates() {
+		diags := template.Diagnose(f)
+		s.storeDiagnostics(snapshot, f.URI(), typeCheckSource, diags)
+	}
 
 	// If there are no workspace packages, there is nothing to diagnose and
 	// there are no orphaned files.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/client.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/client.go
@@ -111,6 +111,10 @@ func (c *Client) WorkDoneProgressCreate(ctx context.Context, params *protocol.Wo
 	return nil
 }
 
+func (c *Client) ShowDocument(context.Context, *protocol.ShowDocumentParams) (*protocol.ShowDocumentResult, error) {
+	return nil, nil
+}
+
 // ApplyEdit applies edits sent from the server.
 func (c *Client) ApplyEdit(ctx context.Context, params *protocol.ApplyWorkspaceEditParams) (*protocol.ApplyWorkspaceEditResponse, error) {
 	if len(params.Edit.Changes) != 0 {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/general.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/general.go
@@ -96,7 +96,24 @@ func (s *Server) initialize(ctx context.Context, params *protocol.ParamInitializ
 		}
 	}
 
-	goplsVersion, err := json.Marshal(debug.VersionInfo())
+	versionInfo := debug.VersionInfo()
+
+	// golang/go#45732: Warn users who've installed sergi/go-diff@v1.2.0, since
+	// it will corrupt the formatting of their files.
+	for _, dep := range versionInfo.Deps {
+		if dep.Path == "github.com/sergi/go-diff" && dep.Version == "v1.2.0" {
+			if err := s.eventuallyShowMessage(ctx, &protocol.ShowMessageParams{
+				Message: `It looks like you have a bad gopls installation.
+Please reinstall gopls by running 'GO111MODULE=on go get golang.org/x/tools/gopls@latest'.
+See https://github.com/golang/go/issues/45732 for more information.`,
+				Type: protocol.Error,
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	goplsVersion, err := json.Marshal(versionInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/highlight.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/highlight.go
@@ -11,6 +11,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/debug/tag"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/template"
 )
 
 func (s *Server) documentHighlight(ctx context.Context, params *protocol.DocumentHighlightParams) ([]protocol.DocumentHighlight, error) {
@@ -19,6 +20,11 @@ func (s *Server) documentHighlight(ctx context.Context, params *protocol.Documen
 	if !ok {
 		return nil, err
 	}
+
+	if fh.Kind() == source.Tmpl {
+		return template.Highlight(ctx, snapshot, fh, params.Position)
+	}
+
 	rngs, err := source.Highlight(ctx, snapshot, fh, params.Position)
 	if err != nil {
 		event.Error(ctx, "no highlight", err, tag.URI.Of(params.TextDocument.URI))

--- a/cmd/govim/internal/golang_org_x_tools/lsp/hover.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/hover.go
@@ -10,6 +10,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/mod"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/template"
 )
 
 func (s *Server) hover(ctx context.Context, params *protocol.HoverParams) (*protocol.Hover, error) {
@@ -23,6 +24,8 @@ func (s *Server) hover(ctx context.Context, params *protocol.HoverParams) (*prot
 		return mod.Hover(ctx, snapshot, fh, params.Position)
 	case source.Go:
 		return source.Hover(ctx, snapshot, fh, params.Position)
+	case source.Tmpl:
+		return template.Hover(ctx, snapshot, fh, params.Position)
 	}
 	return nil, nil
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsserver.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsserver.go
@@ -50,7 +50,6 @@ type Server interface {
 	SemanticTokensFullDelta(context.Context, *SemanticTokensDeltaParams) (interface{} /* SemanticTokens | SemanticTokensDelta | float64*/, error)
 	SemanticTokensRange(context.Context, *SemanticTokensRangeParams) (*SemanticTokens /*SemanticTokens | null*/, error)
 	SemanticTokensRefresh(context.Context) error
-	ShowDocument(context.Context, *ShowDocumentParams) (*ShowDocumentResult, error)
 	LinkedEditingRange(context.Context, *LinkedEditingRangeParams) (*LinkedEditingRanges /*LinkedEditingRanges | null*/, error)
 	WillCreateFiles(context.Context, *CreateFilesParams) (*WorkspaceEdit /*WorkspaceEdit | null*/, error)
 	WillRenameFiles(context.Context, *RenameFilesParams) (*WorkspaceEdit /*WorkspaceEdit | null*/, error)
@@ -294,13 +293,6 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 		}
 		err := server.SemanticTokensRefresh(ctx)
 		return true, reply(ctx, nil, err)
-	case "window/showDocument": // req
-		var params ShowDocumentParams
-		if err := json.Unmarshal(r.Params(), &params); err != nil {
-			return true, sendParseError(ctx, reply, err)
-		}
-		resp, err := server.ShowDocument(ctx, &params)
-		return true, reply(ctx, resp, err)
 	case "textDocument/linkedEditingRange": // req
 		var params LinkedEditingRangeParams
 		if err := json.Unmarshal(r.Params(), &params); err != nil {
@@ -706,14 +698,6 @@ func (s *serverDispatcher) SemanticTokensRange(ctx context.Context, params *Sema
 
 func (s *serverDispatcher) SemanticTokensRefresh(ctx context.Context) error {
 	return Call(ctx, s.Conn, "workspace/semanticTokens/refresh", nil, nil)
-}
-
-func (s *serverDispatcher) ShowDocument(ctx context.Context, params *ShowDocumentParams) (*ShowDocumentResult, error) {
-	var result *ShowDocumentResult
-	if err := Call(ctx, s.Conn, "window/showDocument", params, &result); err != nil {
-		return nil, err
-	}
-	return result, nil
 }
 
 func (s *serverDispatcher) LinkedEditingRange(ctx context.Context, params *LinkedEditingRangeParams) (*LinkedEditingRanges /*LinkedEditingRanges | null*/, error) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/code.ts
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/code.ts
@@ -135,6 +135,7 @@ function setReceives() {
   receives.set('workspace/applyEdit', 'client');
   receives.set('textDocument/publishDiagnostics', 'client');
   receives.set('window/workDoneProgress/create', 'client');
+  receives.set('window/showDocument', 'client');
   receives.set('$/progress', 'client');
   // a small check
   receives.forEach((_, k) => {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/references.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/references.go
@@ -9,13 +9,17 @@ import (
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/template"
 )
 
 func (s *Server) references(ctx context.Context, params *protocol.ReferenceParams) ([]protocol.Location, error) {
-	snapshot, fh, ok, release, err := s.beginFileRequest(ctx, params.TextDocument.URI, source.Go)
+	snapshot, fh, ok, release, err := s.beginFileRequest(ctx, params.TextDocument.URI, source.UnknownKind)
 	defer release()
 	if !ok {
 		return nil, err
+	}
+	if fh.Kind() == source.Tmpl {
+		return template.References(ctx, snapshot, fh, params)
 	}
 	references, err := source.References(ctx, snapshot, fh, params.Position, params.Context.IncludeDeclaration)
 	if err != nil {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/regtest/expectation.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/regtest/expectation.go
@@ -193,6 +193,12 @@ func (e *Env) DoneWithOpen() Expectation {
 	return CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidOpen), opens)
 }
 
+// StartedChange expects there to have been i work items started for
+// processing didChange notifications.
+func StartedChange(i uint64) Expectation {
+	return StartedWork(lsp.DiagnosticWorkTitle(lsp.FromDidChange), i)
+}
+
 // DoneWithChange expects all didChange notifications currently sent by the
 // editor to be completely processed.
 func (e *Env) DoneWithChange() Expectation {
@@ -219,6 +225,22 @@ func (e *Env) DoneWithChangeWatchedFiles() Expectation {
 func (e *Env) DoneWithClose() Expectation {
 	changes := e.Editor.Stats().DidClose
 	return CompletedWork(lsp.DiagnosticWorkTitle(lsp.FromDidClose), changes)
+}
+
+// StartedWork expect a work item to have been started >= atLeast times.
+//
+// See CompletedWork.
+func StartedWork(title string, atLeast uint64) SimpleExpectation {
+	check := func(s State) Verdict {
+		if s.startedWork[title] >= atLeast {
+			return Met
+		}
+		return Unmet
+	}
+	return SimpleExpectation{
+		check:       check,
+		description: fmt.Sprintf("started work %q at least %d time(s)", title, atLeast),
+	}
 }
 
 // CompletedWork expects a work item to have been completed >= atLeast times.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/regtest/regtest.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/regtest/regtest.go
@@ -87,6 +87,9 @@ func DefaultModes() Mode {
 func Main(m *testing.M, hook func(*source.Options)) {
 	testenv.ExitIfSmallMachine()
 
+	// Disable GOPACKAGESDRIVER, as it can cause spurious test failures.
+	os.Setenv("GOPACKAGESDRIVER", "off")
+
 	flag.Parse()
 	if os.Getenv("_GOPLS_TEST_BINARY_RUN_AS_GOPLS") == "true" {
 		tool.Main(context.Background(), cmd.New("gopls", "", nil, nil), os.Args[1:])

--- a/cmd/govim/internal/golang_org_x_tools/lsp/regtest/wrappers.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/regtest/wrappers.go
@@ -201,6 +201,14 @@ func (e *Env) ApplyQuickFixes(path string, diagnostics []protocol.Diagnostic) {
 	}
 }
 
+// ApplyCodeAction applies the given code action.
+func (e *Env) ApplyCodeAction(action protocol.CodeAction) {
+	e.T.Helper()
+	if err := e.Editor.ApplyCodeAction(e.Ctx, action); err != nil {
+		e.T.Fatal(err)
+	}
+}
+
 // GetQuickFixes returns the available quick fix code actions.
 func (e *Env) GetQuickFixes(path string, diagnostics []protocol.Diagnostic) []protocol.CodeAction {
 	e.T.Helper()
@@ -239,7 +247,7 @@ func (e *Env) DocumentHighlight(name string, pos fake.Pos) []protocol.DocumentHi
 	return highlights
 }
 
-func checkIsFatal(t *testing.T, err error) {
+func checkIsFatal(t testing.TB, err error) {
 	t.Helper()
 	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrClosedPipe) {
 		t.Fatal(err)
@@ -271,7 +279,7 @@ func (e *Env) RunGenerate(dir string) {
 // directory.
 func (e *Env) RunGoCommand(verb string, args ...string) {
 	e.T.Helper()
-	if err := e.Sandbox.RunGoCommand(e.Ctx, "", verb, args); err != nil {
+	if err := e.Sandbox.RunGoCommand(e.Ctx, "", verb, args, true); err != nil {
 		e.T.Fatal(err)
 	}
 }
@@ -280,7 +288,7 @@ func (e *Env) RunGoCommand(verb string, args ...string) {
 // relative directory of the sandbox.
 func (e *Env) RunGoCommandInDir(dir, verb string, args ...string) {
 	e.T.Helper()
-	if err := e.Sandbox.RunGoCommand(e.Ctx, dir, verb, args); err != nil {
+	if err := e.Sandbox.RunGoCommand(e.Ctx, dir, verb, args, true); err != nil {
 		e.T.Fatal(err)
 	}
 }
@@ -290,7 +298,7 @@ func (e *Env) RunGoCommandInDir(dir, verb string, args ...string) {
 func (e *Env) DumpGoSum(dir string) {
 	e.T.Helper()
 
-	if err := e.Sandbox.RunGoCommand(e.Ctx, dir, "list", []string{"-mod=mod", "..."}); err != nil {
+	if err := e.Sandbox.RunGoCommand(e.Ctx, dir, "list", []string{"-mod=mod", "..."}, true); err != nil {
 		e.T.Fatal(err)
 	}
 	sumFile := path.Join(dir, "/go.sum")

--- a/cmd/govim/internal/golang_org_x_tools/lsp/server_gen.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/server_gen.go
@@ -228,10 +228,6 @@ func (s *Server) SetTrace(context.Context, *protocol.SetTraceParams) error {
 	return notImplemented("SetTrace")
 }
 
-func (s *Server) ShowDocument(context.Context, *protocol.ShowDocumentParams) (*protocol.ShowDocumentResult, error) {
-	return nil, notImplemented("ShowDocument")
-}
-
 func (s *Server) Shutdown(ctx context.Context) error {
 	return s.shutdown(ctx)
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -93,6 +93,19 @@ var GeneratedAPIJSON = &APIJSON{
 				Hierarchy:  "build",
 			},
 			{
+				Name: "experimentalTemplateSupport",
+				Type: "bool",
+				Doc:  "experimentalTemplateSupport opts into the experimental support\nfor template files.\n",
+				EnumKeys: EnumKeys{
+					ValueType: "",
+					Keys:      nil,
+				},
+				EnumValues: nil,
+				Default:    "false",
+				Status:     "experimental",
+				Hierarchy:  "build",
+			},
+			{
 				Name: "experimentalPackageCacheKey",
 				Type: "bool",
 				Doc:  "experimentalPackageCacheKey controls whether to use a coarser cache key\nfor package type information to increase cache hits. This setting removes\nthe user's environment, build flags, and working directory from the cache\nkey, which should be a safe change as all relevant inputs into the type\nchecking pass are already hashed into the key. This is temporarily guarded\nby an experiment because caching behavior is subtle and difficult to\ncomprehensively test.\n",
@@ -252,7 +265,7 @@ var GeneratedAPIJSON = &APIJSON{
 					Keys:      nil,
 				},
 				EnumValues: nil,
-				Default:    "false",
+				Default:    "true",
 				Status:     "experimental",
 				Hierarchy:  "ui.completion",
 			},

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/builtin.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/builtin.go
@@ -14,13 +14,13 @@ import (
 // argument. It attempts to use the AST hints from builtin.go where
 // possible.
 func (c *completer) builtinArgKind(ctx context.Context, obj types.Object, call *ast.CallExpr) objKind {
-	builtin, err := c.snapshot.BuiltinPackage(ctx)
+	builtin, err := c.snapshot.BuiltinFile(ctx)
 	if err != nil {
 		return 0
 	}
 	exprIdx := exprAtPos(c.pos, call.Args)
 
-	builtinObj := builtin.Package.Scope.Lookup(obj.Name())
+	builtinObj := builtin.File.Scope.Lookup(obj.Name())
 	if builtinObj == nil {
 		return 0
 	}
@@ -69,13 +69,22 @@ func (c *completer) builtinArgType(obj types.Object, call *ast.CallExpr, parentI
 
 	switch obj.Name() {
 	case "append":
-		if parentInf.objType == nil {
+		if exprIdx <= 0 {
+			// Infer first append() arg type as apparent return type of
+			// append().
+			inf.objType = parentInf.objType
 			break
 		}
 
-		inf.objType = parentInf.objType
-
-		if exprIdx <= 0 {
+		// For non-initial append() args, infer slice type from the first
+		// append() arg, or from parent context.
+		if len(call.Args) > 0 {
+			inf.objType = c.pkg.GetTypesInfo().TypeOf(call.Args[0])
+		}
+		if inf.objType == nil {
+			inf.objType = parentInf.objType
+		}
+		if inf.objType == nil {
 			break
 		}
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
@@ -45,7 +45,9 @@ type CompletionItem struct {
 	// The insert text does not contain snippets.
 	InsertText string
 
-	Kind protocol.CompletionItemKind
+	Kind       protocol.CompletionItemKind
+	Tags       []protocol.CompletionItemTag
+	Deprecated bool // Deprecated, prefer Tags if available
 
 	// An optional array of additional TextEdits that are applied when
 	// selecting this completion.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/format.go
@@ -243,6 +243,14 @@ func (c *completer) item(ctx context.Context, cand candidate) (CompletionItem, e
 	if c.opts.fullDocumentation {
 		item.Documentation = hover.FullDocumentation
 	}
+	// The desired pattern is `^// Deprecated`, but the prefix has been removed
+	if strings.HasPrefix(hover.FullDocumentation, "Deprecated") {
+		if c.snapshot.View().Options().CompletionTags {
+			item.Tags = []protocol.CompletionItemTag{protocol.ComplDeprecated}
+		} else if c.snapshot.View().Options().CompletionDeprecated {
+			item.Deprecated = true
+		}
+	}
 
 	return item, nil
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/types_format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/types_format.go
@@ -81,11 +81,11 @@ func (s *signature) Params() []string {
 // NewBuiltinSignature returns signature for the builtin object with a given
 // name, if a builtin object with the name exists.
 func NewBuiltinSignature(ctx context.Context, s Snapshot, name string) (*signature, error) {
-	builtin, err := s.BuiltinPackage(ctx)
+	builtin, err := s.BuiltinFile(ctx)
 	if err != nil {
 		return nil, err
 	}
-	obj := builtin.Package.Scope.Lookup(name)
+	obj := builtin.File.Scope.Lookup(name)
 	if obj == nil {
 		return nil, fmt.Errorf("no builtin object for %s", name)
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
@@ -168,14 +168,21 @@ func DetectLanguage(langID, filename string) FileKind {
 		return Mod
 	case "go.sum":
 		return Sum
+	case "tmpl":
+		return Tmpl
 	}
 	// Fallback to detecting the language based on the file extension.
-	switch filepath.Ext(filename) {
+	switch ext := filepath.Ext(filename); ext {
 	case ".mod":
 		return Mod
 	case ".sum":
 		return Sum
-	default: // fallback to Go
+	default:
+		if strings.HasSuffix(ext, "tmpl") {
+			// .tmpl, .gotmpl, etc
+			return Tmpl
+		}
+		// It's a Go file, or we shouldn't be seeing it
 		return Go
 	}
 }
@@ -186,6 +193,8 @@ func (k FileKind) String() string {
 		return "go.mod"
 	case Sum:
 		return "go.sum"
+	case Tmpl:
+		return "tmpl"
 	default:
 		return "go"
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -69,6 +69,9 @@ type Snapshot interface {
 	// workspace.
 	IgnoredFile(uri span.URI) bool
 
+	// Templates returns the .tmpl files
+	Templates() map[span.URI]VersionedFileHandle
+
 	// ParseGo returns the parsed AST for the file.
 	// If the file is not available, returns nil and an error.
 	ParseGo(ctx context.Context, fh FileHandle, mode ParseMode) (*ParsedGoFile, error)
@@ -125,8 +128,8 @@ type Snapshot interface {
 	// GoModForFile returns the URI of the go.mod file for the given URI.
 	GoModForFile(uri span.URI) span.URI
 
-	// BuiltinPackage returns information about the special builtin package.
-	BuiltinPackage(ctx context.Context) (*BuiltinPackage, error)
+	// BuiltinFile returns information about the special builtin package.
+	BuiltinFile(ctx context.Context) (*ParsedGoFile, error)
 
 	// IsBuiltin reports whether uri is part of the builtin package.
 	IsBuiltin(ctx context.Context, uri span.URI) bool
@@ -257,11 +260,6 @@ type View interface {
 type FileSource interface {
 	// GetFile returns the FileHandle for a given URI.
 	GetFile(ctx context.Context, uri span.URI) (FileHandle, error)
-}
-
-type BuiltinPackage struct {
-	Package    *ast.Package
-	ParsedFile *ParsedGoFile
 }
 
 // A ParsedGoFile contains the results of parsing a Go file.
@@ -514,6 +512,8 @@ const (
 	Mod
 	// Sum is a go.sum file.
 	Sum
+	// Tmpl is a template file.
+	Tmpl
 )
 
 // Analyzer represents a go/analysis analyzer with some boolean properties

--- a/cmd/govim/internal/golang_org_x_tools/lsp/template/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/template/completion.go
@@ -1,0 +1,21 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package template
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source/completion"
+)
+
+func Completion(ctx context.Context, snapshot source.Snapshot, fh source.VersionedFileHandle, pos protocol.Position, context protocol.CompletionContext) ([]completion.CompletionItem, *completion.Selection, error) {
+	if skipTemplates(snapshot) {
+		return nil, nil, nil
+	}
+	return nil, nil, fmt.Errorf("implement template completion")
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/template/highlight.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/template/highlight.go
@@ -1,0 +1,99 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package template
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+)
+
+func Highlight(ctx context.Context, snapshot source.Snapshot, fh source.FileHandle, loc protocol.Position) ([]protocol.DocumentHighlight, error) {
+	if skipTemplates(snapshot) {
+		return nil, nil
+	}
+	buf, err := fh.Read()
+	if err != nil {
+		return nil, err
+	}
+	p := parseBuffer(buf)
+	pos := p.FromPosition(loc)
+	var ans []protocol.DocumentHighlight
+	if p.ParseErr == nil {
+		for _, s := range p.symbols {
+			if s.start <= pos && pos < s.start+s.length {
+				return markSymbols(p, s)
+			}
+		}
+	}
+	// these tokens exist whether or not there was a parse error
+	// (symbols require a successful parse)
+	for _, tok := range p.tokens {
+		if tok.Start <= pos && pos < tok.End {
+			wordAt := findWordAt(p, pos)
+			if len(wordAt) > 0 {
+				return markWordInToken(p, wordAt)
+			}
+		}
+	}
+	// find the 'word' at pos, etc: someday
+	// until then we get the default action, which doesn't respect word boundaries
+	return ans, nil
+}
+
+func markSymbols(p *Parsed, sym symbol) ([]protocol.DocumentHighlight, error) {
+	var ans []protocol.DocumentHighlight
+	for _, s := range p.symbols {
+		if s.name == sym.name {
+			kind := protocol.Read
+			if s.vardef {
+				kind = protocol.Write
+			}
+			ans = append(ans, protocol.DocumentHighlight{
+				Range: p.Range(s.start, s.length),
+				Kind:  kind,
+			})
+		}
+	}
+	return ans, nil
+}
+
+// A token is {{...}}, and this marks words in the token that equal the give word
+func markWordInToken(p *Parsed, wordAt string) ([]protocol.DocumentHighlight, error) {
+	var ans []protocol.DocumentHighlight
+	pat, err := regexp.Compile(fmt.Sprintf(`\b%s\b`, wordAt))
+	if err != nil {
+		return nil, fmt.Errorf("%q: unmatchable word (%v)", wordAt, err)
+	}
+	for _, tok := range p.tokens {
+		got := pat.FindAllIndex(p.buf[tok.Start:tok.End], -1)
+		for i := 0; i < len(got); i++ {
+			ans = append(ans, protocol.DocumentHighlight{
+				Range: p.Range(got[i][0], got[i][1]-got[i][0]),
+				Kind:  protocol.Text,
+			})
+		}
+	}
+	return ans, nil
+}
+
+var wordRe = regexp.MustCompile(`[$]?\w+$`)
+var moreRe = regexp.MustCompile(`^[$]?\w+`)
+
+// findWordAt finds the word the cursor is in (meaning in or just before)
+func findWordAt(p *Parsed, pos int) string {
+	if pos >= len(p.buf) {
+		return "" // can't happen, as we are called with pos < tok.End
+	}
+	after := moreRe.Find(p.buf[pos:])
+	if len(after) == 0 {
+		return "" // end of the word
+	}
+	got := wordRe.Find(p.buf[:pos+len(after)])
+	return string(got)
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/template/implementations.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/template/implementations.go
@@ -1,0 +1,202 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package template
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
+)
+
+// line number (1-based) and message
+var errRe = regexp.MustCompile(`template.*:(\d+): (.*)`)
+
+// Diagnose returns parse errors. There is only one.
+// The errors are not always helpful. For instance { {end}}
+// will likely point to the end of the file.
+func Diagnose(f source.VersionedFileHandle) []*source.Diagnostic {
+	// no need for skipTemplate check, as Diagnose is called on the
+	// snapshot's template files
+	buf, err := f.Read()
+	if err != nil {
+		// Is a Diagnostic with no Range useful? event.Error also?
+		msg := fmt.Sprintf("failed to read %s (%v)", f.URI().Filename(), err)
+		d := source.Diagnostic{Message: msg, Severity: protocol.SeverityError, URI: f.URI()}
+		return []*source.Diagnostic{&d}
+	}
+	p := parseBuffer(buf)
+	if p.ParseErr == nil {
+		return nil
+	}
+	unknownError := func(msg string) []*source.Diagnostic {
+		s := fmt.Sprintf("malformed template error %q: %s", p.ParseErr.Error(), msg)
+		d := source.Diagnostic{Message: s, Severity: protocol.SeverityError, Range: p.Range(p.nls[0], 1), URI: f.URI()}
+		return []*source.Diagnostic{&d}
+	}
+	// errors look like `template: :40: unexpected "}" in operand`
+	// so the string needs to be parsed
+	matches := errRe.FindStringSubmatch(p.ParseErr.Error())
+	if len(matches) != 3 {
+		msg := fmt.Sprintf("expected 3 matches, got %d (%v)", len(matches), matches)
+		return unknownError(msg)
+	}
+	lineno, err := strconv.Atoi(matches[1])
+	if err != nil {
+		msg := fmt.Sprintf("couldn't convert %q to int, %v", matches[1], err)
+		return unknownError(msg)
+	}
+	msg := matches[2]
+	d := source.Diagnostic{Message: msg, Severity: protocol.SeverityError}
+	start := p.nls[lineno-1]
+	if lineno < len(p.nls) {
+		size := p.nls[lineno] - start
+		d.Range = p.Range(start, size)
+	} else {
+		d.Range = p.Range(start, 1)
+	}
+	return []*source.Diagnostic{&d}
+}
+
+func skipTemplates(s source.Snapshot) bool {
+	return !s.View().Options().ExperimentalTemplateSupport
+}
+
+// Definition finds the definitions of the symbol at loc. It
+// does not understand scoping (if any) in templates. This code is
+// for defintions, type definitions, and implementations.
+// Results only for variables and templates.
+func Definition(snapshot source.Snapshot, fh source.VersionedFileHandle, loc protocol.Position) ([]protocol.Location, error) {
+	if skipTemplates(snapshot) {
+		return nil, nil
+	}
+	x, _, err := symAtPosition(fh, loc)
+	if err != nil {
+		return nil, err
+	}
+	sym := x.name
+	ans := []protocol.Location{}
+	// PJW: this is probably a pattern to abstract
+	a := New(snapshot.Templates())
+	for k, p := range a.files {
+		for _, s := range p.symbols {
+			if !s.vardef || s.name != sym {
+				continue
+			}
+			ans = append(ans, protocol.Location{URI: protocol.DocumentURI(k), Range: p.Range(s.start, s.length)})
+		}
+	}
+	return ans, nil
+}
+
+func Hover(ctx context.Context, snapshot source.Snapshot, fh source.FileHandle, position protocol.Position) (*protocol.Hover, error) {
+	if skipTemplates(snapshot) {
+		return nil, nil
+	}
+	sym, p, err := symAtPosition(fh, position)
+	if sym == nil || err != nil {
+		return nil, err
+	}
+	ans := protocol.Hover{Range: p.Range(sym.start, sym.length), Contents: protocol.MarkupContent{Kind: protocol.Markdown}}
+	switch sym.kind {
+	case protocol.Function:
+		ans.Contents.Value = fmt.Sprintf("function: %s", sym.name)
+	case protocol.Variable:
+		ans.Contents.Value = fmt.Sprintf("variable: %s", sym.name)
+	case protocol.Constant:
+		ans.Contents.Value = fmt.Sprintf("constant %s", sym.name)
+	case protocol.Method: // field or method
+		ans.Contents.Value = fmt.Sprintf("%s: field or method", sym.name)
+	case protocol.Package: // template use, template def (PJW: do we want two?)
+		ans.Contents.Value = fmt.Sprintf("template %s\n(add definition)", sym.name)
+	case protocol.Namespace:
+		ans.Contents.Value = fmt.Sprintf("template %s defined", sym.name)
+	default:
+		ans.Contents.Value = fmt.Sprintf("oops, sym=%#v", sym)
+	}
+	return &ans, nil
+}
+
+func References(ctx context.Context, snapshot source.Snapshot, fh source.FileHandle, params *protocol.ReferenceParams) ([]protocol.Location, error) {
+	if skipTemplates(snapshot) {
+		return nil, nil
+	}
+	sym, _, err := symAtPosition(fh, params.Position)
+	if sym == nil || err != nil || sym.name == "" {
+		return nil, err
+	}
+	ans := []protocol.Location{}
+
+	a := New(snapshot.Templates())
+	for k, p := range a.files {
+		for _, s := range p.symbols {
+			if s.name != sym.name {
+				continue
+			}
+			if s.vardef && !params.Context.IncludeDeclaration {
+				continue
+			}
+			ans = append(ans, protocol.Location{URI: protocol.DocumentURI(k), Range: p.Range(s.start, s.length)})
+		}
+	}
+	// do these need to be sorted? (a.files is a map)
+	return ans, nil
+}
+
+func SemanticTokens(ctx context.Context, snapshot source.Snapshot, spn span.URI, add func(line, start, len uint32), d func() ([]uint32, error)) (*protocol.SemanticTokens, error) {
+	if skipTemplates(snapshot) {
+		return nil, nil
+	}
+	fh, err := snapshot.GetFile(ctx, spn)
+	if err != nil {
+		return nil, err
+	}
+	buf, err := fh.Read()
+	if err != nil {
+		return nil, err
+	}
+	p := parseBuffer(buf)
+	if p.ParseErr != nil {
+		return nil, p.ParseErr
+	}
+	for _, t := range p.Tokens() {
+		if t.Multiline {
+			la, ca := p.LineCol(t.Start)
+			lb, cb := p.LineCol(t.End)
+			add(la, ca, p.RuneCount(la, ca, 0))
+			for l := la + 1; l < lb; l++ {
+				add(l, 0, p.RuneCount(l, 0, 0))
+			}
+			add(lb, 0, p.RuneCount(lb, 0, cb))
+			continue
+		}
+		sz, err := p.TokenSize(t)
+		if err != nil {
+			return nil, err
+		}
+		line, col := p.LineCol(t.Start)
+		add(line, col, uint32(sz))
+	}
+	data, err := d()
+	if err != nil {
+		// this is an internal error, likely caused by a typo
+		// for a token or modifier
+		return nil, err
+	}
+	ans := &protocol.SemanticTokens{
+		Data: data,
+		// for small cache, some day. for now, the LSP client ignores this
+		// (that is, when the LSP client starts returning these, we can cache)
+		ResultID: fmt.Sprintf("%v", time.Now()),
+	}
+	return ans, nil
+}
+
+// still need to do rename, etc

--- a/cmd/govim/internal/golang_org_x_tools/lsp/template/parse.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/template/parse.go
@@ -1,0 +1,439 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package template contains code for dealing with templates
+package template
+
+// template files are small enough that the code reprocesses them each time
+// this may be a bad choice for projects with lots of template files.
+
+// This file contains the parsing code, some debugging printing, and
+// implementations for Diagnose, Definition, HJover, References
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"regexp"
+	"runtime"
+	"sort"
+	"text/template"
+	"text/template/parse"
+	"unicode/utf8"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
+)
+
+var (
+	Left  = []byte("{{")
+	Right = []byte("}}")
+)
+
+type Parsed struct {
+	buf   []byte   //contents
+	lines [][]byte // needed?, other than for debugging?
+
+	// tokens, computed before trying to parse
+	tokens []Token
+
+	// result of parsing
+	named    []*template.Template // the template and embedded templates
+	ParseErr error
+	symbols  []symbol
+	stack    []parse.Node // used while computing symbols
+
+	// for mapping from offsets in buf to LSP coordinates
+	nls      []int // offset of newlines before each line (nls[0]==-1)
+	lastnl   int   // last line seen
+	check    int   // used to decide whether to use lastnl or search through nls
+	nonASCII bool  // are there any non-ascii runes in buf?
+}
+
+// Token is a single {{...}}. More precisely, Left...Right
+type Token struct {
+	Start, End int // offset from start of template
+	Multiline  bool
+}
+
+// All contains the Parse of all the template files
+type All struct {
+	files map[span.URI]*Parsed
+}
+
+// New returns the Parses of the snapshot's tmpl files
+// (maybe cache these, but then avoiding import cycles needs code rearrangements)
+func New(tmpls map[span.URI]source.VersionedFileHandle) *All {
+	all := make(map[span.URI]*Parsed)
+	for k, v := range tmpls {
+		buf, err := v.Read()
+		if err != nil { // PJW: decide what to do with these errors
+			log.Printf("failed to read %s (%v)", v.URI().Filename(), err)
+			continue
+		}
+		all[k] = parseBuffer(buf)
+	}
+	return &All{files: all}
+}
+
+func parseBuffer(buf []byte) *Parsed {
+	ans := &Parsed{
+		buf:   buf,
+		check: -1,
+	}
+	// how to compute allAscii...
+	for _, b := range buf {
+		if b >= utf8.RuneSelf {
+			ans.nonASCII = true
+			break
+		}
+	}
+	if buf[len(buf)-1] != '\n' {
+		ans.buf = append(buf, '\n')
+	}
+	// at the cost of complexity we could fold this into the allAscii loop
+	ans.lines = bytes.Split(buf, []byte{'\n'})
+	ans.nls = []int{-1}
+	for i, p := range ans.buf {
+		if p == '\n' {
+			ans.nls = append(ans.nls, i)
+		}
+	}
+	ans.setTokens()
+	t, err := template.New("").Parse(string(buf))
+	if err != nil {
+		funcs := make(template.FuncMap)
+		for t == nil && ans.ParseErr == nil {
+			//  template: :2: function "foo" not defined
+			matches := parseErrR.FindStringSubmatch(err.Error())
+			if len(matches) < 2 { // uncorrectable error
+				ans.ParseErr = err
+				return ans
+			}
+			// suppress the error by giving it a function with the right name
+			funcs[matches[1]] = func(interface{}) interface{} { return nil }
+			t, err = template.New("").Funcs(funcs).Parse(string(buf))
+		}
+	}
+	ans.named = t.Templates()
+	// set the symbols
+	for _, t := range ans.named {
+		ans.stack = append(ans.stack, t.Root)
+		ans.findSymbols()
+		if t.Name() != "" {
+			// defining a template. The pos is just after {{define...}} (or {{block...}}?)
+			at, sz := ans.FindLiteralBefore(int(t.Root.Pos))
+			s := symbol{start: at, length: sz, name: t.Name(), kind: protocol.Namespace, vardef: true}
+			ans.symbols = append(ans.symbols, s)
+		}
+	}
+
+	sort.Slice(ans.symbols, func(i, j int) bool {
+		left, right := ans.symbols[i], ans.symbols[j]
+		if left.start != right.start {
+			return left.start < right.start
+		}
+		if left.vardef != right.vardef {
+			return left.vardef
+		}
+		return left.kind < right.kind
+	})
+	return ans
+}
+
+// FindLiteralBefore locates the first preceding string literal
+// returning its position and length in buf
+// or returns -1 if there is none. Assume "", rather than ``, for now
+func (p *Parsed) FindLiteralBefore(pos int) (int, int) {
+	left, right := -1, -1
+	for i := pos - 1; i >= 0; i-- {
+		if p.buf[i] != '"' {
+			continue
+		}
+		if right == -1 {
+			right = i
+			continue
+		}
+		left = i
+		break
+	}
+	if left == -1 {
+		return -1, 0
+	}
+	return left + 1, right - left - 1
+}
+
+var parseErrR = regexp.MustCompile(`template:.*function "([^"]+)" not defined`)
+
+func (p *Parsed) setTokens() {
+	last := 0
+	for left := bytes.Index(p.buf[last:], Left); left != -1; left = bytes.Index(p.buf[last:], Left) {
+		left += last
+		tok := Token{Start: left}
+		last = left + len(Left)
+		right := bytes.Index(p.buf[last:], Right)
+		if right == -1 {
+			break
+		}
+		right += last + len(Right)
+		tok.End = right
+		tok.Multiline = bytes.Contains(p.buf[left:right], []byte{'\n'})
+		p.tokens = append(p.tokens, tok)
+		last = right
+	}
+}
+
+func (p *Parsed) Tokens() []Token {
+	return p.tokens
+}
+
+func (p *Parsed) utf16len(buf []byte) int {
+	cnt := 0
+	if !p.nonASCII {
+		return len(buf)
+	}
+	// we need a utf16len(rune), but we don't have it
+	for _, r := range string(buf) {
+		cnt++
+		if r >= 1<<16 {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func (p *Parsed) TokenSize(t Token) (int, error) {
+	if t.Multiline {
+		return -1, fmt.Errorf("TokenSize called with Multiline token %#v", t)
+	}
+	ans := p.utf16len(p.buf[t.Start:t.End])
+	return ans, nil
+}
+
+// RuneCount counts runes in a line
+func (p *Parsed) RuneCount(l, s, e uint32) uint32 {
+	start := p.nls[l] + 1 + int(s)
+	end := int(e)
+	if e == 0 || int(e) >= p.nls[l+1] {
+		end = p.nls[l+1]
+	}
+	return uint32(utf8.RuneCount(p.buf[start:end]))
+}
+
+// LineCol converts from a 0-based byte offset to 0-based line, col. col in runes
+func (p *Parsed) LineCol(x int) (uint32, uint32) {
+	if x < p.check {
+		p.lastnl = 0
+	}
+	p.check = x
+	for i := p.lastnl; i < len(p.nls); i++ {
+		if p.nls[i] <= x {
+			continue
+		}
+		p.lastnl = i
+		var count int
+		if i > 0 && x == p.nls[i-1] { // \n
+			count = 0
+		} else {
+			count = p.utf16len(p.buf[p.nls[i-1]+1 : x])
+		}
+		return uint32(i - 1), uint32(count)
+	}
+	if x == len(p.buf)-1 { // trailing \n
+		return uint32(len(p.nls)), 1
+	}
+	// shouldn't happen
+	for i := 1; i < 4; i++ {
+		_, f, l, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		log.Printf("%d: %s:%d", i, f, l)
+	}
+
+	msg := fmt.Errorf("LineCol off the end, %d of %d, nls=%v, %q", x, len(p.buf), p.nls, p.buf[x:])
+	event.Error(context.Background(), "internal error", msg)
+	return 0, 0
+}
+
+// Position produces a protocol.Position from an offset in the template
+func (p *Parsed) Position(pos int) protocol.Position {
+	line, col := p.LineCol(pos)
+	return protocol.Position{Line: line, Character: col}
+}
+
+func (p *Parsed) Range(x, length int) protocol.Range {
+	line, col := p.LineCol(x)
+	ans := protocol.Range{
+		Start: protocol.Position{Line: line, Character: col},
+		End:   protocol.Position{Line: line, Character: col + uint32(length)},
+	}
+	return ans
+}
+
+// FromPosition translates a protocol.Position into an offset into the template
+func (p *Parsed) FromPosition(x protocol.Position) int {
+	l, c := int(x.Line), int(x.Character)
+	line := p.buf[p.nls[l]+1:]
+	cnt := 0
+	for w := range string(line) {
+		if cnt >= c {
+			return w + p.nls[l] + 1
+		}
+		cnt++
+	}
+	// do we get here? NO
+	pos := int(x.Character) + p.nls[int(x.Line)] + 1
+	event.Error(context.Background(), "internal error", fmt.Errorf("surprise %#v", x))
+	return pos
+}
+
+func symAtPosition(fh source.FileHandle, loc protocol.Position) (*symbol, *Parsed, error) {
+	buf, err := fh.Read()
+	if err != nil {
+		return nil, nil, err
+	}
+	p := parseBuffer(buf)
+	pos := p.FromPosition(loc)
+	syms := p.SymsAtPos(pos)
+	if len(syms) == 0 {
+		return nil, p, fmt.Errorf("no symbol found")
+	}
+	if len(syms) > 1 {
+		log.Printf("Hover: %d syms, not 1 %v", len(syms), syms)
+	}
+	sym := syms[0]
+	return &sym, p, nil
+}
+
+func (p *Parsed) SymsAtPos(pos int) []symbol {
+	ans := []symbol{}
+	for _, s := range p.symbols {
+		if s.start <= pos && pos < s.start+s.length {
+			ans = append(ans, s)
+		}
+	}
+	return ans
+}
+
+type wrNode struct {
+	p *Parsed
+	w io.Writer
+}
+
+// WriteNode is for debugging
+func (p *Parsed) WriteNode(w io.Writer, n parse.Node) {
+	wr := wrNode{p: p, w: w}
+	wr.writeNode(n, "")
+}
+
+func (wr wrNode) writeNode(n parse.Node, indent string) {
+	if n == nil {
+		return
+	}
+	at := func(pos parse.Pos) string {
+		line, col := wr.p.LineCol(int(pos))
+		return fmt.Sprintf("(%d)%v:%v", pos, line, col)
+	}
+	switch x := n.(type) {
+	case *parse.ActionNode:
+		fmt.Fprintf(wr.w, "%sActionNode at %s\n", indent, at(x.Pos))
+		wr.writeNode(x.Pipe, indent+". ")
+	case *parse.BoolNode:
+		fmt.Fprintf(wr.w, "%sBoolNode at %s, %v\n", indent, at(x.Pos), x.True)
+	case *parse.BranchNode:
+		fmt.Fprintf(wr.w, "%sBranchNode at %s\n", indent, at(x.Pos))
+		wr.writeNode(x.Pipe, indent+"Pipe. ")
+		wr.writeNode(x.List, indent+"List. ")
+		wr.writeNode(x.ElseList, indent+"Else. ")
+	case *parse.ChainNode:
+		fmt.Fprintf(wr.w, "%sChainNode at %s, %v\n", indent, at(x.Pos), x.Field)
+	case *parse.CommandNode:
+		fmt.Fprintf(wr.w, "%sCommandNode at %s, %d children\n", indent, at(x.Pos), len(x.Args))
+		for _, a := range x.Args {
+			wr.writeNode(a, indent+". ")
+		}
+	//case *parse.CommentNode: // 1.16
+	case *parse.DotNode:
+		fmt.Fprintf(wr.w, "%sDotNode at %s\n", indent, at(x.Pos))
+	case *parse.FieldNode:
+		fmt.Fprintf(wr.w, "%sFieldNode at %s, %v\n", indent, at(x.Pos), x.Ident)
+	case *parse.IdentifierNode:
+		fmt.Fprintf(wr.w, "%sIdentifierNode at %s, %v\n", indent, at(x.Pos), x.Ident)
+	case *parse.IfNode:
+		fmt.Fprintf(wr.w, "%sIfNode at %s\n", indent, at(x.Pos))
+		wr.writeNode(&x.BranchNode, indent+". ")
+	case *parse.ListNode:
+		if x == nil {
+			return // nil BranchNode.ElseList
+		}
+		fmt.Fprintf(wr.w, "%sListNode at %s, %d children\n", indent, at(x.Pos), len(x.Nodes))
+		for _, n := range x.Nodes {
+			wr.writeNode(n, indent+". ")
+		}
+	case *parse.NilNode:
+		fmt.Fprintf(wr.w, "%sNilNode at %s\n", indent, at(x.Pos))
+	case *parse.NumberNode:
+		fmt.Fprintf(wr.w, "%sNumberNode at %s, %s\n", indent, at(x.Pos), x.Text)
+	case *parse.PipeNode:
+		if x == nil {
+			return // {{template "xxx"}}
+		}
+		fmt.Fprintf(wr.w, "%sPipeNode at %s, %d vars, %d cmds, IsAssign:%v\n",
+			indent, at(x.Pos), len(x.Decl), len(x.Cmds), x.IsAssign)
+		for _, d := range x.Decl {
+			wr.writeNode(d, indent+"Decl. ")
+		}
+		for _, c := range x.Cmds {
+			wr.writeNode(c, indent+"Cmd. ")
+		}
+	case *parse.RangeNode:
+		fmt.Fprintf(wr.w, "%sRangeNode at %s\n", indent, at(x.Pos))
+		wr.writeNode(&x.BranchNode, indent+". ")
+	case *parse.StringNode:
+		fmt.Fprintf(wr.w, "%sStringNode at %s, %s\n", indent, at(x.Pos), x.Quoted)
+	case *parse.TemplateNode:
+		fmt.Fprintf(wr.w, "%sTemplateNode at %s, %s\n", indent, at(x.Pos), x.Name)
+		wr.writeNode(x.Pipe, indent+". ")
+	case *parse.TextNode:
+		fmt.Fprintf(wr.w, "%sTextNode at %s, len %d\n", indent, at(x.Pos), len(x.Text))
+	case *parse.VariableNode:
+		fmt.Fprintf(wr.w, "%sVariableNode at %s, %v\n", indent, at(x.Pos), x.Ident)
+	case *parse.WithNode:
+		fmt.Fprintf(wr.w, "%sWithNode at %s\n", indent, at(x.Pos))
+		wr.writeNode(&x.BranchNode, indent+". ")
+	}
+}
+
+// short prints at most 40 bytes of node.String(), for debugging
+func short(n parse.Node) (ret string) {
+	defer func() {
+		if x := recover(); x != nil {
+			// all because of typed nils
+			ret = "NIL"
+		}
+	}()
+	s := n.String()
+	if len(s) > 40 {
+		return s[:40] + "..."
+	}
+	return s
+}
+
+var kindNames = []string{"", "File", "Module", "Namespace", "Package", "Class", "Method", "Property",
+	"Field", "Constructor", "Enum", "Interface", "Function", "Variable", "Constant", "String",
+	"Number", "Boolean", "Array", "Object", "Key", "Null", "EnumMember", "Struct", "Event",
+	"Operator", "TypeParameter"}
+
+func kindStr(k protocol.SymbolKind) string {
+	n := int(k)
+	if n < 1 || n >= len(kindNames) {
+		return fmt.Sprintf("?SymbolKind %d?", n)
+	}
+	return kindNames[n]
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/template/symbols.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/template/symbols.go
@@ -1,0 +1,225 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package template
+
+import (
+	"bytes"
+	"fmt"
+	"text/template/parse"
+	"unicode/utf8"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+)
+
+// in local coordinates, to be translated to protocol.DocumentSymbol
+type symbol struct {
+	start  int // for sorting
+	length int // in runes (unicode code points)
+	name   string
+	kind   protocol.SymbolKind
+	vardef bool // is this a variable definition?
+	// do we care about selection range, or children?
+	// no children yet, and selection range is the same as range
+}
+
+func (s symbol) String() string {
+	return fmt.Sprintf("{%d,%d,%s,%s,%v}", s.start, s.length, s.name, s.kind, s.vardef)
+}
+
+// for FieldNode or VariableNode (or ChainNode?)
+func (p *Parsed) fields(flds []string, x parse.Node) []symbol {
+	ans := []symbol{}
+	// guessing that there are no embedded blanks allowed. The doc is unclear
+	lookfor := ""
+	switch x.(type) {
+	case *parse.FieldNode:
+		for _, f := range flds {
+			lookfor += "." + f // quadratic, but probably ok
+		}
+	case *parse.VariableNode:
+		lookfor = flds[0]
+		for i := 1; i < len(flds); i++ {
+			lookfor += "." + flds[i]
+		}
+	case *parse.ChainNode: // PJW, what are these?
+		for _, f := range flds {
+			lookfor += "." + f // quadratic, but probably ok
+		}
+	default:
+		panic(fmt.Sprintf("%T unexpected in fields()", x))
+	}
+	if len(lookfor) == 0 {
+		panic(fmt.Sprintf("no strings in fields() %#v", x))
+	}
+	startsAt := int(x.Position())
+	ix := bytes.Index(p.buf[startsAt:], []byte(lookfor)) // HasPrefix? PJW?
+	if ix < 0 || ix > len(lookfor) {                     // lookfor expected to be at start (or so)
+		// probably golang.go/#43388, so back up
+		startsAt -= len(flds[0]) + 1
+		ix = bytes.Index(p.buf[startsAt:], []byte(lookfor)) // ix might be 1? PJW
+		if ix < 0 {
+			return ans
+		}
+	}
+	at := ix + startsAt
+	for _, f := range flds {
+		at += 1 // .
+		kind := protocol.Method
+		if f[0] == '$' {
+			kind = protocol.Variable
+		}
+		sym := symbol{name: f, kind: kind, start: at, length: utf8.RuneCount([]byte(f))}
+		if kind == protocol.Variable && len(p.stack) > 1 {
+			if pipe, ok := p.stack[len(p.stack)-2].(*parse.PipeNode); ok {
+				for _, y := range pipe.Decl {
+					if x == y {
+						sym.vardef = true
+					}
+				}
+			}
+		}
+		ans = append(ans, sym)
+		at += len(f)
+	}
+	return ans
+}
+
+func (p *Parsed) findSymbols() {
+	if len(p.stack) == 0 {
+		return
+	}
+	n := p.stack[len(p.stack)-1]
+	pop := func() {
+		p.stack = p.stack[:len(p.stack)-1]
+	}
+	if n == nil { // allowing nil simplifies the code
+		pop()
+		return
+	}
+	nxt := func(nd parse.Node) {
+		p.stack = append(p.stack, nd)
+		p.findSymbols()
+	}
+	switch x := n.(type) {
+	case *parse.ActionNode:
+		nxt(x.Pipe)
+	case *parse.BoolNode:
+		// need to compute the length from the value
+		msg := fmt.Sprintf("%v", x.True)
+		p.symbols = append(p.symbols, symbol{start: int(x.Pos), length: len(msg), kind: protocol.Boolean})
+	case *parse.BranchNode:
+		nxt(x.Pipe)
+		nxt(x.List)
+		nxt(x.ElseList)
+	case *parse.ChainNode:
+		p.symbols = append(p.symbols, p.fields(x.Field, x)...)
+		nxt(x.Node)
+	case *parse.CommandNode:
+		for _, a := range x.Args {
+			nxt(a)
+		}
+	//case *parse.CommentNode: // go 1.16
+	//	log.Printf("implement %d", x.Type())
+	case *parse.DotNode:
+		sym := symbol{name: "dot", kind: protocol.Variable, start: int(x.Pos), length: 1}
+		p.symbols = append(p.symbols, sym)
+	case *parse.FieldNode:
+		p.symbols = append(p.symbols, p.fields(x.Ident, x)...)
+	case *parse.IdentifierNode:
+		sym := symbol{name: x.Ident, kind: protocol.Function, start: int(x.Pos),
+			length: utf8.RuneCount([]byte(x.Ident))}
+		p.symbols = append(p.symbols, sym)
+	case *parse.IfNode:
+		nxt(&x.BranchNode)
+	case *parse.ListNode:
+		if x != nil { // wretched typed nils. Node should have an IfNil
+			for _, nd := range x.Nodes {
+				nxt(nd)
+			}
+		}
+	case *parse.NilNode:
+		sym := symbol{name: "nil", kind: protocol.Constant, start: int(x.Pos), length: 3}
+		p.symbols = append(p.symbols, sym)
+	case *parse.NumberNode:
+		// no name; ascii
+		p.symbols = append(p.symbols, symbol{start: int(x.Pos), length: len(x.Text), kind: protocol.Number})
+	case *parse.PipeNode:
+		if x == nil { // {{template "foo"}}
+			return
+		}
+		for _, d := range x.Decl {
+			nxt(d)
+		}
+		for _, c := range x.Cmds {
+			nxt(c)
+		}
+	case *parse.RangeNode:
+		nxt(&x.BranchNode)
+	case *parse.StringNode:
+		// no name
+		sz := utf8.RuneCount([]byte(x.Text))
+		p.symbols = append(p.symbols, symbol{start: int(x.Pos), length: sz, kind: protocol.String})
+	case *parse.TemplateNode: // invoking a template
+		// x.Pos points to the quote before the name
+		p.symbols = append(p.symbols, symbol{name: x.Name, kind: protocol.Package, start: int(x.Pos) + 1,
+			length: utf8.RuneCount([]byte(x.Name))})
+		nxt(x.Pipe)
+	case *parse.TextNode:
+		if len(x.Text) == 1 && x.Text[0] == '\n' {
+			break
+		}
+		// nothing to report, but build one for hover
+		sz := utf8.RuneCount([]byte(x.Text))
+		p.symbols = append(p.symbols, symbol{start: int(x.Pos), length: sz, kind: protocol.Constant})
+	case *parse.VariableNode:
+		p.symbols = append(p.symbols, p.fields(x.Ident, x)...)
+	case *parse.WithNode:
+		nxt(&x.BranchNode)
+
+	}
+	pop()
+}
+
+// DocumentSymbols returns a heirarchy of the symbols defined in a template file.
+// (The heirarchy is flat. SymbolInformation might be better.)
+func DocumentSymbols(snapshot source.Snapshot, fh source.FileHandle) ([]protocol.DocumentSymbol, error) {
+	if skipTemplates(snapshot) {
+		return nil, nil
+	}
+	buf, err := fh.Read()
+	if err != nil {
+		return nil, err
+	}
+	p := parseBuffer(buf)
+	if p.ParseErr != nil {
+		return nil, p.ParseErr
+	}
+	var ans []protocol.DocumentSymbol
+	for _, s := range p.symbols {
+		if s.kind == protocol.Constant {
+			continue
+		}
+		d := kindStr(s.kind)
+		if d == "Namespace" {
+			d = "Template"
+		}
+		if s.vardef {
+			d += "(def)"
+		} else {
+			d += "(use)"
+		}
+		r := p.Range(s.start, s.length)
+		y := protocol.DocumentSymbol{
+			Name:           s.name,
+			Detail:         d,
+			Kind:           s.kind,
+			Range:          r,
+			SelectionRange: r, // or should this be the entire {{...}}?
+		}
+		ans = append(ans, y)
+	}
+	return ans, nil
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/tests/tests.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/tests/tests.go
@@ -233,7 +233,8 @@ func DefaultOptions(o *source.Options) {
 		source.Mod: {
 			protocol.SourceOrganizeImports: true,
 		},
-		source.Sum: {},
+		source.Sum:  {},
+		source.Tmpl: {},
 	}
 	o.UserOptions.Codelenses[string(command.Test)] = true
 	o.HoverKind = source.SynopsisDocumentation

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57
-	golang.org/x/tools v0.1.1-0.20210429193421-aec13729f180
-	golang.org/x/tools/gopls v0.0.0-20210429193421-aec13729f180
+	golang.org/x/tools v0.1.1-0.20210506192834-c0140e85e11c
+	golang.org/x/tools/gopls v0.0.0-20210506192834-c0140e85e11c
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -80,10 +80,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1-0.20210429193421-aec13729f180 h1:QbLiSa89jGpjevwy+zb4IVvmLYs19zW+HNjfnZknQhQ=
-golang.org/x/tools v0.1.1-0.20210429193421-aec13729f180/go.mod h1:q7cPXv+8VGj9Sx5ckHx2nzMtCSaZFrowzWpjN/cwVb8=
-golang.org/x/tools/gopls v0.0.0-20210429193421-aec13729f180 h1:ImKWmGU3UKJePb4B+NVQac2XukLIao5vPyrRo+Rtr3M=
-golang.org/x/tools/gopls v0.0.0-20210429193421-aec13729f180/go.mod h1:BpTENt6DJuaOZgbyRJ6lYPnWBVjKvxcmYGva5fY1ieU=
+golang.org/x/tools v0.1.1-0.20210506192834-c0140e85e11c h1:Pj1jaoZyxXday8WOYjiTS+Lx8v6jCY85UIHcxjSraUk=
+golang.org/x/tools v0.1.1-0.20210506192834-c0140e85e11c/go.mod h1:sH/Eidr0EddymY8HZSakBo32zU3fG5ovDq874hJLjVg=
+golang.org/x/tools/gopls v0.0.0-20210506192834-c0140e85e11c h1:VHuqlBT5q+9Y9xtv0d5lGX2Z7AG4jt6q7IoD6wL08q8=
+golang.org/x/tools/gopls v0.0.0-20210506192834-c0140e85e11c/go.mod h1:w4OIwUoJx1uwODYTRP8BntbEwZLSwRjETyxT8rjHRRo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This change also includes moving ShowDocument from server to client
according to 062bf4eb (CL 315990).

* go/analysis/passes/printf: adjust error message c0140e85
* internal/lsp/source: support typeDefinition for function/method's return values d1ea2c78
* internal/lsp: handle exclude directives in multi-module mode 08a4f343
* internal/lsp/regtest: add a benchmark for didChange f4a41298
* lsp/source: enable experimentalPostfixCompletions by default dd255f23
* passes/stdmethods: warn when an Is, As, or Unwrap has the wrong signature. 19496731
* lsp/completion: improve append() param type inference 68c6cab8
* internal/lsp: add semantic tokens for comments and multiline strings 250398d0
* internal/lsp: support template files 7cab0ef2
* gopls/go.mod: upgrade to Go 1.17 f03daeac
* internal/lsp/regtest: run one quick fix at a time in TestUnknownRevision 42984c42
* go.mod: upgrade to Go 1.17 19b1717e
* all: upgrade go.mod files to Go 1.16 a1fbb681
* internal/lsp: make ShowDocument RPC available to gopls 062bf4eb
* internal/lsp: warn users who have built gopls with go-diff v1.2.0 3e17c62e
* gopls: clarify policy with respect to support for older Go versions def02638
* internal/lsp: don't use ast.NewPackage to build builtin 7a6108e9
* internal/lsp/completion: indicate completion candidates that are deprecated edbe9bef
* internal/lsp/regtest: force GOPACKAGESDRIVER=off 9b9633e0
* gopls/internal/regtest/modfile: set an explicit go version in the TestUnknownRevision modules 291330a8