### PR TITLE
deps: update x/tools & gopls to 40613125

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
@@ -41,7 +41,7 @@ type packageHandle struct {
 	mode source.ParseMode
 
 	// m is the metadata associated with the package.
-	m *metadata
+	m *knownMetadata
 
 	// key is the hashed key for the package.
 	key packageHandleKey
@@ -117,7 +117,7 @@ func (s *snapshot) buildPackageHandle(ctx context.Context, id packageID, mode so
 		}
 
 		data := &packageData{}
-		data.pkg, data.err = typeCheck(ctx, snapshot, m, mode, deps)
+		data.pkg, data.err = typeCheck(ctx, snapshot, m.metadata, mode, deps)
 		// Make sure that the workers above have finished before we return,
 		// especially in case of cancellation.
 		wg.Wait()
@@ -167,7 +167,10 @@ func (s *snapshot) buildKey(ctx context.Context, id packageID, mode source.Parse
 	var depKeys []packageHandleKey
 	for _, depID := range depList {
 		depHandle, err := s.buildPackageHandle(ctx, depID, s.workspaceParseMode(depID))
-		if err != nil {
+		// Don't use invalid metadata for dependencies if the top-level
+		// metadata is valid. We only load top-level packages, so if the
+		// top-level is valid, all of its dependencies should be as well.
+		if err != nil || m.valid && !depHandle.m.valid {
 			event.Error(ctx, fmt.Sprintf("%s: no dep handle for %s", id, depID), err, tag.Snapshot.Of(s.id))
 			if ctx.Err() != nil {
 				return nil, nil, ctx.Err()
@@ -500,7 +503,7 @@ func doTypeCheck(ctx context.Context, snapshot *snapshot, m *metadata, mode sour
 			if dep == nil {
 				return nil, snapshot.missingPkgError(pkgPath)
 			}
-			if !isValidImport(m.pkgPath, dep.m.pkgPath) {
+			if !source.IsValidImport(string(m.pkgPath), string(dep.m.pkgPath)) {
 				return nil, errors.Errorf("invalid use of internal package %s", pkgPath)
 			}
 			depPkg, err := dep.check(ctx, snapshot)
@@ -829,17 +832,6 @@ func resolveImportPath(importPath string, pkg *pkg, deps map[packagePath]*packag
 		}
 	}
 	return nil
-}
-
-func isValidImport(pkgPath, importPkgPath packagePath) bool {
-	i := strings.LastIndex(string(importPkgPath), "/internal/")
-	if i == -1 {
-		return true
-	}
-	if isCommandLineArguments(string(pkgPath)) {
-		return true
-	}
-	return strings.HasPrefix(string(pkgPath), string(importPkgPath[:i]))
 }
 
 // An importFunc is an implementation of the single-method

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
@@ -55,7 +55,7 @@ func (s *snapshot) load(ctx context.Context, allowNetwork bool, scopes ...interf
 	for _, scope := range scopes {
 		switch scope := scope.(type) {
 		case packagePath:
-			if isCommandLineArguments(string(scope)) {
+			if source.IsCommandLineArguments(string(scope)) {
 				panic("attempted to load command-line-arguments")
 			}
 			// The only time we pass package paths is when we're doing a
@@ -420,7 +420,7 @@ func (s *snapshot) setMetadata(ctx context.Context, pkgPath packagePath, pkg *pa
 			m.missingDeps[importPkgPath] = struct{}{}
 			continue
 		}
-		if s.getMetadata(importID) == nil {
+		if s.noValidMetadataForID(importID) {
 			if _, err := s.setMetadata(ctx, importPkgPath, importPkg, cfg, copied); err != nil {
 				event.Error(ctx, "error in dependency", err)
 			}
@@ -434,10 +434,13 @@ func (s *snapshot) setMetadata(ctx context.Context, pkgPath packagePath, pkg *pa
 	// TODO: We should make sure not to set duplicate metadata,
 	// and instead panic here. This can be done by making sure not to
 	// reset metadata information for packages we've already seen.
-	if original, ok := s.metadata[m.id]; ok {
-		m = original
+	if original, ok := s.metadata[m.id]; ok && original.valid {
+		m = original.metadata
 	} else {
-		s.metadata[m.id] = m
+		s.metadata[m.id] = &knownMetadata{
+			metadata: m,
+			valid:    true,
+		}
 	}
 
 	// Set the workspace packages. If any of the package's files belong to the

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
@@ -221,7 +221,7 @@ func (s *Session) createView(ctx context.Context, name string, folder, tempWorks
 		generation:        s.cache.store.Generation(generationName(v, 0)),
 		packages:          make(map[packageKey]*packageHandle),
 		ids:               make(map[span.URI][]packageID),
-		metadata:          make(map[packageID]*metadata),
+		metadata:          make(map[packageID]*knownMetadata),
 		files:             make(map[span.URI]source.VersionedFileHandle),
 		goFiles:           make(map[parseKey]*parseGoHandle),
 		importedBy:        make(map[packageID][]packageID),

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
@@ -73,7 +73,7 @@ type snapshot struct {
 
 	// metadata maps file IDs to their associated metadata.
 	// It may invalidated on calls to go/packages.
-	metadata map[packageID]*metadata
+	metadata map[packageID]*knownMetadata
 
 	// importedBy maps package IDs to the list of packages that import them.
 	importedBy map[packageID][]packageID
@@ -121,6 +121,15 @@ type packageKey struct {
 type actionKey struct {
 	pkg      packageKey
 	analyzer *analysis.Analyzer
+}
+
+// knownMetadata is a wrapper around metadata that tracks its validity.
+type knownMetadata struct {
+	*metadata
+
+	// valid is true if the given metadata is valid.
+	// Invalid metadata can still be used if a metadata reload fails.
+	valid bool
 }
 
 func (s *snapshot) ID() uint64 {
@@ -503,13 +512,13 @@ func (s *snapshot) packageHandlesForFile(ctx context.Context, uri span.URI, mode
 	if fh.Kind() != source.Go {
 		return nil, fmt.Errorf("no packages for non-Go file %s", uri)
 	}
-	ids := s.getIDsForURI(uri)
-	reload := len(ids) == 0
-	for _, id := range ids {
+	knownIDs := s.getIDsForURI(uri)
+	reload := len(knownIDs) == 0
+	for _, id := range knownIDs {
 		// Reload package metadata if any of the metadata has missing
 		// dependencies, in case something has changed since the last time we
 		// reloaded it.
-		if m := s.getMetadata(id); m == nil {
+		if s.noValidMetadataForID(id) {
 			reload = true
 			break
 		}
@@ -518,13 +527,21 @@ func (s *snapshot) packageHandlesForFile(ctx context.Context, uri span.URI, mode
 		// calls to packages.Load. Determine what we should do instead.
 	}
 	if reload {
-		if err := s.load(ctx, false, fileURI(uri)); err != nil {
+		err = s.load(ctx, false, fileURI(uri))
+
+		if !s.useInvalidMetadata() && err != nil {
+			return nil, err
+		}
+		// We've tried to reload and there are still no known IDs for the URI.
+		// Return the load error, if there was one.
+		knownIDs = s.getIDsForURI(uri)
+		if len(knownIDs) == 0 {
 			return nil, err
 		}
 	}
-	// Get the list of IDs from the snapshot again, in case it has changed.
+
 	var phs []*packageHandle
-	for _, id := range s.getIDsForURI(uri) {
+	for _, id := range knownIDs {
 		var parseModes []source.ParseMode
 		switch mode {
 		case source.TypecheckAll:
@@ -547,8 +564,14 @@ func (s *snapshot) packageHandlesForFile(ctx context.Context, uri span.URI, mode
 			phs = append(phs, ph)
 		}
 	}
-
 	return phs, nil
+}
+
+// Only use invalid metadata for Go versions >= 1.13. Go 1.12 and below has
+// issues with overlays that will cause confusing error messages if we reuse
+// old metadata.
+func (s *snapshot) useInvalidMetadata() bool {
+	return s.view.goversion >= 13 && s.view.Options().ExperimentalUseInvalidMetadata
 }
 
 func (s *snapshot) GetReverseDependencies(ctx context.Context, id string) ([]source.Package, error) {
@@ -580,13 +603,15 @@ func (s *snapshot) checkedPackage(ctx context.Context, id packageID, mode source
 	return ph.check(ctx, s)
 }
 
-// transitiveReverseDependencies populates the uris map with file URIs
+// transitiveReverseDependencies populates the ids map with package IDs
 // belonging to the provided package and its transitive reverse dependencies.
 func (s *snapshot) transitiveReverseDependencies(id packageID, ids map[packageID]struct{}) {
 	if _, ok := ids[id]; ok {
 		return
 	}
-	if s.getMetadata(id) == nil {
+	m := s.getMetadata(id)
+	// Only use invalid metadata if we support it.
+	if m == nil || !(m.valid || s.useInvalidMetadata()) {
 		return
 	}
 	ids[id] = struct{}{}
@@ -927,54 +952,64 @@ func (s *snapshot) getIDsForURI(uri span.URI) []packageID {
 	return s.ids[uri]
 }
 
-func (s *snapshot) getMetadataForURILocked(uri span.URI) (metadata []*metadata) {
-	// TODO(matloob): uri can be a file or directory. Should we update the mappings
-	// to map directories to their contained packages?
-
-	for _, id := range s.ids[uri] {
-		if m, ok := s.metadata[id]; ok {
-			metadata = append(metadata, m)
-		}
-	}
-	return metadata
-}
-
-func (s *snapshot) getMetadata(id packageID) *metadata {
+func (s *snapshot) getMetadata(id packageID) *knownMetadata {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	return s.metadata[id]
 }
 
+// noValidMetadataForURILocked reports whether there is any valid metadata for
+// the given URI.
+func (s *snapshot) noValidMetadataForURILocked(uri span.URI) bool {
+	ids, ok := s.ids[uri]
+	if !ok {
+		return true
+	}
+	for _, id := range ids {
+		if m, ok := s.metadata[id]; ok && m.valid {
+			return false
+		}
+	}
+	return true
+}
+
+// noValidMetadataForID reports whether there is no valid metadata for the
+// given ID.
+func (s *snapshot) noValidMetadataForID(id packageID) bool {
+	m := s.getMetadata(id)
+	return m == nil || !m.valid
+}
+
+// addID adds the given ID to the set of known IDs for the given URI.
+// Any existing invalid IDs are not preserved, and IDs that are not
+// "command-line-arguments" are preferred.
 func (s *snapshot) addID(uri span.URI, id packageID) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	var newIDs []packageID
 	for i, existingID := range s.ids[uri] {
-		// TODO: We should make sure not to set duplicate IDs,
-		// and instead panic here. This can be done by making sure not to
-		// reset metadata information for packages we've already seen.
 		if existingID == id {
 			return
 		}
-		// If we are setting a real ID, when the package had only previously
-		// had a command-line-arguments ID, we should just replace it.
-		if isCommandLineArguments(string(existingID)) {
+		// If the package previously only had a command-line-arguments ID,
+		// we should just replace it.
+		if source.IsCommandLineArguments(string(existingID)) {
 			s.ids[uri][i] = id
 			// Delete command-line-arguments if it was a workspace package.
 			delete(s.workspacePackages, existingID)
 			return
 		}
+		if m, ok := s.metadata[existingID]; !ok || !m.valid {
+			continue
+		}
+		newIDs = append(newIDs, existingID)
 	}
-	s.ids[uri] = append(s.ids[uri], id)
-}
-
-// isCommandLineArguments reports whether a given value denotes
-// "command-line-arguments" package, which is a package with an unknown ID
-// created by the go command. It can have a test variant, which is why callers
-// should not check that a value equals "command-line-arguments" directly.
-func isCommandLineArguments(s string) bool {
-	return strings.Contains(s, "command-line-arguments")
+	sort.Slice(newIDs, func(i, j int) bool {
+		return newIDs[i] < newIDs[j]
+	})
+	s.ids[uri] = append(newIDs, id)
 }
 
 func (s *snapshot) isWorkspacePackage(id packageID) bool {
@@ -1057,9 +1092,21 @@ func (s *snapshot) awaitLoaded(ctx context.Context) error {
 	// If we still have absolutely no metadata, check if the view failed to
 	// initialize and return any errors.
 	// TODO(rstambler): Should we clear the error after we return it?
+	useInvalidMetadata := s.useInvalidMetadata()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if len(s.metadata) == 0 && loadErr != nil {
+
+	// Only return a load error if we have no valid metadata.
+	if useInvalidMetadata && len(s.metadata) > 0 {
+		return nil
+	}
+	for _, m := range s.metadata {
+		if m.valid {
+			return nil
+		}
+	}
+	if loadErr != nil {
 		return loadErr.MainError
 	}
 	return nil
@@ -1114,7 +1161,7 @@ func shouldShowAdHocPackagesWarning(snapshot source.Snapshot, pkgs []source.Pack
 
 func containsCommandLineArguments(pkgs []source.Package) bool {
 	for _, pkg := range pkgs {
-		if isCommandLineArguments(pkg.ID()) {
+		if source.IsCommandLineArguments(pkg.ID()) {
 			return true
 		}
 	}
@@ -1169,18 +1216,20 @@ func (s *snapshot) AwaitInitialized(ctx context.Context) {
 
 // reloadWorkspace reloads the metadata for all invalidated workspace packages.
 func (s *snapshot) reloadWorkspace(ctx context.Context) error {
+	useInvalidMetadata := s.useInvalidMetadata()
+
 	// See which of the workspace packages are missing metadata.
 	s.mu.Lock()
 	missingMetadata := len(s.workspacePackages) == 0 || len(s.metadata) == 0
 	pkgPathSet := map[packagePath]struct{}{}
 	for id, pkgPath := range s.workspacePackages {
-		if s.metadata[id] != nil {
+		if m, ok := s.metadata[id]; ok && (m.valid || useInvalidMetadata) {
 			continue
 		}
 		missingMetadata = true
 
 		// Don't try to reload "command-line-arguments" directly.
-		if isCommandLineArguments(string(pkgPath)) {
+		if source.IsCommandLineArguments(string(pkgPath)) {
 			continue
 		}
 		pkgPathSet[pkgPath] = struct{}{}
@@ -1246,7 +1295,7 @@ func (s *snapshot) reloadOrphanedFiles(ctx context.Context) error {
 		s.mu.Lock()
 		for _, scope := range scopes {
 			uri := span.URI(scope.(fileURI))
-			if s.getMetadataForURILocked(uri) == nil {
+			if s.noValidMetadataForURILocked(uri) {
 				s.unloadableFiles[uri] = struct{}{}
 			}
 		}
@@ -1279,7 +1328,7 @@ func (s *snapshot) orphanedFiles() []source.VersionedFileHandle {
 		if _, ok := s.unloadableFiles[uri]; ok {
 			continue
 		}
-		if s.getMetadataForURILocked(uri) == nil {
+		if s.noValidMetadataForURILocked(uri) {
 			files = append(files, fh)
 		}
 	}
@@ -1357,7 +1406,7 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 		initializedErr:    s.initializedErr,
 		ids:               make(map[span.URI][]packageID, len(s.ids)),
 		importedBy:        make(map[packageID][]packageID, len(s.importedBy)),
-		metadata:          make(map[packageID]*metadata, len(s.metadata)),
+		metadata:          make(map[packageID]*knownMetadata, len(s.metadata)),
 		packages:          make(map[packageKey]*packageHandle, len(s.packages)),
 		actions:           make(map[actionKey]*actionHandle, len(s.actions)),
 		files:             make(map[span.URI]source.VersionedFileHandle, len(s.files)),
@@ -1481,10 +1530,10 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 	// transitiveIDs keeps track of transitive reverse dependencies.
 	// If an ID is present in the map, invalidate its types.
 	// If an ID's value is true, invalidate its metadata too.
-	transitiveIDs := make(map[packageID]bool)
+	idsToInvalidate := make(map[packageID]bool)
 	var addRevDeps func(packageID, bool)
 	addRevDeps = func(id packageID, invalidateMetadata bool) {
-		current, seen := transitiveIDs[id]
+		current, seen := idsToInvalidate[id]
 		newInvalidateMetadata := current || invalidateMetadata
 
 		// If we've already seen this ID, and the value of invalidate
@@ -1492,7 +1541,7 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 		if seen && current == newInvalidateMetadata {
 			return
 		}
-		transitiveIDs[id] = newInvalidateMetadata
+		idsToInvalidate[id] = newInvalidateMetadata
 		for _, rid := range s.getImportedByLocked(id) {
 			addRevDeps(rid, invalidateMetadata)
 		}
@@ -1503,7 +1552,7 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 
 	// Copy the package type information.
 	for k, v := range s.packages {
-		if _, ok := transitiveIDs[k.id]; ok {
+		if _, ok := idsToInvalidate[k.id]; ok {
 			continue
 		}
 		newGen.Inherit(v.handle)
@@ -1511,26 +1560,69 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 	}
 	// Copy the package analysis information.
 	for k, v := range s.actions {
-		if _, ok := transitiveIDs[k.pkg.id]; ok {
+		if _, ok := idsToInvalidate[k.pkg.id]; ok {
 			continue
 		}
 		newGen.Inherit(v.handle)
 		result.actions[k] = v
 	}
+
+	// If the workspace mode has changed or a file has been deleted, we *must*
+	// delete all metadata, as it is unusable and may produce confusing or
+	// incorrect diagnostics.
+	workspaceModeChanged := s.workspaceMode() != result.workspaceMode()
+	deletedFiles := map[span.URI]struct{}{}
+	for _, c := range changes {
+		if c.exists {
+			continue
+		}
+		deletedFiles[c.fileHandle.URI()] = struct{}{}
+	}
+	skipID := map[packageID]struct{}{}
+	for uri, ids := range s.ids {
+		if _, ok := deletedFiles[uri]; ok {
+			for _, id := range ids {
+				skipID[id] = struct{}{}
+			}
+		}
+	}
+
+	// Copy the URI to package ID mappings, skipping only those URIs whose
+	// metadata will be reloaded in future calls to load.
+	deleteInvalidMetadata := forceReloadMetadata || workspaceModeChanged
+	idsInSnapshot := map[packageID]bool{} // track all known IDs
+	for uri, ids := range s.ids {
+		for _, id := range ids {
+			invalidateMetadata := idsToInvalidate[id]
+			if _, ok := skipID[id]; ok || (invalidateMetadata && deleteInvalidMetadata) {
+				continue
+			}
+			idsInSnapshot[id] = true
+			result.ids[uri] = append(result.ids[uri], id)
+		}
+	}
+
 	// Copy the package metadata. We only need to invalidate packages directly
 	// containing the affected file, and only if it changed in a relevant way.
 	for k, v := range s.metadata {
-		if invalidateMetadata, ok := transitiveIDs[k]; invalidateMetadata && ok {
+		if !idsInSnapshot[k] {
+			// Delete metadata for IDs that are no longer reachable from files
+			// in the snapshot.
 			continue
 		}
-		result.metadata[k] = v
+		invalidateMetadata := idsToInvalidate[k]
+		// Mark invalidated metadata rather than deleting it outright.
+		result.metadata[k] = &knownMetadata{
+			metadata: v.metadata,
+			valid:    v.valid && !invalidateMetadata,
+		}
 	}
 	// Copy the URI to package ID mappings, skipping only those URIs whose
 	// metadata will be reloaded in future calls to load.
 	for k, ids := range s.ids {
 		var newIDs []packageID
 		for _, id := range ids {
-			if invalidateMetadata, ok := transitiveIDs[id]; invalidateMetadata && ok {
+			if invalidateMetadata, ok := idsToInvalidate[id]; invalidateMetadata && ok {
 				continue
 			}
 			newIDs = append(newIDs, id)
@@ -1539,14 +1631,15 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 			result.ids[k] = newIDs
 		}
 	}
+
 	// Copy the set of initially loaded packages.
 	for id, pkgPath := range s.workspacePackages {
 		// Packages with the id "command-line-arguments" are generated by the
 		// go command when the user is outside of GOPATH and outside of a
 		// module. Do not cache them as workspace packages for longer than
 		// necessary.
-		if isCommandLineArguments(string(id)) {
-			if invalidateMetadata, ok := transitiveIDs[id]; invalidateMetadata && ok {
+		if source.IsCommandLineArguments(string(id)) {
+			if invalidateMetadata, ok := idsToInvalidate[id]; invalidateMetadata && ok {
 				continue
 			}
 		}
@@ -1598,7 +1691,7 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 
 	// If the snapshot's workspace mode has changed, the packages loaded using
 	// the previous mode are no longer relevant, so clear them out.
-	if s.workspaceMode() != result.workspaceMode() {
+	if workspaceModeChanged {
 		result.workspacePackages = map[packageID]packagePath{}
 	}
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/cmdtest.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/cmdtest.go
@@ -100,6 +100,10 @@ func (r *runner) FunctionExtraction(t *testing.T, start span.Span, end span.Span
 	//TODO: function extraction not supported on command line
 }
 
+func (r *runner) AddImport(t *testing.T, uri span.URI, expectedImport string) {
+	//TODO: import addition not supported on command line
+}
+
 func (r *runner) runGoplsCmd(t testing.TB, args ...string) (string, string) {
 	rStdout, wStdout, err := os.Pipe()
 	if err != nil {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command/command_gen.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command/command_gen.go
@@ -77,7 +77,7 @@ func Dispatch(ctx context.Context, params *protocol.ExecuteCommandParams, s Inte
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {
 			return nil, err
 		}
-		return s.AddImport(ctx, a0)
+		return nil, s.AddImport(ctx, a0)
 	case "gopls.apply_fix":
 		var a0 ApplyFixArgs
 		if err := UnmarshalArgs(params.Arguments, &a0); err != nil {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/command/interface.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/command/interface.go
@@ -115,9 +115,14 @@ type Interface interface {
 	// (Re)generate the gopls.mod file for a workspace.
 	GenerateGoplsMod(context.Context, URIArg) error
 
+	// ListKnownPackages: retrieves a list of packages
+	// that are importable from the given URI.
 	ListKnownPackages(context.Context, URIArg) (ListKnownPackagesResult, error)
 
-	AddImport(context.Context, AddImportArgs) (AddImportResult, error)
+	// AddImport: asks the server to add an import path to a given Go file.
+	// The method will call applyEdit on the client so that clients don't have
+	// to apply the edit themselves.
+	AddImport(context.Context, AddImportArgs) error
 
 	WorkspaceMetadata(context.Context) (WorkspaceMetadataResult, error)
 
@@ -196,18 +201,21 @@ type GoGetPackageArgs struct {
 	AddRequire bool
 }
 
-// TODO (Marwan): document :)
-
 type AddImportArgs struct {
+	// ImportPath is the target import path that should
+	// be added to the URI file
 	ImportPath string
-	URI        protocol.DocumentURI
-}
-
-type AddImportResult struct {
-	Edits []protocol.TextDocumentEdit
+	// URI is the file that the ImportPath should be
+	// added to
+	URI protocol.DocumentURI
 }
 
 type ListKnownPackagesResult struct {
+	// Packages is a list of packages relative
+	// to the URIArg passed by the command request.
+	// In other words, it omits paths that are already
+	// imported or cannot be imported due to compiler
+	// restrictions.
 	Packages []string
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/diagnostics.go
@@ -435,7 +435,7 @@ func (s *Server) checkForOrphanedFile(ctx context.Context, snapshot source.Snaps
 		Severity: protocol.SeverityWarning,
 		Source:   source.ListError,
 		Message: fmt.Sprintf(`No packages found for open file %s: %v.
-If this file contains build tags, try adding "-tags=<build tag>" to your gopls "buildFlag" configuration (see (https://github.com/golang/tools/blob/master/gopls/doc/settings.md#buildflags-string).
+If this file contains build tags, try adding "-tags=<build tag>" to your gopls "buildFlags" configuration (see (https://github.com/golang/tools/blob/master/gopls/doc/settings.md#buildflags-string).
 Otherwise, see the troubleshooting guidelines for help investigating (https://github.com/golang/tools/blob/master/gopls/doc/troubleshooting.md).
 `, fh.URI().Filename(), err),
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/edit.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/edit.go
@@ -18,6 +18,10 @@ type Pos struct {
 	Line, Column int
 }
 
+func (p Pos) String() string {
+	return fmt.Sprintf("%v:%v", p.Line, p.Column)
+}
+
 // Range corresponds to protocol.Range, but uses the editor friend Pos
 // instead of UTF-16 oriented protocol.Position
 type Range struct {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
@@ -114,11 +114,10 @@ type EditorConfig struct {
 	// Whether to edit files with windows line endings.
 	WindowsLineEndings bool
 
-	DirectoryFilters []string
-
-	VerboseOutput bool
-
-	ImportShortcut string
+	ImportShortcut                 string
+	DirectoryFilters               []string
+	VerboseOutput                  bool
+	ExperimentalUseInvalidMetadata bool
 }
 
 // NewEditor Creates a new Editor.
@@ -227,6 +226,9 @@ func (e *Editor) configuration() map[string]interface{} {
 	}
 	if e.Config.DirectoryFilters != nil {
 		config["directoryFilters"] = e.Config.DirectoryFilters
+	}
+	if e.Config.ExperimentalUseInvalidMetadata {
+		config["experimentalUseInvalidMetadata"] = true
 	}
 	if e.Config.CodeLenses != nil {
 		config["codelenses"] = e.Config.CodeLenses

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/workdir.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/workdir.go
@@ -190,6 +190,9 @@ func (w *Workdir) RemoveFile(ctx context.Context, path string) error {
 	if err := os.RemoveAll(fp); err != nil {
 		return errors.Errorf("removing %q: %w", path, err)
 	}
+	w.fileMu.Lock()
+	defer w.fileMu.Unlock()
+
 	evts := []FileEvent{{
 		Path: path,
 		ProtocolEvent: protocol.FileEvent{
@@ -198,6 +201,7 @@ func (w *Workdir) RemoveFile(ctx context.Context, path string) error {
 		},
 	}}
 	w.sendEvents(ctx, evts)
+	delete(w.files, path)
 	return nil
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/regtest/runner.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/regtest/runner.go
@@ -44,7 +44,7 @@ const (
 	// SeparateProcess forwards connection to a shared separate gopls process.
 	SeparateProcess
 	// Experimental enables all of the experimental configurations that are
-	// being developed. Currently, it enables the workspace module.
+	// being developed.
 	Experimental
 )
 
@@ -240,7 +240,7 @@ func (r *Runner) Run(t *testing.T, files string, test TestFunc, opts ...RunOptio
 		{"singleton", Singleton, singletonServer},
 		{"forwarded", Forwarded, r.forwardedServer},
 		{"separate_process", SeparateProcess, r.separateProcessServer},
-		{"experimental_workspace_module", Experimental, experimentalWorkspaceModule},
+		{"experimental", Experimental, experimentalServer},
 	}
 
 	for _, tc := range tests {
@@ -395,9 +395,12 @@ func singletonServer(ctx context.Context, t *testing.T, optsHook func(*source.Op
 	return lsprpc.NewStreamServer(cache.New(optsHook), false)
 }
 
-func experimentalWorkspaceModule(_ context.Context, _ *testing.T, optsHook func(*source.Options)) jsonrpc2.StreamServer {
+func experimentalServer(_ context.Context, t *testing.T, optsHook func(*source.Options)) jsonrpc2.StreamServer {
 	options := func(o *source.Options) {
 		optsHook(o)
+		o.EnableAllExperiments()
+		// ExperimentalWorkspaceModule is not (as of writing) enabled by
+		// source.Options.EnableAllExperiments, but we want to test it.
 		o.ExperimentalWorkspaceModule = true
 	}
 	return lsprpc.NewStreamServer(cache.New(options), false)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/semantic.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/semantic.go
@@ -611,9 +611,14 @@ func (e *encoded) Data() []uint32 {
 			x[j+1] = e.items[i].start - e.items[i-1].start
 		}
 		x[j+2] = e.items[i].len
-		x[j+3] = uint32(typeMap[e.items[i].typeStr])
+		typ, ok := typeMap[e.items[i].typeStr]
+		if !ok {
+			continue // client doesn't want typeStr
+		}
+		x[j+3] = uint32(typ)
 		mask := 0
 		for _, s := range e.items[i].mods {
+			// modMpa[s] is 0 if the client doesn't want this modifier
 			mask |= modMap[s]
 		}
 		x[j+4] = uint32(mask)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/add_import.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/add_import.go
@@ -1,0 +1,26 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package source
+
+import (
+	"context"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/imports"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+)
+
+// AddImport adds a single import statement to the given file
+func AddImport(ctx context.Context, snapshot Snapshot, fh VersionedFileHandle, importPath string) ([]protocol.TextEdit, error) {
+	_, pgf, err := GetParsedFile(ctx, snapshot, fh, NarrowestPackage)
+	if err != nil {
+		return nil, err
+	}
+	return ComputeOneImportFixEdits(snapshot, pgf, &imports.ImportFix{
+		StmtInfo: imports.ImportInfo{
+			ImportPath: importPath,
+		},
+		FixType: imports.AddImport,
+	})
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -145,6 +145,19 @@ var GeneratedAPIJSON = &APIJSON{
 				Hierarchy:  "build",
 			},
 			{
+				Name: "experimentalUseInvalidMetadata",
+				Type: "bool",
+				Doc:  "experimentalUseInvalidMetadata enables gopls to fall back on outdated\npackage metadata to provide editor features if the go command fails to\nload packages for some reason (like an invalid go.mod file). This will\neventually be the default behavior, and this setting will be removed.\n",
+				EnumKeys: EnumKeys{
+					ValueType: "",
+					Keys:      nil,
+				},
+				EnumValues: nil,
+				Default:    "false",
+				Status:     "experimental",
+				Hierarchy:  "build",
+			},
+			{
 				Name: "hoverKind",
 				Type: "enum",
 				Doc:  "hoverKind controls the information that appears in the hover text.\nSingleLine and Structured are intended for use only by authors of editor plugins.\n",
@@ -738,9 +751,9 @@ var GeneratedAPIJSON = &APIJSON{
 		},
 		{
 			Command: "gopls.add_import",
-			Title:   "",
-			Doc:     "",
-			ArgDoc:  "{\n\t\"ImportPath\": string,\n\t\"URI\": string,\n}",
+			Title:   "asks the server to add an import path to a given Go file.",
+			Doc:     "The method will call applyEdit on the client so that clients don't have\nto apply the edit themselves.",
+			ArgDoc:  "{\n\t// ImportPath is the target import path that should\n\t// be added to the URI file\n\t\"ImportPath\": string,\n\t// URI is the file that the ImportPath should be\n\t// added to\n\t\"URI\": string,\n}",
 		},
 		{
 			Command: "gopls.apply_fix",
@@ -780,8 +793,8 @@ var GeneratedAPIJSON = &APIJSON{
 		},
 		{
 			Command: "gopls.list_known_packages",
-			Title:   "",
-			Doc:     "",
+			Title:   "retrieves a list of packages",
+			Doc:     "that are importable from the given URI.",
 			ArgDoc:  "{\n\t// The file URI.\n\t\"URI\": string,\n}",
 		},
 		{

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/comment.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/comment.go
@@ -42,45 +42,40 @@ var (
 )
 
 func commentToMarkdown(w io.Writer, text string) {
-	isFirstLine := true
-	for _, b := range blocks(text) {
+	blocks := blocks(text)
+	for i, b := range blocks {
 		switch b.op {
 		case opPara:
-			if !isFirstLine {
-				w.Write(mdNewline)
-			}
-
 			for _, line := range b.lines {
 				emphasize(w, line, true)
 			}
 		case opHead:
-			if !isFirstLine {
-				w.Write(mdNewline)
+			// The header block can consist of only one line.
+			// However, check the number of lines, just in case.
+			if len(b.lines) == 0 {
+				// Skip this block.
+				continue
 			}
-			w.Write(mdNewline)
+			header := b.lines[0]
 
-			for _, line := range b.lines {
-				w.Write(mdHeader)
-				commentEscape(w, line, true)
-				w.Write(mdNewline)
-			}
+			w.Write(mdHeader)
+			commentEscape(w, header, true)
+			// Header doesn't end with \n unlike the lines of other blocks.
+			w.Write(mdNewline)
 		case opPre:
-			if !isFirstLine {
-				w.Write(mdNewline)
-			}
-			w.Write(mdNewline)
-
 			for _, line := range b.lines {
 				if isBlank(line) {
 					w.Write(mdNewline)
-				} else {
-					w.Write(mdIndent)
-					w.Write([]byte(line))
-					w.Write(mdNewline)
+					continue
 				}
+				w.Write(mdIndent)
+				w.Write([]byte(line))
 			}
 		}
-		isFirstLine = false
+
+		if i < len(blocks)-1 {
+			w.Write(mdNewline)
+		}
 	}
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/known_packages.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/known_packages.go
@@ -1,0 +1,118 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package source
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/imports"
+	errors "golang.org/x/xerrors"
+)
+
+// KnownPackages returns a list of all known packages
+// in the package graph that could potentially be imported
+// by the given file.
+func KnownPackages(ctx context.Context, snapshot Snapshot, fh VersionedFileHandle) ([]string, error) {
+	pkg, pgf, err := GetParsedFile(ctx, snapshot, fh, NarrowestPackage)
+	if err != nil {
+		return nil, errors.Errorf("GetParsedFile: %w", err)
+	}
+	alreadyImported := map[string]struct{}{}
+	for _, imp := range pgf.File.Imports {
+		alreadyImported[imp.Path.Value] = struct{}{}
+	}
+	pkgs, err := snapshot.CachedImportPaths(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var (
+		seen  = make(map[string]struct{})
+		paths []string
+	)
+	for path, knownPkg := range pkgs {
+		gofiles := knownPkg.CompiledGoFiles()
+		if len(gofiles) == 0 || gofiles[0].File.Name == nil {
+			continue
+		}
+		pkgName := gofiles[0].File.Name.Name
+		// package main cannot be imported
+		if pkgName == "main" {
+			continue
+		}
+		// test packages cannot be imported
+		if knownPkg.ForTest() != "" {
+			continue
+		}
+		// no need to import what the file already imports
+		if _, ok := alreadyImported[path]; ok {
+			continue
+		}
+		// snapshot.KnownPackages could have multiple versions of a pkg
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		// make sure internal packages are importable by the file
+		if !IsValidImport(pkg.PkgPath(), path) {
+			continue
+		}
+		// naive check on cyclical imports
+		if isDirectlyCyclical(pkg, knownPkg) {
+			continue
+		}
+		paths = append(paths, path)
+		seen[path] = struct{}{}
+	}
+	err = snapshot.RunProcessEnvFunc(ctx, func(o *imports.Options) error {
+		var mu sync.Mutex
+		ctx, cancel := context.WithTimeout(ctx, time.Millisecond*80)
+		defer cancel()
+		return imports.GetAllCandidates(ctx, func(ifix imports.ImportFix) {
+			mu.Lock()
+			defer mu.Unlock()
+			if _, ok := seen[ifix.StmtInfo.ImportPath]; ok {
+				return
+			}
+			paths = append(paths, ifix.StmtInfo.ImportPath)
+		}, "", pgf.URI.Filename(), pkg.GetTypes().Name(), o.Env)
+	})
+	if err != nil {
+		// if an error occurred, we stil have a decent list we can
+		// show to the user through snapshot.CachedImportPaths
+		event.Error(ctx, "imports.GetAllCandidates", err)
+	}
+	sort.Slice(paths, func(i, j int) bool {
+		importI, importJ := paths[i], paths[j]
+		iHasDot := strings.Contains(importI, ".")
+		jHasDot := strings.Contains(importJ, ".")
+		if iHasDot && !jHasDot {
+			return false
+		}
+		if jHasDot && !iHasDot {
+			return true
+		}
+		return importI < importJ
+	})
+	return paths, nil
+}
+
+// isDirectlyCyclical checks if imported directly imports pkg.
+// It does not (yet) offer a full cyclical check because showing a user
+// a list of importable packages already generates a very large list
+// and having a few false positives in there could be worth the
+// performance snappiness.
+func isDirectlyCyclical(pkg, imported Package) bool {
+	for _, imp := range imported.Imports() {
+		if imp.PkgPath() == pkg.PkgPath() {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
@@ -264,6 +264,12 @@ type BuildOptions struct {
 	// downloads rather than requiring user action. This option will eventually
 	// be removed.
 	AllowImplicitNetworkAccess bool `status:"experimental"`
+
+	// ExperimentalUseInvalidMetadata enables gopls to fall back on outdated
+	// package metadata to provide editor features if the go command fails to
+	// load packages for some reason (like an invalid go.mod file). This will
+	// eventually be the default behavior, and this setting will be removed.
+	ExperimentalUseInvalidMetadata bool `status:"experimental"`
 }
 
 type UIOptions struct {
@@ -606,7 +612,7 @@ func SetOptions(options *Options, opts interface{}) OptionResults {
 		for name, value := range opts {
 			if b, ok := value.(bool); name == "allExperiments" && ok && b {
 				enableExperiments = true
-				options.enableAllExperiments()
+				options.EnableAllExperiments()
 			}
 		}
 		seen := map[string]struct{}{}
@@ -714,13 +720,14 @@ func (o *Options) AddStaticcheckAnalyzer(a *analysis.Analyzer, enabled bool) {
 	o.StaticcheckAnalyzers[a.Name] = &Analyzer{Analyzer: a, Enabled: enabled}
 }
 
-// enableAllExperiments turns on all of the experimental "off-by-default"
+// EnableAllExperiments turns on all of the experimental "off-by-default"
 // features offered by gopls. Any experimental features specified in maps
 // should be enabled in enableAllExperimentMaps.
-func (o *Options) enableAllExperiments() {
+func (o *Options) EnableAllExperiments() {
 	o.SemanticTokens = true
 	o.ExperimentalPostfixCompletions = true
 	o.ExperimentalTemplateSupport = true
+	o.ExperimentalUseInvalidMetadata = true
 }
 
 func (o *Options) enableAllExperimentMaps() {
@@ -919,6 +926,9 @@ func (o *Options) set(name string, value interface{}, seen map[string]struct{}) 
 
 	case "allowImplicitNetworkAccess":
 		result.setBool(&o.AllowImplicitNetworkAccess)
+
+	case "experimentalUseInvalidMetadata":
+		result.setBool(&o.ExperimentalUseInvalidMetadata)
 
 	case "allExperiments":
 		// This setting should be handled before all of the other options are

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
@@ -507,3 +507,24 @@ func inDirLex(dir, path string) bool {
 		return false
 	}
 }
+
+// IsValidImport returns whether importPkgPath is importable
+// by pkgPath
+func IsValidImport(pkgPath, importPkgPath string) bool {
+	i := strings.LastIndex(string(importPkgPath), "/internal/")
+	if i == -1 {
+		return true
+	}
+	if IsCommandLineArguments(string(pkgPath)) {
+		return true
+	}
+	return strings.HasPrefix(string(pkgPath), string(importPkgPath[:i]))
+}
+
+// IsCommandLineArguments reports whether a given value denotes
+// "command-line-arguments" package, which is a package with an unknown ID
+// created by the go command. It can have a test variant, which is why callers
+// should not check that a value equals "command-line-arguments" directly.
+func IsCommandLineArguments(s string) bool {
+	return strings.Contains(s, "command-line-arguments")
+}

--- a/cmd/govim/internal/golang_org_x_tools/span/utf16.go
+++ b/cmd/govim/internal/golang_org_x_tools/span/utf16.go
@@ -6,7 +6,6 @@ package span
 
 import (
 	"fmt"
-	"unicode/utf16"
 	"unicode/utf8"
 )
 
@@ -41,9 +40,14 @@ func ToUTF16Column(p Point, content []byte) (int, error) {
 	// Now, truncate down to the supplied column.
 	start = start[:colZero]
 
-	// and count the number of utf16 characters
-	// in theory we could do this by hand more efficiently...
-	return len(utf16.Encode([]rune(string(start)))) + 1, nil
+	cnt := 0
+	for _, r := range string(start) {
+		cnt++
+		if r > 0xffff {
+			cnt++
+		}
+	}
+	return cnt + 1, nil // the +1 is for 1-based columns
 }
 
 // FromUTF16Column advances the point by the utf16 character offset given the

--- a/cmd/govim/testdata/scenario_bugs/bug_govim_680.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_govim_680.txt
@@ -39,7 +39,7 @@ func main() {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Printf format %v reads arg #2, but call has 1 arg",
+    "text": "fmt.Printf format %v reads arg #2, but call has 1 arg",
     "type": "",
     "valid": 1,
     "vcol": 0

--- a/cmd/govim/testdata/scenario_default/function_hover.txt
+++ b/cmd/govim/testdata/scenario_default/function_hover.txt
@@ -78,14 +78,14 @@ Println formats using the default formats for its operands and writes to standar
 Spaces are always added between operands and a newline is appended.
 It returns the number of bytes written and any write error encountered.
 -- warnings_popup.golden --
-Println call has possible formatting directive %v printf
+fmt.Println call has possible formatting directive %v printf
 unreachable code unreachable
 func fmt.Println(a ...interface{}) (n int, err error)
 Println formats using the default formats for its operands and writes to standard output.
 Spaces are always added between operands and a newline is appended.
 It returns the number of bytes written and any write error encountered.
 -- warnings_nodoc_popup.golden --
-Println call has possible formatting directive %v printf
+fmt.Println call has possible formatting directive %v printf
 unreachable code unreachable
 -- error_popup.golden --
 Pintln not declared by package fmt compiler
@@ -113,7 +113,7 @@ Pintln not declared by package fmt compiler
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Println call has possible formatting directive %v",
+    "text": "fmt.Println call has possible formatting directive %v",
     "type": "",
     "valid": 1,
     "vcol": 0

--- a/cmd/govim/testdata/scenario_default/implements.txt
+++ b/cmd/govim/testdata/scenario_default/implements.txt
@@ -68,7 +68,7 @@ func main() {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
     "type": "",
     "valid": 1,
     "vcol": 0

--- a/cmd/govim/testdata/scenario_default/quickfix_from_other.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_from_other.txt
@@ -83,7 +83,7 @@ func main() {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
     "type": "",
     "valid": 1,
     "vcol": 0
@@ -98,7 +98,7 @@ func main() {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
     "type": "",
     "valid": 1,
     "vcol": 0
@@ -110,7 +110,7 @@ func main() {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
     "type": "",
     "valid": 1,
     "vcol": 0

--- a/cmd/govim/testdata/scenario_default/references.txt
+++ b/cmd/govim/testdata/scenario_default/references.txt
@@ -246,7 +246,7 @@ func DoIt() {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
     "type": "",
     "valid": 1,
     "vcol": 0

--- a/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
+++ b/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
@@ -50,7 +50,7 @@ func foo() {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
     "type": "",
     "valid": 1,
     "vcol": 0

--- a/cmd/govim/testdata/scenario_default/signs_unload_load_buffer.txt
+++ b/cmd/govim/testdata/scenario_default/signs_unload_load_buffer.txt
@@ -52,7 +52,7 @@ func foo() {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
     "type": "",
     "valid": 1,
     "vcol": 0
@@ -64,7 +64,7 @@ func foo() {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
     "type": "",
     "valid": 1,
     "vcol": 0

--- a/cmd/govim/testdata/scenario_staticcheck/staticcheck.txt
+++ b/cmd/govim/testdata/scenario_staticcheck/staticcheck.txt
@@ -5,11 +5,7 @@
 # for now in this test to give exposure to the staticcheck work
 
 vim ex 'e main.go'
-[go1.15] vimexprwait errors.golden GOVIMTest_getqflist()
-
-# Unclear why go1.14 is special.. but we'll be dropping support
-# for it soon
-[go1.14] [!go1.15] vimexprwait errors.go1.14.golden GOVIMTest_getqflist()
+vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -51,22 +47,7 @@ func main() {
     "module": "",
     "nr": 0,
     "pattern": "",
-    "text": "Printf format %v reads arg #1, but call has 0 args",
-    "type": "",
-    "valid": 1,
-    "vcol": 0
-  }
-]
--- errors.go1.14.golden --
-[
-  {
-    "bufname": "main.go",
-    "col": 2,
-    "lnum": 9,
-    "module": "",
-    "nr": 0,
-    "pattern": "",
-    "text": "Printf format %v reads arg #1, but call has 0 args",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
     "type": "",
     "valid": 1,
     "vcol": 0

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
-	golang.org/x/tools v0.1.2-0.20210519160823-49064d2332f9
-	golang.org/x/tools/gopls v0.0.0-20210519160823-49064d2332f9
+	golang.org/x/tools v0.1.2-0.20210523035700-4061312594fc
+	golang.org/x/tools/gopls v0.0.0-20210523035700-4061312594fc
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -81,10 +81,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.2-0.20210519160823-49064d2332f9 h1:2XlR/j4I4xz5GQZI7zBjqTfezYyRIE2jD5IMousB2rg=
-golang.org/x/tools v0.1.2-0.20210519160823-49064d2332f9/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools/gopls v0.0.0-20210519160823-49064d2332f9 h1:O4QJZybt8RgBtM9ZQ3DF6NsGMJzC16y6hMZRXdrK5PI=
-golang.org/x/tools/gopls v0.0.0-20210519160823-49064d2332f9/go.mod h1:FmJMctxBu1t9QN/YAw3b+ofUURc4dvfsf3xmdO8Y6N0=
+golang.org/x/tools v0.1.2-0.20210523035700-4061312594fc h1:XjP8c/tYhnjjE/Lyars8DjtNALPaHuChoZo0F10B1WI=
+golang.org/x/tools v0.1.2-0.20210523035700-4061312594fc/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools/gopls v0.0.0-20210523035700-4061312594fc h1:4ICrHVTBbiVu7CnPCQtFz0b075lp1RaXO/jI3lHbB0M=
+golang.org/x/tools/gopls v0.0.0-20210523035700-4061312594fc/go.mod h1:FmJMctxBu1t9QN/YAw3b+ofUURc4dvfsf3xmdO8Y6N0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Includes some test assertion fix ups following
https://go-review.googlesource.com/c/tools/+/301949

* internal/lsp: add list_known_packages and add_import commands 40613125
* tools: make printf analysis have more helpful output 1e0c9609
* internal/lsp: correct typo in orphaned file error message 2275bb55
* internal/lsp/semantic: only return token types the client asked for 30637901
* internal/span: compute utf16 length directly 0886cdd1
* internal/lsp/cache: don't delete metadata until it's reloaded 46e69bf3
* internal/lsp/source: refactor commentToMarkdown function f803486e