### PR TITLE
deps: update x/tools & gopls to 49064d2

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2/jsonrpc2.go
+++ b/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2/jsonrpc2.go
@@ -51,6 +51,12 @@ func (defaultHandler) Handle(context.Context, *Request) (interface{}, error) {
 	return nil, ErrNotHandled
 }
 
+type HandlerFunc func(ctx context.Context, req *Request) (interface{}, error)
+
+func (f HandlerFunc) Handle(ctx context.Context, req *Request) (interface{}, error) {
+	return f(ctx, req)
+}
+
 // async is a small helper for things with an asynchronous result that you can
 // wait for.
 type async struct {

--- a/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2/serve.go
+++ b/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2/serve.go
@@ -133,13 +133,18 @@ func isClosingError(err error) bool {
 	if err == nil {
 		return false
 	}
-	// fully unwrap the error, so the following tests work
+	// Fully unwrap the error, so the following tests work.
 	for wrapped := err; wrapped != nil; wrapped = errors.Unwrap(err) {
 		err = wrapped
 	}
 
-	// was it based on an EOF error?
+	// Was it based on an EOF error?
 	if err == io.EOF {
+		return true
+	}
+
+	// Was it based on a closed pipe?
+	if err == io.ErrClosedPipe {
 		return true
 	}
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/general.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/general.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -201,7 +200,7 @@ func (s *Server) initialized(ctx context.Context, params *protocol.InitializedPa
 			},
 		}
 		if options.SemanticTokens {
-			registrations = append(registrations, semanticTokenRegistration())
+			registrations = append(registrations, semanticTokenRegistration(options.SemanticTypes, options.SemanticMods))
 		}
 		if err := s.client.RegisterCapability(ctx, &protocol.RegistrationParams{
 			Registrations: registrations,
@@ -498,8 +497,7 @@ func (s *Server) exit(ctx context.Context) error {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 
-	// TODO: We need a better way to find the conn close method.
-	s.client.(io.Closer).Close()
+	s.client.Close()
 
 	if s.state != serverShutDown {
 		// TODO: We should be able to do better than this.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/binder.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/binder.go
@@ -1,0 +1,109 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package lsprpc
+
+import (
+	"context"
+	"encoding/json"
+
+	jsonrpc2_v2 "github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	errors "golang.org/x/xerrors"
+)
+
+type ServerFunc func(context.Context, protocol.ClientCloser) protocol.Server
+type ClientFunc func(context.Context, protocol.Server) protocol.Client
+
+// ServerBinder binds incoming connections to a new server.
+type ServerBinder struct {
+	newServer ServerFunc
+}
+
+func NewServerBinder(newServer ServerFunc) *ServerBinder {
+	return &ServerBinder{newServer}
+}
+
+func (b *ServerBinder) Bind(ctx context.Context, conn *jsonrpc2_v2.Connection) (jsonrpc2_v2.ConnectionOptions, error) {
+	client := protocol.ClientDispatcherV2(conn)
+	server := b.newServer(ctx, client)
+	serverHandler := protocol.ServerHandlerV2(server)
+	// Wrap the server handler to inject the client into each request context, so
+	// that log events are reflected back to the client.
+	wrapped := jsonrpc2_v2.HandlerFunc(func(ctx context.Context, req *jsonrpc2_v2.Request) (interface{}, error) {
+		ctx = protocol.WithClient(ctx, client)
+		return serverHandler.Handle(ctx, req)
+	})
+	preempter := &canceler{
+		conn: conn,
+	}
+	return jsonrpc2_v2.ConnectionOptions{
+		Handler:   wrapped,
+		Preempter: preempter,
+	}, nil
+}
+
+type canceler struct {
+	conn *jsonrpc2_v2.Connection
+}
+
+func (c *canceler) Preempt(ctx context.Context, req *jsonrpc2_v2.Request) (interface{}, error) {
+	if req.Method != "$/cancelRequest" {
+		return nil, jsonrpc2_v2.ErrNotHandled
+	}
+	var params protocol.CancelParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return nil, errors.Errorf("%w: %v", jsonrpc2_v2.ErrParse, err)
+	}
+	var id jsonrpc2_v2.ID
+	switch raw := params.ID.(type) {
+	case float64:
+		id = jsonrpc2_v2.Int64ID(int64(raw))
+	case string:
+		id = jsonrpc2_v2.StringID(raw)
+	default:
+		return nil, errors.Errorf("%w: invalid ID type %T", jsonrpc2_v2.ErrParse, params.ID)
+	}
+	c.conn.Cancel(id)
+	return nil, nil
+}
+
+type ForwardBinder struct {
+	dialer jsonrpc2_v2.Dialer
+}
+
+func NewForwardBinder(dialer jsonrpc2_v2.Dialer) *ForwardBinder {
+	return &ForwardBinder{
+		dialer: dialer,
+	}
+}
+
+func (b *ForwardBinder) Bind(ctx context.Context, conn *jsonrpc2_v2.Connection) (opts jsonrpc2_v2.ConnectionOptions, _ error) {
+	client := protocol.ClientDispatcherV2(conn)
+	clientBinder := NewClientBinder(func(context.Context, protocol.Server) protocol.Client { return client })
+	serverConn, err := jsonrpc2_v2.Dial(context.Background(), b.dialer, clientBinder)
+	if err != nil {
+		return opts, err
+	}
+	server := protocol.ServerDispatcherV2(serverConn)
+	return jsonrpc2_v2.ConnectionOptions{
+		Handler: protocol.ServerHandlerV2(server),
+	}, nil
+}
+
+type ClientBinder struct {
+	newClient ClientFunc
+}
+
+func NewClientBinder(newClient ClientFunc) *ClientBinder {
+	return &ClientBinder{newClient}
+}
+
+func (b *ClientBinder) Bind(ctx context.Context, conn *jsonrpc2_v2.Connection) (jsonrpc2_v2.ConnectionOptions, error) {
+	server := protocol.ServerDispatcherV2(conn)
+	client := b.newClient(ctx, server)
+	return jsonrpc2_v2.ConnectionOptions{
+		Handler: protocol.ClientHandlerV2(client),
+	}, nil
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/lsprpc.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/lsprpc.go
@@ -22,6 +22,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/gocommand"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/jsonrpc2"
+	jsonrpc2_v2 "github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/cache"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/command"
@@ -54,6 +55,19 @@ type StreamServer struct {
 // records RPC statistics.
 func NewStreamServer(cache *cache.Cache, daemon bool) *StreamServer {
 	return &StreamServer{cache: cache, daemon: daemon}
+}
+
+func (s *StreamServer) Binder() *ServerBinder {
+	newServer := func(ctx context.Context, client protocol.ClientCloser) protocol.Server {
+		session := s.cache.NewSession(ctx)
+		server := s.serverForTest
+		if server == nil {
+			server = lsp.NewServer(session, client)
+			debug.GetInstance(ctx).AddService(server, session)
+		}
+		return server
+	}
+	return NewServerBinder(newServer)
 }
 
 // ServeStream implements the jsonrpc2.StreamServer interface, by handling
@@ -280,6 +294,14 @@ func (f *Forwarder) ServeStream(ctx context.Context, clientConn jsonrpc2.Conn) e
 	return err
 }
 
+func (f *Forwarder) Binder() *ForwardBinder {
+	network, address := realNetworkAddress(f.network, f.addr, f.goplsPath)
+	dialer := jsonrpc2_v2.NetDialer(network, address, net.Dialer{
+		Timeout: 5 * time.Second,
+	})
+	return NewForwardBinder(dialer)
+}
+
 func (f *Forwarder) handshake(ctx context.Context) {
 	var (
 		hreq = handshakeRequest{
@@ -328,19 +350,21 @@ func ConnectToRemote(ctx context.Context, addr string, opts ...RemoteOption) (ne
 	return connectToRemote(ctx, network, address, goplsPath, rcfg)
 }
 
+func realNetworkAddress(inNetwork, inAddr, goplsPath string) (network, address string) {
+	if inNetwork != AutoNetwork {
+		return inNetwork, inAddr
+	}
+	// The "auto" network is a fake network used for service discovery. It
+	// resolves a known address based on gopls binary path.
+	return autoNetworkAddress(goplsPath, inAddr)
+}
+
 func connectToRemote(ctx context.Context, inNetwork, inAddr, goplsPath string, rcfg remoteConfig) (net.Conn, error) {
 	var (
 		netConn          net.Conn
 		err              error
-		network, address = inNetwork, inAddr
+		network, address = realNetworkAddress(inNetwork, inAddr, goplsPath)
 	)
-	if inNetwork == AutoNetwork {
-		// f.network is overloaded to support a concept of 'automatic' addresses,
-		// which signals that the gopls remote address should be automatically
-		// derived.
-		// So we need to resolve a real network and address here.
-		network, address = autoNetworkAddress(goplsPath, inAddr)
-	}
 	// Attempt to verify that we own the remote. This is imperfect, but if we can
 	// determine that the remote is owned by a different user, we should fail.
 	ok, err := verifyRemoteOwnership(network, address)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/protocol.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/protocol.go
@@ -8,36 +8,105 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/jsonrpc2"
+	jsonrpc2_v2 "github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/xcontext"
 	errors "golang.org/x/xerrors"
 )
 
 var (
 	// RequestCancelledError should be used when a request is cancelled early.
-	RequestCancelledError = jsonrpc2.NewError(-32800, "JSON RPC cancelled")
+	RequestCancelledError   = jsonrpc2.NewError(-32800, "JSON RPC cancelled")
+	RequestCancelledErrorV2 = jsonrpc2_v2.NewError(-32800, "JSON RPC cancelled")
 )
 
-// ClientDispatcher returns a Client that dispatches LSP requests across the
-// given jsonrpc2 connection.
-func ClientDispatcher(conn jsonrpc2.Conn) Client {
-	return &clientDispatcher{Conn: conn}
+type ClientCloser interface {
+	Client
+	io.Closer
+}
+
+type connSender interface {
+	io.Closer
+
+	Notify(ctx context.Context, method string, params interface{}) error
+	Call(ctx context.Context, method string, params, result interface{}) error
 }
 
 type clientDispatcher struct {
-	jsonrpc2.Conn
+	sender connSender
+}
+
+func (c *clientDispatcher) Close() error {
+	return c.sender.Close()
+}
+
+// ClientDispatcher returns a Client that dispatches LSP requests across the
+// given jsonrpc2 connection.
+func ClientDispatcher(conn jsonrpc2.Conn) ClientCloser {
+	return &clientDispatcher{sender: clientConn{conn}}
+}
+
+type clientConn struct {
+	conn jsonrpc2.Conn
+}
+
+func (c clientConn) Close() error {
+	return c.conn.Close()
+}
+
+func (c clientConn) Notify(ctx context.Context, method string, params interface{}) error {
+	return c.conn.Notify(ctx, method, params)
+}
+
+func (c clientConn) Call(ctx context.Context, method string, params interface{}, result interface{}) error {
+	id, err := c.conn.Call(ctx, method, params, result)
+	if ctx.Err() != nil {
+		cancelCall(ctx, c, id)
+	}
+	return err
+}
+
+func ClientDispatcherV2(conn *jsonrpc2_v2.Connection) ClientCloser {
+	return &clientDispatcher{clientConnV2{conn}}
+}
+
+type clientConnV2 struct {
+	conn *jsonrpc2_v2.Connection
+}
+
+func (c clientConnV2) Close() error {
+	return c.conn.Close()
+}
+
+func (c clientConnV2) Notify(ctx context.Context, method string, params interface{}) error {
+	return c.conn.Notify(ctx, method, params)
+}
+
+func (c clientConnV2) Call(ctx context.Context, method string, params interface{}, result interface{}) error {
+	call := c.conn.Call(ctx, method, params)
+	err := call.Await(ctx, result)
+	if ctx.Err() != nil {
+		detached := xcontext.Detach(ctx)
+		c.conn.Notify(detached, "$/cancelRequest", &CancelParams{ID: call.ID().Raw()})
+	}
+	return err
 }
 
 // ServerDispatcher returns a Server that dispatches LSP requests across the
 // given jsonrpc2 connection.
 func ServerDispatcher(conn jsonrpc2.Conn) Server {
-	return &serverDispatcher{Conn: conn}
+	return &serverDispatcher{sender: clientConn{conn}}
+}
+
+func ServerDispatcherV2(conn *jsonrpc2_v2.Connection) Server {
+	return &serverDispatcher{sender: clientConnV2{conn}}
 }
 
 type serverDispatcher struct {
-	jsonrpc2.Conn
+	sender connSender
 }
 
 func ClientHandler(client Client, handler jsonrpc2.Handler) jsonrpc2.Handler {
@@ -52,6 +121,28 @@ func ClientHandler(client Client, handler jsonrpc2.Handler) jsonrpc2.Handler {
 		}
 		return handler(ctx, reply, req)
 	}
+}
+
+func ClientHandlerV2(client Client) jsonrpc2_v2.Handler {
+	return jsonrpc2_v2.HandlerFunc(func(ctx context.Context, req *jsonrpc2_v2.Request) (interface{}, error) {
+		if ctx.Err() != nil {
+			return nil, RequestCancelledErrorV2
+		}
+		req1 := req2to1(req)
+		var (
+			result interface{}
+			resErr error
+		)
+		replier := func(_ context.Context, res interface{}, err error) error {
+			result, resErr = res, err
+			return nil
+		}
+		_, err := clientDispatch(ctx, client, replier, req1)
+		if err != nil {
+			return nil, err
+		}
+		return result, resErr
+	})
 }
 
 func ServerHandler(server Server, handler jsonrpc2.Handler) jsonrpc2.Handler {
@@ -76,6 +167,54 @@ func ServerHandler(server Server, handler jsonrpc2.Handler) jsonrpc2.Handler {
 
 	}
 }
+
+func ServerHandlerV2(server Server) jsonrpc2_v2.Handler {
+	return jsonrpc2_v2.HandlerFunc(func(ctx context.Context, req *jsonrpc2_v2.Request) (interface{}, error) {
+		if ctx.Err() != nil {
+			return nil, RequestCancelledErrorV2
+		}
+		req1 := req2to1(req)
+		var (
+			result interface{}
+			resErr error
+		)
+		replier := func(_ context.Context, res interface{}, err error) error {
+			result, resErr = res, err
+			return nil
+		}
+		_, err := serverDispatch(ctx, server, replier, req1)
+		if err != nil {
+			return nil, err
+		}
+		return result, resErr
+	})
+}
+
+func req2to1(req2 *jsonrpc2_v2.Request) jsonrpc2.Request {
+	if req2.ID.IsValid() {
+		raw := req2.ID.Raw()
+		var idv1 jsonrpc2.ID
+		switch v := raw.(type) {
+		case int64:
+			idv1 = jsonrpc2.NewIntID(v)
+		case string:
+			idv1 = jsonrpc2.NewStringID(v)
+		default:
+			panic(fmt.Sprintf("unsupported ID type %T", raw))
+		}
+		req1, err := jsonrpc2.NewCall(idv1, req2.Method, req2.Params)
+		if err != nil {
+			panic(err)
+		}
+		return req1
+	}
+	req1, err := jsonrpc2.NewNotification(req2.Method, req2.Params)
+	if err != nil {
+		panic(err)
+	}
+	return req1
+}
+
 func Handlers(handler jsonrpc2.Handler) jsonrpc2.Handler {
 	return CancelHandler(
 		jsonrpc2.AsyncHandler(
@@ -120,17 +259,17 @@ func CancelHandler(handler jsonrpc2.Handler) jsonrpc2.Handler {
 func Call(ctx context.Context, conn jsonrpc2.Conn, method string, params interface{}, result interface{}) error {
 	id, err := conn.Call(ctx, method, params, result)
 	if ctx.Err() != nil {
-		cancelCall(ctx, conn, id)
+		cancelCall(ctx, clientConn{conn}, id)
 	}
 	return err
 }
 
-func cancelCall(ctx context.Context, conn jsonrpc2.Conn, id jsonrpc2.ID) {
+func cancelCall(ctx context.Context, sender connSender, id jsonrpc2.ID) {
 	ctx = xcontext.Detach(ctx)
 	ctx, done := event.Start(ctx, "protocol.canceller")
 	defer done()
 	// Note that only *jsonrpc2.ID implements json.Marshaler.
-	conn.Notify(ctx, "$/cancelRequest", &CancelParams{ID: &id})
+	sender.Notify(ctx, "$/cancelRequest", &CancelParams{ID: &id})
 }
 
 func sendParseError(ctx context.Context, reply jsonrpc2.Replier, err error) error {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsclient.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsclient.go
@@ -7,7 +7,7 @@ package protocol
 // Package protocol contains data types and code for LSP jsonrpcs
 // generated automatically from vscode-languageserver-node
 // commit: d58c00bbf8837b9fd0144924db5e7b1c543d839e
-// last fetched Sat Apr 17 2021 08:26:29 GMT-0400 (Eastern Daylight Time)
+// last fetched Tue May 18 2021 13:45:07 GMT-0400 (Eastern Daylight Time)
 
 // Code generated (see typescript/README.md) DO NOT EDIT.
 
@@ -134,27 +134,27 @@ func clientDispatch(ctx context.Context, client Client, reply jsonrpc2.Replier, 
 }
 
 func (s *clientDispatcher) ShowMessage(ctx context.Context, params *ShowMessageParams) error {
-	return s.Conn.Notify(ctx, "window/showMessage", params)
+	return s.sender.Notify(ctx, "window/showMessage", params)
 }
 
 func (s *clientDispatcher) LogMessage(ctx context.Context, params *LogMessageParams) error {
-	return s.Conn.Notify(ctx, "window/logMessage", params)
+	return s.sender.Notify(ctx, "window/logMessage", params)
 }
 
 func (s *clientDispatcher) Event(ctx context.Context, params *interface{}) error {
-	return s.Conn.Notify(ctx, "telemetry/event", params)
+	return s.sender.Notify(ctx, "telemetry/event", params)
 }
 
 func (s *clientDispatcher) PublishDiagnostics(ctx context.Context, params *PublishDiagnosticsParams) error {
-	return s.Conn.Notify(ctx, "textDocument/publishDiagnostics", params)
+	return s.sender.Notify(ctx, "textDocument/publishDiagnostics", params)
 }
 
 func (s *clientDispatcher) Progress(ctx context.Context, params *ProgressParams) error {
-	return s.Conn.Notify(ctx, "$/progress", params)
+	return s.sender.Notify(ctx, "$/progress", params)
 }
 func (s *clientDispatcher) WorkspaceFolders(ctx context.Context) ([]WorkspaceFolder /*WorkspaceFolder[] | null*/, error) {
 	var result []WorkspaceFolder /*WorkspaceFolder[] | null*/
-	if err := Call(ctx, s.Conn, "workspace/workspaceFolders", nil, &result); err != nil {
+	if err := s.sender.Call(ctx, "workspace/workspaceFolders", nil, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -162,35 +162,35 @@ func (s *clientDispatcher) WorkspaceFolders(ctx context.Context) ([]WorkspaceFol
 
 func (s *clientDispatcher) Configuration(ctx context.Context, params *ParamConfiguration) ([]interface{}, error) {
 	var result []interface{}
-	if err := Call(ctx, s.Conn, "workspace/configuration", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "workspace/configuration", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
 func (s *clientDispatcher) WorkDoneProgressCreate(ctx context.Context, params *WorkDoneProgressCreateParams) error {
-	return Call(ctx, s.Conn, "window/workDoneProgress/create", params, nil) // Call, not Notify
+	return s.sender.Call(ctx, "window/workDoneProgress/create", params, nil) // Call, not Notify
 }
 
 func (s *clientDispatcher) ShowDocument(ctx context.Context, params *ShowDocumentParams) (*ShowDocumentResult, error) {
 	var result *ShowDocumentResult
-	if err := Call(ctx, s.Conn, "window/showDocument", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "window/showDocument", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
 func (s *clientDispatcher) RegisterCapability(ctx context.Context, params *RegistrationParams) error {
-	return Call(ctx, s.Conn, "client/registerCapability", params, nil) // Call, not Notify
+	return s.sender.Call(ctx, "client/registerCapability", params, nil) // Call, not Notify
 }
 
 func (s *clientDispatcher) UnregisterCapability(ctx context.Context, params *UnregistrationParams) error {
-	return Call(ctx, s.Conn, "client/unregisterCapability", params, nil) // Call, not Notify
+	return s.sender.Call(ctx, "client/unregisterCapability", params, nil) // Call, not Notify
 }
 
 func (s *clientDispatcher) ShowMessageRequest(ctx context.Context, params *ShowMessageRequestParams) (*MessageActionItem /*MessageActionItem | null*/, error) {
 	var result *MessageActionItem /*MessageActionItem | null*/
-	if err := Call(ctx, s.Conn, "window/showMessageRequest", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "window/showMessageRequest", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -198,7 +198,7 @@ func (s *clientDispatcher) ShowMessageRequest(ctx context.Context, params *ShowM
 
 func (s *clientDispatcher) ApplyEdit(ctx context.Context, params *ApplyWorkspaceEditParams) (*ApplyWorkspaceEditResponse, error) {
 	var result *ApplyWorkspaceEditResponse
-	if err := Call(ctx, s.Conn, "workspace/applyEdit", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "workspace/applyEdit", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsprotocol.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsprotocol.go
@@ -5,7 +5,7 @@
 // Package protocol contains data types and code for LSP jsonrpcs
 // generated automatically from vscode-languageserver-node
 // commit: d58c00bbf8837b9fd0144924db5e7b1c543d839e
-// last fetched Sat Apr 17 2021 08:26:29 GMT-0400 (Eastern Daylight Time)
+// last fetched Tue May 18 2021 13:45:07 GMT-0400 (Eastern Daylight Time)
 package protocol
 
 // Code generated (see typescript/README.md) DO NOT EDIT.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsserver.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsserver.go
@@ -7,7 +7,7 @@ package protocol
 // Package protocol contains data types and code for LSP jsonrpcs
 // generated automatically from vscode-languageserver-node
 // commit: d58c00bbf8837b9fd0144924db5e7b1c543d839e
-// last fetched Sat Apr 17 2021 08:26:29 GMT-0400 (Eastern Daylight Time)
+// last fetched Tue May 18 2021 13:45:07 GMT-0400 (Eastern Daylight Time)
 
 // Code generated (see typescript/README.md) DO NOT EDIT.
 
@@ -530,71 +530,71 @@ func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, 
 }
 
 func (s *serverDispatcher) DidChangeWorkspaceFolders(ctx context.Context, params *DidChangeWorkspaceFoldersParams) error {
-	return s.Conn.Notify(ctx, "workspace/didChangeWorkspaceFolders", params)
+	return s.sender.Notify(ctx, "workspace/didChangeWorkspaceFolders", params)
 }
 
 func (s *serverDispatcher) WorkDoneProgressCancel(ctx context.Context, params *WorkDoneProgressCancelParams) error {
-	return s.Conn.Notify(ctx, "window/workDoneProgress/cancel", params)
+	return s.sender.Notify(ctx, "window/workDoneProgress/cancel", params)
 }
 
 func (s *serverDispatcher) DidCreateFiles(ctx context.Context, params *CreateFilesParams) error {
-	return s.Conn.Notify(ctx, "workspace/didCreateFiles", params)
+	return s.sender.Notify(ctx, "workspace/didCreateFiles", params)
 }
 
 func (s *serverDispatcher) DidRenameFiles(ctx context.Context, params *RenameFilesParams) error {
-	return s.Conn.Notify(ctx, "workspace/didRenameFiles", params)
+	return s.sender.Notify(ctx, "workspace/didRenameFiles", params)
 }
 
 func (s *serverDispatcher) DidDeleteFiles(ctx context.Context, params *DeleteFilesParams) error {
-	return s.Conn.Notify(ctx, "workspace/didDeleteFiles", params)
+	return s.sender.Notify(ctx, "workspace/didDeleteFiles", params)
 }
 
 func (s *serverDispatcher) Initialized(ctx context.Context, params *InitializedParams) error {
-	return s.Conn.Notify(ctx, "initialized", params)
+	return s.sender.Notify(ctx, "initialized", params)
 }
 
 func (s *serverDispatcher) Exit(ctx context.Context) error {
-	return s.Conn.Notify(ctx, "exit", nil)
+	return s.sender.Notify(ctx, "exit", nil)
 }
 
 func (s *serverDispatcher) DidChangeConfiguration(ctx context.Context, params *DidChangeConfigurationParams) error {
-	return s.Conn.Notify(ctx, "workspace/didChangeConfiguration", params)
+	return s.sender.Notify(ctx, "workspace/didChangeConfiguration", params)
 }
 
 func (s *serverDispatcher) DidOpen(ctx context.Context, params *DidOpenTextDocumentParams) error {
-	return s.Conn.Notify(ctx, "textDocument/didOpen", params)
+	return s.sender.Notify(ctx, "textDocument/didOpen", params)
 }
 
 func (s *serverDispatcher) DidChange(ctx context.Context, params *DidChangeTextDocumentParams) error {
-	return s.Conn.Notify(ctx, "textDocument/didChange", params)
+	return s.sender.Notify(ctx, "textDocument/didChange", params)
 }
 
 func (s *serverDispatcher) DidClose(ctx context.Context, params *DidCloseTextDocumentParams) error {
-	return s.Conn.Notify(ctx, "textDocument/didClose", params)
+	return s.sender.Notify(ctx, "textDocument/didClose", params)
 }
 
 func (s *serverDispatcher) DidSave(ctx context.Context, params *DidSaveTextDocumentParams) error {
-	return s.Conn.Notify(ctx, "textDocument/didSave", params)
+	return s.sender.Notify(ctx, "textDocument/didSave", params)
 }
 
 func (s *serverDispatcher) WillSave(ctx context.Context, params *WillSaveTextDocumentParams) error {
-	return s.Conn.Notify(ctx, "textDocument/willSave", params)
+	return s.sender.Notify(ctx, "textDocument/willSave", params)
 }
 
 func (s *serverDispatcher) DidChangeWatchedFiles(ctx context.Context, params *DidChangeWatchedFilesParams) error {
-	return s.Conn.Notify(ctx, "workspace/didChangeWatchedFiles", params)
+	return s.sender.Notify(ctx, "workspace/didChangeWatchedFiles", params)
 }
 
 func (s *serverDispatcher) SetTrace(ctx context.Context, params *SetTraceParams) error {
-	return s.Conn.Notify(ctx, "$/setTrace", params)
+	return s.sender.Notify(ctx, "$/setTrace", params)
 }
 
 func (s *serverDispatcher) LogTrace(ctx context.Context, params *LogTraceParams) error {
-	return s.Conn.Notify(ctx, "$/logTrace", params)
+	return s.sender.Notify(ctx, "$/logTrace", params)
 }
 func (s *serverDispatcher) Implementation(ctx context.Context, params *ImplementationParams) (Definition /*Definition | DefinitionLink[] | null*/, error) {
 	var result Definition /*Definition | DefinitionLink[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/implementation", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/implementation", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -602,7 +602,7 @@ func (s *serverDispatcher) Implementation(ctx context.Context, params *Implement
 
 func (s *serverDispatcher) TypeDefinition(ctx context.Context, params *TypeDefinitionParams) (Definition /*Definition | DefinitionLink[] | null*/, error) {
 	var result Definition /*Definition | DefinitionLink[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/typeDefinition", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/typeDefinition", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -610,7 +610,7 @@ func (s *serverDispatcher) TypeDefinition(ctx context.Context, params *TypeDefin
 
 func (s *serverDispatcher) DocumentColor(ctx context.Context, params *DocumentColorParams) ([]ColorInformation, error) {
 	var result []ColorInformation
-	if err := Call(ctx, s.Conn, "textDocument/documentColor", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/documentColor", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -618,7 +618,7 @@ func (s *serverDispatcher) DocumentColor(ctx context.Context, params *DocumentCo
 
 func (s *serverDispatcher) ColorPresentation(ctx context.Context, params *ColorPresentationParams) ([]ColorPresentation, error) {
 	var result []ColorPresentation
-	if err := Call(ctx, s.Conn, "textDocument/colorPresentation", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/colorPresentation", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -626,7 +626,7 @@ func (s *serverDispatcher) ColorPresentation(ctx context.Context, params *ColorP
 
 func (s *serverDispatcher) FoldingRange(ctx context.Context, params *FoldingRangeParams) ([]FoldingRange /*FoldingRange[] | null*/, error) {
 	var result []FoldingRange /*FoldingRange[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/foldingRange", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/foldingRange", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -634,7 +634,7 @@ func (s *serverDispatcher) FoldingRange(ctx context.Context, params *FoldingRang
 
 func (s *serverDispatcher) Declaration(ctx context.Context, params *DeclarationParams) (Declaration /*Declaration | DeclarationLink[] | null*/, error) {
 	var result Declaration /*Declaration | DeclarationLink[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/declaration", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/declaration", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -642,7 +642,7 @@ func (s *serverDispatcher) Declaration(ctx context.Context, params *DeclarationP
 
 func (s *serverDispatcher) SelectionRange(ctx context.Context, params *SelectionRangeParams) ([]SelectionRange /*SelectionRange[] | null*/, error) {
 	var result []SelectionRange /*SelectionRange[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/selectionRange", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/selectionRange", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -650,7 +650,7 @@ func (s *serverDispatcher) SelectionRange(ctx context.Context, params *Selection
 
 func (s *serverDispatcher) PrepareCallHierarchy(ctx context.Context, params *CallHierarchyPrepareParams) ([]CallHierarchyItem /*CallHierarchyItem[] | null*/, error) {
 	var result []CallHierarchyItem /*CallHierarchyItem[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/prepareCallHierarchy", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/prepareCallHierarchy", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -658,7 +658,7 @@ func (s *serverDispatcher) PrepareCallHierarchy(ctx context.Context, params *Cal
 
 func (s *serverDispatcher) IncomingCalls(ctx context.Context, params *CallHierarchyIncomingCallsParams) ([]CallHierarchyIncomingCall /*CallHierarchyIncomingCall[] | null*/, error) {
 	var result []CallHierarchyIncomingCall /*CallHierarchyIncomingCall[] | null*/
-	if err := Call(ctx, s.Conn, "callHierarchy/incomingCalls", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "callHierarchy/incomingCalls", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -666,7 +666,7 @@ func (s *serverDispatcher) IncomingCalls(ctx context.Context, params *CallHierar
 
 func (s *serverDispatcher) OutgoingCalls(ctx context.Context, params *CallHierarchyOutgoingCallsParams) ([]CallHierarchyOutgoingCall /*CallHierarchyOutgoingCall[] | null*/, error) {
 	var result []CallHierarchyOutgoingCall /*CallHierarchyOutgoingCall[] | null*/
-	if err := Call(ctx, s.Conn, "callHierarchy/outgoingCalls", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "callHierarchy/outgoingCalls", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -674,7 +674,7 @@ func (s *serverDispatcher) OutgoingCalls(ctx context.Context, params *CallHierar
 
 func (s *serverDispatcher) SemanticTokensFull(ctx context.Context, params *SemanticTokensParams) (*SemanticTokens /*SemanticTokens | null*/, error) {
 	var result *SemanticTokens /*SemanticTokens | null*/
-	if err := Call(ctx, s.Conn, "textDocument/semanticTokens/full", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/semanticTokens/full", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -682,7 +682,7 @@ func (s *serverDispatcher) SemanticTokensFull(ctx context.Context, params *Seman
 
 func (s *serverDispatcher) SemanticTokensFullDelta(ctx context.Context, params *SemanticTokensDeltaParams) (interface{} /* SemanticTokens | SemanticTokensDelta | float64*/, error) {
 	var result interface{} /* SemanticTokens | SemanticTokensDelta | float64*/
-	if err := Call(ctx, s.Conn, "textDocument/semanticTokens/full/delta", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/semanticTokens/full/delta", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -690,19 +690,19 @@ func (s *serverDispatcher) SemanticTokensFullDelta(ctx context.Context, params *
 
 func (s *serverDispatcher) SemanticTokensRange(ctx context.Context, params *SemanticTokensRangeParams) (*SemanticTokens /*SemanticTokens | null*/, error) {
 	var result *SemanticTokens /*SemanticTokens | null*/
-	if err := Call(ctx, s.Conn, "textDocument/semanticTokens/range", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/semanticTokens/range", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
 func (s *serverDispatcher) SemanticTokensRefresh(ctx context.Context) error {
-	return Call(ctx, s.Conn, "workspace/semanticTokens/refresh", nil, nil)
+	return s.sender.Call(ctx, "workspace/semanticTokens/refresh", nil, nil)
 }
 
 func (s *serverDispatcher) LinkedEditingRange(ctx context.Context, params *LinkedEditingRangeParams) (*LinkedEditingRanges /*LinkedEditingRanges | null*/, error) {
 	var result *LinkedEditingRanges /*LinkedEditingRanges | null*/
-	if err := Call(ctx, s.Conn, "textDocument/linkedEditingRange", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/linkedEditingRange", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -710,7 +710,7 @@ func (s *serverDispatcher) LinkedEditingRange(ctx context.Context, params *Linke
 
 func (s *serverDispatcher) WillCreateFiles(ctx context.Context, params *CreateFilesParams) (*WorkspaceEdit /*WorkspaceEdit | null*/, error) {
 	var result *WorkspaceEdit /*WorkspaceEdit | null*/
-	if err := Call(ctx, s.Conn, "workspace/willCreateFiles", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "workspace/willCreateFiles", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -718,7 +718,7 @@ func (s *serverDispatcher) WillCreateFiles(ctx context.Context, params *CreateFi
 
 func (s *serverDispatcher) WillRenameFiles(ctx context.Context, params *RenameFilesParams) (*WorkspaceEdit /*WorkspaceEdit | null*/, error) {
 	var result *WorkspaceEdit /*WorkspaceEdit | null*/
-	if err := Call(ctx, s.Conn, "workspace/willRenameFiles", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "workspace/willRenameFiles", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -726,7 +726,7 @@ func (s *serverDispatcher) WillRenameFiles(ctx context.Context, params *RenameFi
 
 func (s *serverDispatcher) WillDeleteFiles(ctx context.Context, params *DeleteFilesParams) (*WorkspaceEdit /*WorkspaceEdit | null*/, error) {
 	var result *WorkspaceEdit /*WorkspaceEdit | null*/
-	if err := Call(ctx, s.Conn, "workspace/willDeleteFiles", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "workspace/willDeleteFiles", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -734,7 +734,7 @@ func (s *serverDispatcher) WillDeleteFiles(ctx context.Context, params *DeleteFi
 
 func (s *serverDispatcher) Moniker(ctx context.Context, params *MonikerParams) ([]Moniker /*Moniker[] | null*/, error) {
 	var result []Moniker /*Moniker[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/moniker", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/moniker", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -742,19 +742,19 @@ func (s *serverDispatcher) Moniker(ctx context.Context, params *MonikerParams) (
 
 func (s *serverDispatcher) Initialize(ctx context.Context, params *ParamInitialize) (*InitializeResult, error) {
 	var result *InitializeResult
-	if err := Call(ctx, s.Conn, "initialize", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "initialize", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
 func (s *serverDispatcher) Shutdown(ctx context.Context) error {
-	return Call(ctx, s.Conn, "shutdown", nil, nil)
+	return s.sender.Call(ctx, "shutdown", nil, nil)
 }
 
 func (s *serverDispatcher) WillSaveWaitUntil(ctx context.Context, params *WillSaveTextDocumentParams) ([]TextEdit /*TextEdit[] | null*/, error) {
 	var result []TextEdit /*TextEdit[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/willSaveWaitUntil", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/willSaveWaitUntil", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -762,7 +762,7 @@ func (s *serverDispatcher) WillSaveWaitUntil(ctx context.Context, params *WillSa
 
 func (s *serverDispatcher) Completion(ctx context.Context, params *CompletionParams) (*CompletionList /*CompletionItem[] | CompletionList | null*/, error) {
 	var result *CompletionList /*CompletionItem[] | CompletionList | null*/
-	if err := Call(ctx, s.Conn, "textDocument/completion", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/completion", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -770,7 +770,7 @@ func (s *serverDispatcher) Completion(ctx context.Context, params *CompletionPar
 
 func (s *serverDispatcher) Resolve(ctx context.Context, params *CompletionItem) (*CompletionItem, error) {
 	var result *CompletionItem
-	if err := Call(ctx, s.Conn, "completionItem/resolve", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "completionItem/resolve", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -778,7 +778,7 @@ func (s *serverDispatcher) Resolve(ctx context.Context, params *CompletionItem) 
 
 func (s *serverDispatcher) Hover(ctx context.Context, params *HoverParams) (*Hover /*Hover | null*/, error) {
 	var result *Hover /*Hover | null*/
-	if err := Call(ctx, s.Conn, "textDocument/hover", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/hover", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -786,7 +786,7 @@ func (s *serverDispatcher) Hover(ctx context.Context, params *HoverParams) (*Hov
 
 func (s *serverDispatcher) SignatureHelp(ctx context.Context, params *SignatureHelpParams) (*SignatureHelp /*SignatureHelp | null*/, error) {
 	var result *SignatureHelp /*SignatureHelp | null*/
-	if err := Call(ctx, s.Conn, "textDocument/signatureHelp", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/signatureHelp", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -794,7 +794,7 @@ func (s *serverDispatcher) SignatureHelp(ctx context.Context, params *SignatureH
 
 func (s *serverDispatcher) Definition(ctx context.Context, params *DefinitionParams) (Definition /*Definition | DefinitionLink[] | null*/, error) {
 	var result Definition /*Definition | DefinitionLink[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/definition", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/definition", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -802,7 +802,7 @@ func (s *serverDispatcher) Definition(ctx context.Context, params *DefinitionPar
 
 func (s *serverDispatcher) References(ctx context.Context, params *ReferenceParams) ([]Location /*Location[] | null*/, error) {
 	var result []Location /*Location[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/references", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/references", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -810,7 +810,7 @@ func (s *serverDispatcher) References(ctx context.Context, params *ReferencePara
 
 func (s *serverDispatcher) DocumentHighlight(ctx context.Context, params *DocumentHighlightParams) ([]DocumentHighlight /*DocumentHighlight[] | null*/, error) {
 	var result []DocumentHighlight /*DocumentHighlight[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/documentHighlight", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/documentHighlight", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -818,7 +818,7 @@ func (s *serverDispatcher) DocumentHighlight(ctx context.Context, params *Docume
 
 func (s *serverDispatcher) DocumentSymbol(ctx context.Context, params *DocumentSymbolParams) ([]interface{} /*SymbolInformation[] | DocumentSymbol[] | null*/, error) {
 	var result []interface{} /*SymbolInformation[] | DocumentSymbol[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/documentSymbol", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/documentSymbol", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -826,7 +826,7 @@ func (s *serverDispatcher) DocumentSymbol(ctx context.Context, params *DocumentS
 
 func (s *serverDispatcher) CodeAction(ctx context.Context, params *CodeActionParams) ([]CodeAction /*(Command | CodeAction)[] | null*/, error) {
 	var result []CodeAction /*(Command | CodeAction)[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/codeAction", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/codeAction", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -834,7 +834,7 @@ func (s *serverDispatcher) CodeAction(ctx context.Context, params *CodeActionPar
 
 func (s *serverDispatcher) ResolveCodeAction(ctx context.Context, params *CodeAction) (*CodeAction, error) {
 	var result *CodeAction
-	if err := Call(ctx, s.Conn, "codeAction/resolve", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "codeAction/resolve", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -842,7 +842,7 @@ func (s *serverDispatcher) ResolveCodeAction(ctx context.Context, params *CodeAc
 
 func (s *serverDispatcher) Symbol(ctx context.Context, params *WorkspaceSymbolParams) ([]SymbolInformation /*SymbolInformation[] | null*/, error) {
 	var result []SymbolInformation /*SymbolInformation[] | null*/
-	if err := Call(ctx, s.Conn, "workspace/symbol", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "workspace/symbol", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -850,7 +850,7 @@ func (s *serverDispatcher) Symbol(ctx context.Context, params *WorkspaceSymbolPa
 
 func (s *serverDispatcher) CodeLens(ctx context.Context, params *CodeLensParams) ([]CodeLens /*CodeLens[] | null*/, error) {
 	var result []CodeLens /*CodeLens[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/codeLens", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/codeLens", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -858,19 +858,19 @@ func (s *serverDispatcher) CodeLens(ctx context.Context, params *CodeLensParams)
 
 func (s *serverDispatcher) ResolveCodeLens(ctx context.Context, params *CodeLens) (*CodeLens, error) {
 	var result *CodeLens
-	if err := Call(ctx, s.Conn, "codeLens/resolve", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "codeLens/resolve", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
 func (s *serverDispatcher) CodeLensRefresh(ctx context.Context) error {
-	return Call(ctx, s.Conn, "workspace/codeLens/refresh", nil, nil)
+	return s.sender.Call(ctx, "workspace/codeLens/refresh", nil, nil)
 }
 
 func (s *serverDispatcher) DocumentLink(ctx context.Context, params *DocumentLinkParams) ([]DocumentLink /*DocumentLink[] | null*/, error) {
 	var result []DocumentLink /*DocumentLink[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/documentLink", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/documentLink", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -878,7 +878,7 @@ func (s *serverDispatcher) DocumentLink(ctx context.Context, params *DocumentLin
 
 func (s *serverDispatcher) ResolveDocumentLink(ctx context.Context, params *DocumentLink) (*DocumentLink, error) {
 	var result *DocumentLink
-	if err := Call(ctx, s.Conn, "documentLink/resolve", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "documentLink/resolve", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -886,7 +886,7 @@ func (s *serverDispatcher) ResolveDocumentLink(ctx context.Context, params *Docu
 
 func (s *serverDispatcher) Formatting(ctx context.Context, params *DocumentFormattingParams) ([]TextEdit /*TextEdit[] | null*/, error) {
 	var result []TextEdit /*TextEdit[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/formatting", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/formatting", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -894,7 +894,7 @@ func (s *serverDispatcher) Formatting(ctx context.Context, params *DocumentForma
 
 func (s *serverDispatcher) RangeFormatting(ctx context.Context, params *DocumentRangeFormattingParams) ([]TextEdit /*TextEdit[] | null*/, error) {
 	var result []TextEdit /*TextEdit[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/rangeFormatting", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/rangeFormatting", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -902,7 +902,7 @@ func (s *serverDispatcher) RangeFormatting(ctx context.Context, params *Document
 
 func (s *serverDispatcher) OnTypeFormatting(ctx context.Context, params *DocumentOnTypeFormattingParams) ([]TextEdit /*TextEdit[] | null*/, error) {
 	var result []TextEdit /*TextEdit[] | null*/
-	if err := Call(ctx, s.Conn, "textDocument/onTypeFormatting", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/onTypeFormatting", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -910,7 +910,7 @@ func (s *serverDispatcher) OnTypeFormatting(ctx context.Context, params *Documen
 
 func (s *serverDispatcher) Rename(ctx context.Context, params *RenameParams) (*WorkspaceEdit /*WorkspaceEdit | null*/, error) {
 	var result *WorkspaceEdit /*WorkspaceEdit | null*/
-	if err := Call(ctx, s.Conn, "textDocument/rename", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/rename", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -918,7 +918,7 @@ func (s *serverDispatcher) Rename(ctx context.Context, params *RenameParams) (*W
 
 func (s *serverDispatcher) PrepareRename(ctx context.Context, params *PrepareRenameParams) (*Range /*Range | { range: Range, placeholder: string } | { defaultBehavior: boolean } | null*/, error) {
 	var result *Range /*Range | { range: Range, placeholder: string } | { defaultBehavior: boolean } | null*/
-	if err := Call(ctx, s.Conn, "textDocument/prepareRename", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/prepareRename", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -926,7 +926,7 @@ func (s *serverDispatcher) PrepareRename(ctx context.Context, params *PrepareRen
 
 func (s *serverDispatcher) ExecuteCommand(ctx context.Context, params *ExecuteCommandParams) (interface{} /*any | null*/, error) {
 	var result interface{} /*any | null*/
-	if err := Call(ctx, s.Conn, "workspace/executeCommand", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "workspace/executeCommand", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -934,7 +934,7 @@ func (s *serverDispatcher) ExecuteCommand(ctx context.Context, params *ExecuteCo
 
 func (s *serverDispatcher) Diagnostic(ctx context.Context, params *string) (*string, error) {
 	var result *string
-	if err := Call(ctx, s.Conn, "textDocument/diagnostic", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "textDocument/diagnostic", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -942,19 +942,19 @@ func (s *serverDispatcher) Diagnostic(ctx context.Context, params *string) (*str
 
 func (s *serverDispatcher) DiagnosticWorkspace(ctx context.Context, params *WorkspaceDiagnosticParams) (*WorkspaceDiagnosticReport, error) {
 	var result *WorkspaceDiagnosticReport
-	if err := Call(ctx, s.Conn, "workspace/diagnostic", params, &result); err != nil {
+	if err := s.sender.Call(ctx, "workspace/diagnostic", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
 func (s *serverDispatcher) DiagnosticRefresh(ctx context.Context) error {
-	return Call(ctx, s.Conn, "workspace/diagnostic/refresh", nil, nil)
+	return s.sender.Call(ctx, "workspace/diagnostic/refresh", nil, nil)
 }
 
 func (s *serverDispatcher) NonstandardRequest(ctx context.Context, method string, params interface{}) (interface{}, error) {
 	var result interface{}
-	if err := Call(ctx, s.Conn, method, params, &result); err != nil {
+	if err := s.sender.Call(ctx, method, params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/server.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/server.go
@@ -21,7 +21,7 @@ const concurrentAnalyses = 1
 
 // NewServer creates an LSP server and binds it to handle incoming client
 // messages on on the supplied stream.
-func NewServer(session source.Session, client protocol.Client) *Server {
+func NewServer(session source.Session, client protocol.ClientCloser) *Server {
 	return &Server{
 		diagnostics:           map[span.URI]*fileReports{},
 		gcOptimizationDetails: make(map[string]struct{}),
@@ -60,7 +60,7 @@ func (s serverState) String() string {
 
 // Server implements the protocol.Server interface.
 type Server struct {
-	client protocol.Client
+	client protocol.ClientCloser
 
 	stateMu sync.Mutex
 	state   serverState

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/format.go
@@ -223,7 +223,7 @@ func (c *completer) item(ctx context.Context, cand candidate) (CompletionItem, e
 	if err != nil {
 		return CompletionItem{}, err
 	}
-	hover, err := source.HoverInfo(ctx, c.snapshot, pkg, obj, decl)
+	hover, err := source.HoverInfo(ctx, c.snapshot, pkg, obj, decl, nil)
 	if err != nil {
 		event.Error(ctx, "failed to find Hover", err, tag.URI.Of(uri))
 		return item, nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/identifier.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/identifier.go
@@ -8,13 +8,16 @@ import (
 	"context"
 	"fmt"
 	"go/ast"
+	"go/parser"
 	"go/token"
 	"go/types"
 	"sort"
 	"strconv"
 
+	"golang.org/x/tools/go/ast/astutil"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 	errors "golang.org/x/xerrors"
 )
 
@@ -48,8 +51,16 @@ func (i *IdentifierInfo) IsImport() bool {
 
 type Declaration struct {
 	MappedRange []MappedRange
-	node        ast.Node
-	obj         types.Object
+
+	// The typechecked node.
+	node ast.Node
+	// Optional: the fully parsed spec, to be used for formatting in cases where
+	// node has missing information. This could be the case when node was parsed
+	// in ParseExported mode.
+	fullSpec ast.Spec
+
+	// The typechecked object.
+	obj types.Object
 
 	// typeSwitchImplicit indicates that the declaration is in an implicit
 	// type switch. Its type is the type of the variable on the right-hand
@@ -88,7 +99,7 @@ func Identifier(ctx context.Context, snapshot Snapshot, fh FileHandle, pos proto
 			return nil, err
 		}
 		var ident *IdentifierInfo
-		ident, findErr = findIdentifier(ctx, snapshot, pkg, pgf.File, rng.Start)
+		ident, findErr = findIdentifier(ctx, snapshot, pkg, pgf, rng.Start)
 		if findErr == nil {
 			return ident, nil
 		}
@@ -99,7 +110,8 @@ func Identifier(ctx context.Context, snapshot Snapshot, fh FileHandle, pos proto
 // ErrNoIdentFound is error returned when no identifer is found at a particular position
 var ErrNoIdentFound = errors.New("no identifier found")
 
-func findIdentifier(ctx context.Context, snapshot Snapshot, pkg Package, file *ast.File, pos token.Pos) (*IdentifierInfo, error) {
+func findIdentifier(ctx context.Context, snapshot Snapshot, pkg Package, pgf *ParsedGoFile, pos token.Pos) (*IdentifierInfo, error) {
+	file := pgf.File
 	// Handle import specs separately, as there is no formal position for a
 	// package declaration.
 	if result, err := importSpec(snapshot, pkg, file, pos); result != nil || err != nil {
@@ -269,6 +281,12 @@ func findIdentifier(ctx context.Context, snapshot Snapshot, pkg Package, file *a
 	if result.Declaration.node, err = snapshot.PosToDecl(ctx, declPkg, result.Declaration.obj.Pos()); err != nil {
 		return nil, err
 	}
+	// Ensure that we have the full declaration, in case the declaration was
+	// parsed in ParseExported and therefore could be missing information.
+	result.Declaration.fullSpec, err = fullSpec(snapshot, result.Declaration.obj, declPkg)
+	if err != nil {
+		return nil, err
+	}
 	typ := pkg.GetTypesInfo().TypeOf(result.ident)
 	if typ == nil {
 		return result, nil
@@ -285,6 +303,38 @@ func findIdentifier(ctx context.Context, snapshot Snapshot, pkg Package, file *a
 		}
 	}
 	return result, nil
+}
+
+// fullSpec tries to extract the full spec corresponding to obj's declaration.
+// If the package was not parsed in full, the declaration file will be
+// re-parsed to ensure it has complete syntax.
+func fullSpec(snapshot Snapshot, obj types.Object, pkg Package) (ast.Spec, error) {
+	// declaration in a different package... make sure we have full AST information.
+	tok := snapshot.FileSet().File(obj.Pos())
+	uri := span.URIFromPath(tok.Name())
+	pgf, err := pkg.File(uri)
+	if err != nil {
+		return nil, err
+	}
+	file := pgf.File
+	pos := obj.Pos()
+	if pgf.Mode != ParseFull {
+		fset := snapshot.FileSet()
+		file2, _ := parser.ParseFile(fset, tok.Name(), pgf.Src, parser.AllErrors|parser.ParseComments)
+		if file2 != nil {
+			offset := tok.Offset(obj.Pos())
+			file = file2
+			tok2 := fset.File(file2.Pos())
+			pos = tok2.Pos(offset)
+		}
+	}
+	path, _ := astutil.PathEnclosingInterval(file, pos, pos)
+	if len(path) > 1 {
+		if spec, _ := path[1].(*ast.TypeSpec); spec != nil {
+			return spec, nil
+		}
+	}
+	return nil, nil
 }
 
 func searchForEnclosing(info *types.Info, path []ast.Node) types.Type {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/references.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/references.go
@@ -73,7 +73,7 @@ func references(ctx context.Context, snapshot Snapshot, qos []qualifiedObject, i
 	if err != nil {
 		return nil, err
 	}
-	declIdent, err := findIdentifier(ctx, snapshot, qos[0].pkg, pgf.File, qos[0].obj.Pos())
+	declIdent, err := findIdentifier(ctx, snapshot, qos[0].pkg, pgf, qos[0].obj.Pos())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/signature_help.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/signature_help.go
@@ -110,7 +110,7 @@ FindCall:
 			node: node,
 		}
 		decl.MappedRange = append(decl.MappedRange, rng)
-		d, err := HoverInfo(ctx, snapshot, pkg, decl.obj, decl.node)
+		d, err := HoverInfo(ctx, snapshot, pkg, decl.obj, decl.node, nil)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/workspace.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/workspace.go
@@ -86,10 +86,11 @@ func (s *Server) didChangeConfiguration(ctx context.Context, _ *protocol.DidChan
 		}()
 	}
 
+	registration := semanticTokenRegistration(options.SemanticTypes, options.SemanticMods)
 	// Update any session-specific registrations or unregistrations.
 	if !semanticTokensRegistered && options.SemanticTokens {
 		if err := s.client.RegisterCapability(ctx, &protocol.RegistrationParams{
-			Registrations: []protocol.Registration{semanticTokenRegistration()},
+			Registrations: []protocol.Registration{registration},
 		}); err != nil {
 			return err
 		}
@@ -97,8 +98,8 @@ func (s *Server) didChangeConfiguration(ctx context.Context, _ *protocol.DidChan
 		if err := s.client.UnregisterCapability(ctx, &protocol.UnregistrationParams{
 			Unregisterations: []protocol.Unregistration{
 				{
-					ID:     semanticTokenRegistration().ID,
-					Method: semanticTokenRegistration().Method,
+					ID:     registration.ID,
+					Method: registration.Method,
 				},
 			},
 		}); err != nil {
@@ -108,7 +109,7 @@ func (s *Server) didChangeConfiguration(ctx context.Context, _ *protocol.DidChan
 	return nil
 }
 
-func semanticTokenRegistration() protocol.Registration {
+func semanticTokenRegistration(tokenTypes, tokenModifiers []string) protocol.Registration {
 	return protocol.Registration{
 		ID:     "textDocument/semanticTokens",
 		Method: "textDocument/semanticTokens",
@@ -116,8 +117,8 @@ func semanticTokenRegistration() protocol.Registration {
 			Legend: protocol.SemanticTokensLegend{
 				// TODO(pjw): trim these to what we use (and an unused one
 				// at position 0 of TokTypes, to catch typos)
-				TokenTypes:     SemanticTypes(),
-				TokenModifiers: SemanticModifiers(),
+				TokenTypes:     tokenTypes,
+				TokenModifiers: tokenModifiers,
 			},
 			Full:  true,
 			Range: true,

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
-	golang.org/x/tools v0.1.2-0.20210517171820-8f301ca0d324
-	golang.org/x/tools/gopls v0.0.0-20210517171820-8f301ca0d324
+	golang.org/x/tools v0.1.2-0.20210519160823-49064d2332f9
+	golang.org/x/tools/gopls v0.0.0-20210519160823-49064d2332f9
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -81,10 +81,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.2-0.20210517171820-8f301ca0d324 h1:7bkyQds6vkP3w5UljnWucbkWO6Q/1Vz4yEqanNOzKZo=
-golang.org/x/tools v0.1.2-0.20210517171820-8f301ca0d324/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools/gopls v0.0.0-20210517171820-8f301ca0d324 h1:Gbc8JUNv0ImvHd/gz5xXIaVQaujqkUSNZ8HhLsAze4g=
-golang.org/x/tools/gopls v0.0.0-20210517171820-8f301ca0d324/go.mod h1:FmJMctxBu1t9QN/YAw3b+ofUURc4dvfsf3xmdO8Y6N0=
+golang.org/x/tools v0.1.2-0.20210519160823-49064d2332f9 h1:2XlR/j4I4xz5GQZI7zBjqTfezYyRIE2jD5IMousB2rg=
+golang.org/x/tools v0.1.2-0.20210519160823-49064d2332f9/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools/gopls v0.0.0-20210519160823-49064d2332f9 h1:O4QJZybt8RgBtM9ZQ3DF6NsGMJzC16y6hMZRXdrK5PI=
+golang.org/x/tools/gopls v0.0.0-20210519160823-49064d2332f9/go.mod h1:FmJMctxBu1t9QN/YAw3b+ofUURc4dvfsf3xmdO8Y6N0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/lsp: report used semantic token order in registerCapability 49064d23
* internal/lsp/lsprpc: implement cancellation using jsonrpc2_v2 a0f4b7b8
* internal/lsp/lsprpc: partial integration of the jsonrpc_v2 library f451690e
* internal/jsonrpc2_v2: consider ErrClosedPipe as a closing error 17b34666
* internal/lsp/source: re-parse if needed when collecting identifier info 6da3d7ac