### PR TITLE
cmd/govim: use span.URI.Filename() when handling filenames

### DIFF
--- a/cmd/govim/go_to_def.go
+++ b/cmd/govim/go_to_def.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/govim/govim"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
@@ -124,7 +123,7 @@ func (v *vimstate) loadLocation(mods govim.CommModList, loc protocol.Location, a
 	v.ChannelEx("normal! m'")
 
 	vp := v.Viewport()
-	tf := strings.TrimPrefix(string(loc.URI), "file://")
+	tf := loc.URI.SpanURI().Filename()
 
 	bn := v.ParseInt(v.ChannelCall("bufnr", tf))
 	if bn != -1 {

--- a/cmd/govim/testdata/mod/example.com_bla!h_v1.0.0.txt
+++ b/cmd/govim/testdata/mod/example.com_bla!h_v1.0.0.txt
@@ -1,0 +1,13 @@
+-- .mod --
+module example.com/blaH
+
+-- .info --
+{"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
+
+-- go.mod --
+module example.com/blaH
+
+-- main.go --
+package blaH
+
+const Name = "example.com/blaH"

--- a/cmd/govim/testdata/scenario_default/go_to_def_upper_case.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_upper_case.txt
@@ -1,0 +1,37 @@
+# Test that GOVIMGoToDef works jumping to a definition within
+# the module cache for a package path with a capital letter
+
+# More natural to split below and to the right
+vim ex 'set splitbelow'
+vim ex 'set splitright'
+
+# Definition in same file
+vim ex 'e '$WORK/p.go
+vim ex 'call cursor(5,18)'
+vim ex 'GOVIMGoToDef'
+vim expr 'expand(''%:p'')'
+stdout '^\Q"'$WORK'/.home/gopath/pkg/mod/example.com/bla!h@v1.0.0/main.go"\E$'
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '^\Q[3,7]\E$'
+vim ex 'GOVIMGoToPrevDef'
+vim expr 'expand(''%:p'')'
+stdout '^\Q"'$WORK'/p.go"\E$'
+vim expr '[getcurpos()[1], getcurpos()[2]]'
+stdout '^\Q[5,18]\E$'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+
+require example.com/blah v1.0.0
+-- p.go --
+package p
+
+import "example.com/blaH"
+
+const sink = blaH.Name


### PR DESCRIPTION
When interpretting URIs from gopls, we need to use the
span.URI.Filename() when we are expecting a filename. This ensures we
properly decode the URL, which in turn properly decodes the hex-encoded
path elements, like '!', which can appear in module paths.