### PR TITLE
deps: update x/tools & gopls to 1225b6f5

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/gocommand/version.go
+++ b/cmd/govim/internal/golang_org_x_tools/gocommand/version.go
@@ -14,7 +14,7 @@ import (
 // It returns the X in Go 1.X.
 func GoVersion(ctx context.Context, inv Invocation, r *Runner) (int, error) {
 	inv.Verb = "list"
-	inv.Args = []string{"-e", "-f", `{{context.ReleaseTags}}`}
+	inv.Args = []string{"-e", "-f", `{{context.ReleaseTags}}`, `--`, `unsafe`}
 	inv.Env = append(append([]string{}, inv.Env...), "GO111MODULE=off")
 	// Unset any unneeded flags, and remove them from BuildFlags, if they're
 	// present.

--- a/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2/serve.go
+++ b/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2/serve.go
@@ -7,7 +7,10 @@ package jsonrpc2
 import (
 	"context"
 	"io"
+	"runtime"
+	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	errors "golang.org/x/xerrors"
@@ -155,6 +158,16 @@ func isClosingError(err error) bool {
 		return true
 	}
 
+	if runtime.GOOS == "plan9" {
+		// Error reading from a closed connection.
+		if err == syscall.EINVAL {
+			return true
+		}
+		// Error trying to accept a new connection from a closed listener.
+		if strings.HasSuffix(err.Error(), " listen hungup") {
+			return true
+		}
+	}
 	return false
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/check.go
@@ -41,7 +41,7 @@ type packageHandle struct {
 	mode source.ParseMode
 
 	// m is the metadata associated with the package.
-	m *knownMetadata
+	m *metadata
 
 	// key is the hashed key for the package.
 	key packageHandleKey
@@ -117,7 +117,7 @@ func (s *snapshot) buildPackageHandle(ctx context.Context, id packageID, mode so
 		}
 
 		data := &packageData{}
-		data.pkg, data.err = typeCheck(ctx, snapshot, m.metadata, mode, deps)
+		data.pkg, data.err = typeCheck(ctx, snapshot, m, mode, deps)
 		// Make sure that the workers above have finished before we return,
 		// especially in case of cancellation.
 		wg.Wait()
@@ -167,10 +167,7 @@ func (s *snapshot) buildKey(ctx context.Context, id packageID, mode source.Parse
 	var depKeys []packageHandleKey
 	for _, depID := range depList {
 		depHandle, err := s.buildPackageHandle(ctx, depID, s.workspaceParseMode(depID))
-		// Don't use invalid metadata for dependencies if the top-level
-		// metadata is valid. We only load top-level packages, so if the
-		// top-level is valid, all of its dependencies should be as well.
-		if err != nil || m.valid && !depHandle.m.valid {
+		if err != nil {
 			event.Error(ctx, fmt.Sprintf("%s: no dep handle for %s", id, depID), err, tag.Snapshot.Of(s.id))
 			if ctx.Err() != nil {
 				return nil, nil, ctx.Err()

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/parse.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/parse.go
@@ -120,8 +120,7 @@ func (s *snapshot) astCacheData(ctx context.Context, spkg source.Package, pos to
 		return nil, err
 	}
 	astHandle := s.generation.Bind(astCacheKey{pkgHandle.key, pgf.URI}, func(ctx context.Context, arg memoize.Arg) interface{} {
-		snapshot := arg.(*snapshot)
-		return buildASTCache(ctx, snapshot, pgf)
+		return buildASTCache(pgf)
 	}, nil)
 
 	d, err := astHandle.Get(ctx, s.generation, s)
@@ -160,7 +159,7 @@ type astCacheData struct {
 
 // buildASTCache builds caches to aid in quickly going from the typed
 // world to the syntactic world.
-func buildASTCache(ctx context.Context, snapshot *snapshot, pgf *source.ParsedGoFile) *astCacheData {
+func buildASTCache(pgf *source.ParsedGoFile) *astCacheData {
 	var (
 		// path contains all ancestors, including n.
 		path []ast.Node

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
@@ -221,7 +221,7 @@ func (s *Session) createView(ctx context.Context, name string, folder, tempWorks
 		generation:        s.cache.store.Generation(generationName(v, 0)),
 		packages:          make(map[packageKey]*packageHandle),
 		ids:               make(map[span.URI][]packageID),
-		metadata:          make(map[packageID]*knownMetadata),
+		metadata:          make(map[packageID]*metadata),
 		files:             make(map[span.URI]source.VersionedFileHandle),
 		goFiles:           make(map[parseKey]*parseGoHandle),
 		importedBy:        make(map[packageID][]packageID),
@@ -553,8 +553,7 @@ func knownDirectories(ctx context.Context, snapshots []*snapshot) map[span.URI]s
 		for _, dir := range dirs {
 			result[dir] = struct{}{}
 		}
-		subdirs := snapshot.allKnownSubdirs(ctx)
-		for dir := range subdirs {
+		for _, dir := range snapshot.getKnownSubdirs(dirs) {
 			result[dir] = struct{}{}
 		}
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
@@ -557,6 +557,7 @@ func (s *snapshot) initialize(ctx context.Context, firstAttempt bool) {
 	}
 	s.initializeOnce.Do(func() {
 		s.loadWorkspace(ctx, firstAttempt)
+		s.collectAllKnownSubdirs(ctx)
 	})
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/edit.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/edit.go
@@ -18,10 +18,6 @@ type Pos struct {
 	Line, Column int
 }
 
-func (p Pos) String() string {
-	return fmt.Sprintf("%v:%v", p.Line, p.Column)
-}
-
 // Range corresponds to protocol.Range, but uses the editor friend Pos
 // instead of UTF-16 oriented protocol.Position
 type Range struct {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/editor.go
@@ -114,10 +114,11 @@ type EditorConfig struct {
 	// Whether to edit files with windows line endings.
 	WindowsLineEndings bool
 
-	ImportShortcut                 string
-	DirectoryFilters               []string
-	VerboseOutput                  bool
-	ExperimentalUseInvalidMetadata bool
+	DirectoryFilters []string
+
+	VerboseOutput bool
+
+	ImportShortcut string
 }
 
 // NewEditor Creates a new Editor.
@@ -226,9 +227,6 @@ func (e *Editor) configuration() map[string]interface{} {
 	}
 	if e.Config.DirectoryFilters != nil {
 		config["directoryFilters"] = e.Config.DirectoryFilters
-	}
-	if e.Config.ExperimentalUseInvalidMetadata {
-		config["experimentalUseInvalidMetadata"] = true
 	}
 	if e.Config.CodeLenses != nil {
 		config["codelenses"] = e.Config.CodeLenses

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/workdir.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/workdir.go
@@ -190,9 +190,6 @@ func (w *Workdir) RemoveFile(ctx context.Context, path string) error {
 	if err := os.RemoveAll(fp); err != nil {
 		return errors.Errorf("removing %q: %w", path, err)
 	}
-	w.fileMu.Lock()
-	defer w.fileMu.Unlock()
-
 	evts := []FileEvent{{
 		Path: path,
 		ProtocolEvent: protocol.FileEvent{
@@ -201,7 +198,6 @@ func (w *Workdir) RemoveFile(ctx context.Context, path string) error {
 		},
 	}}
 	w.sendEvents(ctx, evts)
-	delete(w.files, path)
 	return nil
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/regtest/runner.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/regtest/runner.go
@@ -44,7 +44,7 @@ const (
 	// SeparateProcess forwards connection to a shared separate gopls process.
 	SeparateProcess
 	// Experimental enables all of the experimental configurations that are
-	// being developed.
+	// being developed. Currently, it enables the workspace module.
 	Experimental
 )
 
@@ -240,7 +240,7 @@ func (r *Runner) Run(t *testing.T, files string, test TestFunc, opts ...RunOptio
 		{"singleton", Singleton, singletonServer},
 		{"forwarded", Forwarded, r.forwardedServer},
 		{"separate_process", SeparateProcess, r.separateProcessServer},
-		{"experimental", Experimental, experimentalServer},
+		{"experimental_workspace_module", Experimental, experimentalWorkspaceModule},
 	}
 
 	for _, tc := range tests {
@@ -395,12 +395,9 @@ func singletonServer(ctx context.Context, t *testing.T, optsHook func(*source.Op
 	return lsprpc.NewStreamServer(cache.New(optsHook), false)
 }
 
-func experimentalServer(_ context.Context, t *testing.T, optsHook func(*source.Options)) jsonrpc2.StreamServer {
+func experimentalWorkspaceModule(_ context.Context, _ *testing.T, optsHook func(*source.Options)) jsonrpc2.StreamServer {
 	options := func(o *source.Options) {
 		optsHook(o)
-		o.EnableAllExperiments()
-		// ExperimentalWorkspaceModule is not (as of writing) enabled by
-		// source.Options.EnableAllExperiments, but we want to test it.
 		o.ExperimentalWorkspaceModule = true
 	}
 	return lsprpc.NewStreamServer(cache.New(options), false)

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -145,19 +145,6 @@ var GeneratedAPIJSON = &APIJSON{
 				Hierarchy:  "build",
 			},
 			{
-				Name: "experimentalUseInvalidMetadata",
-				Type: "bool",
-				Doc:  "experimentalUseInvalidMetadata enables gopls to fall back on outdated\npackage metadata to provide editor features if the go command fails to\nload packages for some reason (like an invalid go.mod file). This will\neventually be the default behavior, and this setting will be removed.\n",
-				EnumKeys: EnumKeys{
-					ValueType: "",
-					Keys:      nil,
-				},
-				EnumValues: nil,
-				Default:    "false",
-				Status:     "experimental",
-				Hierarchy:  "build",
-			},
-			{
 				Name: "hoverKind",
 				Type: "enum",
 				Doc:  "hoverKind controls the information that appears in the hover text.\nSingleLine and Structured are intended for use only by authors of editor plugins.\n",
@@ -697,7 +684,7 @@ var GeneratedAPIJSON = &APIJSON{
 					Keys:      nil,
 				},
 				EnumValues: nil,
-				Default:    "true",
+				Default:    "false",
 				Status:     "experimental",
 				Hierarchy:  "ui",
 			},

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/call_hierarchy.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/call_hierarchy.go
@@ -223,6 +223,10 @@ func collectCallExpressions(fset *token.FileSet, mapper *protocol.ColumnMapper, 
 				start, end = n.Sel.NamePos, call.Lparen
 			case *ast.Ident:
 				start, end = n.NamePos, call.Lparen
+			case *ast.FuncLit:
+				// while we don't add the function literal as an 'outgoing' call
+				// we still want to traverse into it
+				return true
 			default:
 				// ignore any other kind of call expressions
 				// for ex: direct function literal calls since that's not an 'outgoing' call

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/completion.go
@@ -2702,6 +2702,12 @@ func (ci *candidateInference) assigneesMatch(cand *candidate, sig *types.Signatu
 		return false
 	}
 
+	// Don't prefer completing into func(...interface{}) calls since all
+	// functions wouuld match.
+	if ci.variadicAssignees && len(ci.assignees) == 1 && isEmptyInterface(deslice(ci.assignees[0])) {
+		return false
+	}
+
 	var numberOfResultsCouldMatch bool
 	if ci.variadicAssignees {
 		numberOfResultsCouldMatch = sig.Results().Len() >= len(ci.assignees)-1

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/literal.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/literal.go
@@ -369,6 +369,11 @@ func (c *completer) compositeLiteral(T types.Type, typeName string, matchScore f
 // basicLiteral adds a literal completion item for the given basic
 // type name typeName.
 func (c *completer) basicLiteral(T types.Type, typeName string, matchScore float64, edits []protocol.TextEdit) {
+	// Never give type conversions like "untyped int()".
+	if isUntyped(T) {
+		return
+	}
+
 	snip := &snippet.Builder{}
 	snip.WriteText(typeName + "(")
 	snip.WriteFinalTabstop()

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/format.go
@@ -241,7 +241,7 @@ func importPrefix(src []byte) string {
 				// comment by scanning the content of the file.
 				startOffset := tok.Offset(c.Pos())
 				if startLine != endLine && bytes.Contains(src[startOffset:], []byte("\r")) {
-					if commentEnd := scanForCommentEnd(tok, src[startOffset:]); commentEnd > 0 {
+					if commentEnd := scanForCommentEnd(src[startOffset:]); commentEnd > 0 {
 						end = startOffset + commentEnd
 					}
 				}
@@ -257,7 +257,7 @@ func importPrefix(src []byte) string {
 
 // scanForCommentEnd returns the offset of the end of the multi-line comment
 // at the start of the given byte slice.
-func scanForCommentEnd(tok *token.File, src []byte) int {
+func scanForCommentEnd(src []byte) int {
 	var s scanner.Scanner
 	s.Init(bytes.NewReader(src))
 	s.Mode ^= scanner.SkipComments

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
@@ -143,7 +143,6 @@ func DefaultOptions() *Options {
 						string(command.UpgradeDependency): true,
 						string(command.Vendor):            true,
 					},
-					SemanticTokens: true,
 				},
 			},
 			InternalOptions: InternalOptions{
@@ -265,12 +264,6 @@ type BuildOptions struct {
 	// downloads rather than requiring user action. This option will eventually
 	// be removed.
 	AllowImplicitNetworkAccess bool `status:"experimental"`
-
-	// ExperimentalUseInvalidMetadata enables gopls to fall back on outdated
-	// package metadata to provide editor features if the go command fails to
-	// load packages for some reason (like an invalid go.mod file). This will
-	// eventually be the default behavior, and this setting will be removed.
-	ExperimentalUseInvalidMetadata bool `status:"experimental"`
 }
 
 type UIOptions struct {
@@ -613,7 +606,7 @@ func SetOptions(options *Options, opts interface{}) OptionResults {
 		for name, value := range opts {
 			if b, ok := value.(bool); name == "allExperiments" && ok && b {
 				enableExperiments = true
-				options.EnableAllExperiments()
+				options.enableAllExperiments()
 			}
 		}
 		seen := map[string]struct{}{}
@@ -725,14 +718,13 @@ func (o *Options) AddStaticcheckAnalyzer(a *analysis.Analyzer, enabled bool, sev
 	}
 }
 
-// EnableAllExperiments turns on all of the experimental "off-by-default"
+// enableAllExperiments turns on all of the experimental "off-by-default"
 // features offered by gopls. Any experimental features specified in maps
 // should be enabled in enableAllExperimentMaps.
-func (o *Options) EnableAllExperiments() {
+func (o *Options) enableAllExperiments() {
 	o.SemanticTokens = true
 	o.ExperimentalPostfixCompletions = true
 	o.ExperimentalTemplateSupport = true
-	o.ExperimentalUseInvalidMetadata = true
 }
 
 func (o *Options) enableAllExperimentMaps() {
@@ -931,9 +923,6 @@ func (o *Options) set(name string, value interface{}, seen map[string]struct{}) 
 
 	case "allowImplicitNetworkAccess":
 		result.setBool(&o.AllowImplicitNetworkAccess)
-
-	case "experimentalUseInvalidMetadata":
-		result.setBool(&o.ExperimentalUseInvalidMetadata)
 
 	case "allExperiments":
 		// This setting should be handled before all of the other options are

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/types_format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/types_format.go
@@ -252,11 +252,7 @@ func varType(ctx context.Context, snapshot Snapshot, pkg Package, obj *types.Var
 	if field == nil {
 		return nil, fmt.Errorf("no declaration for object %s", obj.Name())
 	}
-	typ, ok := field.Type.(ast.Expr)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type for node (%T)", field.Type)
-	}
-	return typ, nil
+	return field.Type, nil
 }
 
 // qualifyExpr applies the "pkgName." prefix to any *ast.Ident in the expr.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/template/parse.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/template/parse.go
@@ -28,6 +28,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
+	errors "golang.org/x/xerrors"
 )
 
 var (
@@ -85,6 +86,10 @@ func parseBuffer(buf []byte) *Parsed {
 	ans := &Parsed{
 		buf:   buf,
 		check: -1,
+	}
+	if len(buf) == 0 {
+		ans.ParseErr = errors.New("empty buffer")
+		return ans
 	}
 	// how to compute allAscii...
 	for _, b := range buf {

--- a/cmd/govim/internal/golang_org_x_tools/testenv/testenv.go
+++ b/cmd/govim/internal/golang_org_x_tools/testenv/testenv.go
@@ -247,7 +247,7 @@ func NeedsGoBuild(t Testing) {
 //
 // It should be called from within a TestMain function.
 func ExitIfSmallMachine() {
-	switch os.Getenv("GO_BUILDER_NAME") {
+	switch b := os.Getenv("GO_BUILDER_NAME"); b {
 	case "linux-arm-scaleway":
 		// "linux-arm" was renamed to "linux-arm-scaleway" in CL 303230.
 		fmt.Fprintln(os.Stderr, "skipping test: linux-arm-scaleway builder lacks sufficient memory (https://golang.org/issue/32834)")
@@ -255,6 +255,11 @@ func ExitIfSmallMachine() {
 	case "plan9-arm":
 		fmt.Fprintln(os.Stderr, "skipping test: plan9-arm builder lacks sufficient memory (https://golang.org/issue/38772)")
 		os.Exit(0)
+	case "netbsd-arm-bsiegert", "netbsd-arm64-bsiegert":
+		// As of 2021-06-02, these builders are running with GO_TEST_TIMEOUT_SCALE=10,
+		// and there is only one of each. We shouldn't waste those scarce resources
+		// running very slow tests.
+		fmt.Fprintf(os.Stderr, "skipping test: %s builder is very slow\n", b)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
-	golang.org/x/tools v0.1.3-0.20210527195127-5ab822f631a3
-	golang.org/x/tools/gopls v0.0.0-20210527195127-5ab822f631a3
+	golang.org/x/tools v0.1.3-0.20210604203405-1225b6f53f67
+	golang.org/x/tools/gopls v0.0.0-20210604203405-1225b6f53f67
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -80,10 +80,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.3-0.20210527195127-5ab822f631a3 h1:nJWVOqN6IIbzGwCN4WT6TzqaPwaMlD5rbUPNyln3i2k=
-golang.org/x/tools v0.1.3-0.20210527195127-5ab822f631a3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools/gopls v0.0.0-20210527195127-5ab822f631a3 h1:GfRWOGLxJEq0Kul+M8qdmGphzXB/YuR5ztCYixUn3Uk=
-golang.org/x/tools/gopls v0.0.0-20210527195127-5ab822f631a3/go.mod h1:ekCtf0GOS1JSF+KM46LZvJUyEsyKfFZOfcytlR7aBfg=
+golang.org/x/tools v0.1.3-0.20210604203405-1225b6f53f67 h1:Hn4qGPy/ZgFlXm3qWEscqNdrEzzyZzRp2WNGoPgNtiI=
+golang.org/x/tools v0.1.3-0.20210604203405-1225b6f53f67/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools/gopls v0.0.0-20210604203405-1225b6f53f67 h1:mZvS3wYakSmFpLALpQVTn/kpjw0lD2fYWJVPNUMWs/E=
+golang.org/x/tools/gopls v0.0.0-20210604203405-1225b6f53f67/go.mod h1:ekCtf0GOS1JSF+KM46LZvJUyEsyKfFZOfcytlR7aBfg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/lsp: memoize allKnownSubdirs instead of recomputing 1225b6f5
* lsp/completion: don't offer untyped conversions 7295a4e7
* vta: adds VTA graph construction for basic program statements bf132055
* gopls/internal/regtest: clean up TestFillReturnsPanic 8f2cf6cc
* internal/lsp: handle empty buffers in template parsing 4abb1e2f
* internal/lsp: don't diagnose/analyze intermediate test variants 7ac129f2
* internal/lsp: address some staticcheck warning 1c2154ae
* Revert "internal/lsp/cache: don't delete metadata until it's reloaded" 384c3925
* internal/testenv: treat netbsd-arm*-bsiegert as slow builders 29f5b8f0
* go/packages/packagestest: make Export skip tests involving unsupported links 79224910
* Revert "internal/lsp: enable semantic tokens by default" 726034ec
* internal/jsonrpc2_v2: make TestIdleTimeout pass on Plan 9 7271753b
* internal/lsp: include function literals in outgoing call hierarchy 377464f2
* lsp/completion: fix variadic param candidate ordering edge case df07577e
* internal/gocommand: run 'go list' on the unsafe package when fetching release tags 6123e5fb