### PR TITLE
cmd/govim: adapt to changes in Vim v8.2.3019

### DIFF
--- a/cmd/govim/testdata/scenario_autoreadloadedbuffers/autoread_loaded_buffers.txt
+++ b/cmd/govim/testdata/scenario_autoreadloadedbuffers/autoread_loaded_buffers.txt
@@ -13,7 +13,8 @@ vim ex 'e main.go'
 # "edit" the loaded file from outside of vim
 cp const.go.commented const.go
 
-vimexprwait errors.undeclared GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.undeclared GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.undeclared GOVIMTest_getqflist()
 
 # No warnings or errors during the test
 
@@ -52,6 +53,23 @@ const (
   {
     "bufname": "main.go",
     "col": 14,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: Const1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.undeclared --
+[
+  {
+    "bufname": "main.go",
+    "col": 14,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 6,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_bugs/bug_gopls_36144.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_gopls_36144.txt
@@ -11,7 +11,8 @@
 # cancellation of the initial diagnostics for the package, or the diagnostics
 # that are sent when a file is opened.
 
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -29,6 +30,23 @@ blah
   {
     "bufname": "main.go",
     "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found blah",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 3,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_error_error_error.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_error_error_error.txt
@@ -9,17 +9,20 @@
 
 # Expect the initial state
 vim ex 'e main.go'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Make a change that shouldn't alter the diagnostics
 vim call append '[4,"\t"]'
 sleep $GOVIM_ERRLOGMATCH_WAIT
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Undo that change and ensure we still have the diagnostics
 vim ex 5delete
 sleep $GOVIM_ERRLOGMATCH_WAIT
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -40,6 +43,23 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "x declared but not used",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 4,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_error_no-error_error.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_error_no-error_error.txt
@@ -7,7 +7,8 @@
 
 # Expect the initial state
 vim ex 'e main.go'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Make a change that removes diagnostics
 vim call append '[4,"\tprintln(x)"]'
@@ -15,7 +16,8 @@ vimexprwait empty.golden GOVIMTest_getqflist()
 
 # Undo that change and ensure we have the original diagnostics
 vim ex 5delete
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -36,6 +38,23 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "x declared but not used",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 4,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_no-error_error_no-error.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_no-error_error_no-error.txt
@@ -14,7 +14,8 @@ vimexprwait empty.golden GOVIMTest_getqflist()
 
 # Make a change that adds diagnostics
 vim call append '[4,"\tx := 123"]'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Undo that change and ensure we still zero diagnostics again
 vim ex 5delete
@@ -40,6 +41,23 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "x declared but not used",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 5,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_bugs/bug_govim_680.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_govim_680.txt
@@ -2,7 +2,8 @@
 
 # Open main.go and verify we have one error
 vim ex 'e main.go'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Find references to x then select the second instance
 vim ex 'call cursor(5,5)'
@@ -35,6 +36,23 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 8,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Printf format %v reads arg #2, but call has 1 arg",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 8,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_bugs/bug_govim_940.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_govim_940.txt
@@ -4,7 +4,8 @@
 
 # Open main.go that lacks import statement for "fmt"
 vim ex 'e main.go'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Save the file so the import statment is added (and cursor is moved)
 vim ex 'call cursor(4,15)'
@@ -33,6 +34,23 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: fmt",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 4,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/codelens_gc_details.txt
+++ b/cmd/govim/testdata/scenario_default/codelens_gc_details.txt
@@ -6,8 +6,10 @@
 # Compiler details are reported using "information" severity
 vim ex 'e main.go'
 vim ex 'GOVIMGCDetails'
-[go1.14] [!go1.15] vimexprwait errors.go114.golden GOVIMTest_getqflist()
-[go1.15] vimexprwait errors.go115.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] [go1.14] [!go1.15] vimexprwait errors.go114.v8.2.3019.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] [go1.15] vimexprwait errors.go115.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] [go1.14] [!go1.15] vimexprwait errors.go114.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] [go1.15] vimexprwait errors.go115.golden GOVIMTest_getqflist()
 
 
 [short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'
@@ -73,6 +75,51 @@ func fn() {}
     "vcol": 0
   }
 ]
+-- errors.go114.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "canInlineFunction(cost: 2)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 4,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "inlineCall(main.fn)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "canInlineFunction(cost: 0)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- errors.go115.golden --
 [
   {
@@ -90,6 +137,37 @@ func fn() {}
   {
     "bufname": "main.go",
     "col": 6,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "canInlineFunction(cost: 0)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.go115.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "canInlineFunction(cost: 2)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 7,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/function_hover.txt
+++ b/cmd/govim/testdata/scenario_default/function_hover.txt
@@ -14,7 +14,8 @@ cmp stdout popup.golden
 # Single warning (unreachable code) + docs as popup content
 vim call append '[5,"\treturn"]'
 vim ex 'call feedkeys(\"\\<CursorHold>\", \"xt\")'
-vimexprwait warning.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait warning.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait warning.golden GOVIMTest_getqflist()
 vim expr 'GOVIMHover()'
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout warning_popup.golden
@@ -24,7 +25,8 @@ cmp stdout warning_popup.golden
 # Two warnings (unreachable code + formatting directive %v) + docs
 vim ex '7s/Hello, world/%v/'
 vim ex 'call cursor(7,8)'
-vimexprwait warnings.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait warnings.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait warnings.golden GOVIMTest_getqflist()
 vim expr 'GOVIMHover()'
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout warnings_popup.golden
@@ -44,7 +46,8 @@ vim ex 'call cursor(6,1)'
 vim ex 'normal dd'
 vim ex 'call cursor(6,7)'
 vim ex 'normal x'
-vimexprwait error.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait error.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait error.golden GOVIMTest_getqflist()
 vim expr 'GOVIMHover()'
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout error_popup.golden
@@ -104,6 +107,23 @@ Pintln not declared by package fmt compiler
     "vcol": 0
   }
 ]
+-- warning.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "unreachable code",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- warnings.golden --
 [
   {
@@ -131,11 +151,59 @@ Pintln not declared by package fmt compiler
     "vcol": 0
   }
 ]
+-- warnings.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Println call has possible formatting directive %v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "unreachable code",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- error.golden --
 [
   {
     "bufname": "main.go",
     "col": 6,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Pintln not declared by package fmt",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- error.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 6,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/gofmt.txt
+++ b/cmd/govim/testdata/scenario_default/gofmt.txt
@@ -19,7 +19,8 @@ cp file.go.bad file.go
 vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.bad
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
 
@@ -61,6 +62,23 @@ const (
   {
     "bufname": "file.go",
     "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found blah",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "file.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 3,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/goimports.txt
+++ b/cmd/govim/testdata/scenario_default/goimports.txt
@@ -19,7 +19,8 @@ cp file.go.bad file.go
 vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.bad
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
 
@@ -63,6 +64,23 @@ y = os.PathSeparator
   {
     "bufname": "file.go",
     "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found blah",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "file.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 3,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/implements.txt
+++ b/cmd/govim/testdata/scenario_default/implements.txt
@@ -8,17 +8,20 @@ vim ex 'e main.go'
 vim ex 'call cursor (9,6)' #TODO: replcae with my values
 vim ex 'GOVIMImplements' # note this moves the cursor to the quickfix window
 vim ex 'call win_gotoid(win_findbuf(bufnr(\"main.go\"))[0])'
-vimexprwait locations.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
 
 # Introduce an error - locations should remain
 vim ex 'call cursor(14, 1)'
 vim ex 'call feedkeys(\"ofmt.Printf(\\\"%v\\\")\\<ESC>\", \"xt\")'
 sleep $GOVIM_ERRLOGMATCH_WAIT
-vimexprwait locations.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
 
 # Now use quickfix for errors
 vim ex 'GOVIMQuickfixDiagnostics'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -59,11 +62,45 @@ func main() {
     "vcol": 0
   }
 ]
+-- locations.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "type Foo interface {",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- errors.golden --
 [
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 15,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 15,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/load_initial_file.txt
+++ b/cmd/govim/testdata/scenario_default/load_initial_file.txt
@@ -4,7 +4,8 @@
 vim expr 'bufname(\"\")'
 stdout '^"main.go"$'
 ! stderr .+
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -19,6 +20,23 @@ asdf
   {
     "bufname": "main.go",
     "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found asdf",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 3,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix.txt
@@ -1,7 +1,8 @@
 # Test that the quickfix window gets populated with error messages from gopls
 
 vim ex 'e main.go'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -63,6 +64,65 @@ func f2() string {}
   {
     "bufname": "main.go",
     "col": 19,
+    "lnum": 10,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "missing return",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 36,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: i",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 39,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 19,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 9,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "missing return",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 19,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 10,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix_config.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_config.txt
@@ -2,7 +2,8 @@
 
 # Default behaviour is quickfix autodiagnostics & sign placment enabled
 vim ex 'e main.go'
-vimexprwait errors.golden1 GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden1 GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden1 GOVIMTest_getqflist()
 vimexprwait signs.golden1 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 
 # There must be no quickfix entries or signs when both are explicitly disabled
@@ -14,12 +15,14 @@ vimexprwait nosigns.golden 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"
 
 # Enabling quickfix autodiagnostics should give quickfix entries but no signs
 vim call 'govim#config#Set' '["QuickfixAutoDiagnostics", 1]'
-vimexprwait errors.golden2 GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden2 GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden2 GOVIMTest_getqflist()
 vimexprwait nosigns.golden 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 
 # Enabling signs should place signs again
 vim call 'govim#config#Set' '["QuickfixSigns", 1]'
-vimexprwait errors.golden2 GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden2 GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden2 GOVIMTest_getqflist()
 vimexprwait signs.golden2 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 
 # Signs should be placed with quickfix autodiagnostics disabled
@@ -30,7 +33,8 @@ vimexprwait signs.golden3 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"*
 
 # Calling :GOVIMQuickfixDiagnostics should force-populate the quickfix window
 vim ex 'GOVIMQuickfixDiagnostics'
-vimexprwait errors.golden3 GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden3 GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden3 GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -92,6 +96,65 @@ func f2() string {}
   {
     "bufname": "main.go",
     "col": 19,
+    "lnum": 10,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "missing return",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden1 --
+[
+  {
+    "bufname": "main.go",
+    "col": 36,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: i",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 39,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 19,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 9,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "missing return",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 19,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 10,
     "module": "",
     "nr": 0,
@@ -213,6 +276,93 @@ func f2() string {}
     "vcol": 0
   }
 ]
+-- errors.v8.2.3019.golden2 --
+[
+  {
+    "bufname": "main.go",
+    "col": 36,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: i",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 39,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 35,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: i",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 38,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 19,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 10,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "missing return",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 19,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 11,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "missing return",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- signs.golden2 --
 [
   {
@@ -257,70 +407,6 @@ func f2() string {}
         "group": "govim",
         "id": 6,
         "lnum": 11,
-        "name": "GOVIMSignErr",
-        "priority": 14
-      }
-    ]
-  }
-]
--- signs.golden3 --
-[
-  {
-    "bufname": "main.go",
-    "signs": [
-      {
-        "group": "govim",
-        "id": 2,
-        "lnum": 6,
-        "name": "GOVIMSignErr",
-        "priority": 14
-      },
-      {
-        "group": "govim",
-        "id": 1,
-        "lnum": 6,
-        "name": "GOVIMSignErr",
-        "priority": 14
-      },
-      {
-        "group": "govim",
-        "id": 4,
-        "lnum": 7,
-        "name": "GOVIMSignErr",
-        "priority": 14
-      },
-      {
-        "group": "govim",
-        "id": 3,
-        "lnum": 7,
-        "name": "GOVIMSignErr",
-        "priority": 14
-      },
-      {
-        "group": "govim",
-        "id": 6,
-        "lnum": 8,
-        "name": "GOVIMSignErr",
-        "priority": 14
-      },
-      {
-        "group": "govim",
-        "id": 5,
-        "lnum": 8,
-        "name": "GOVIMSignErr",
-        "priority": 14
-      },
-      {
-        "group": "govim",
-        "id": 7,
-        "lnum": 11,
-        "name": "GOVIMSignErr",
-        "priority": 14
-      },
-      {
-        "group": "govim",
-        "id": 8,
-        "lnum": 12,
         "name": "GOVIMSignErr",
         "priority": 14
       }
@@ -424,6 +510,185 @@ func f2() string {}
     "type": "",
     "valid": 1,
     "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden3 --
+[
+  {
+    "bufname": "main.go",
+    "col": 36,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: i",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 39,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 35,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: i",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 38,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 35,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 8,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: i",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 38,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 8,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 19,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 11,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "missing return",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 19,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 12,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "missing return",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- signs.golden3 --
+[
+  {
+    "bufname": "main.go",
+    "signs": [
+      {
+        "group": "govim",
+        "id": 2,
+        "lnum": 6,
+        "name": "GOVIMSignErr",
+        "priority": 14
+      },
+      {
+        "group": "govim",
+        "id": 1,
+        "lnum": 6,
+        "name": "GOVIMSignErr",
+        "priority": 14
+      },
+      {
+        "group": "govim",
+        "id": 4,
+        "lnum": 7,
+        "name": "GOVIMSignErr",
+        "priority": 14
+      },
+      {
+        "group": "govim",
+        "id": 3,
+        "lnum": 7,
+        "name": "GOVIMSignErr",
+        "priority": 14
+      },
+      {
+        "group": "govim",
+        "id": 6,
+        "lnum": 8,
+        "name": "GOVIMSignErr",
+        "priority": 14
+      },
+      {
+        "group": "govim",
+        "id": 5,
+        "lnum": 8,
+        "name": "GOVIMSignErr",
+        "priority": 14
+      },
+      {
+        "group": "govim",
+        "id": 7,
+        "lnum": 11,
+        "name": "GOVIMSignErr",
+        "priority": 14
+      },
+      {
+        "group": "govim",
+        "id": 8,
+        "lnum": 12,
+        "name": "GOVIMSignErr",
+        "priority": 14
+      }
+    ]
   }
 ]
 -- nosigns.golden --

--- a/cmd/govim/testdata/scenario_default/quickfix_dependency_package_error.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_dependency_package_error.txt
@@ -2,7 +2,8 @@
 # where the error is in a dependency of the current file's package.
 
 vim ex 'e main.go'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -28,6 +29,23 @@ var x Type
   {
     "bufname": "p/p.go",
     "col": 7,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: Type",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "p/p.go",
+    "col": 7,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 3,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
@@ -31,7 +31,8 @@ vim ex 'noau w! check'
 cmp check p/x_test.go.orig
 
 # Expect the errors
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Change p.DoIt to accept an integer
 vim ex 'sp p/p.go'
@@ -119,6 +120,51 @@ func TestDoIt(t *testing.T) {
   {
     "bufname": "p/x_test.go",
     "col": 9,
+    "lnum": 10,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to p.DoIt",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 9,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to p.DoIt",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "p/p_test.go",
+    "col": 7,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to DoIt",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "p/x_test.go",
+    "col": 9,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 10,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix_eof.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_eof.txt
@@ -2,7 +2,8 @@
 # in the edge case of an error that references the end of file.
 
 vim ex 'e main.go'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -21,6 +22,23 @@ var _ *
   {
     "bufname": "main.go",
     "col": 8,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected ';', found 'EOF'",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 8,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 3,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_directory.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_directory.txt
@@ -3,7 +3,8 @@
 # there's no other errors in this entry file.
 
 vim ex 'e charly.go'
-vimexprwait errors.golden.orig GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
 
 # Now move to error 'errc' and check the position
 vim expr 'setqflist([], \"r\", {\"idx\": 3})'
@@ -14,7 +15,8 @@ stdout '{"idx":3}'
 # Now fix selected error and assert the index points to the first file of the directory
 vim ex 'call cursor(3,1)'
 vim normal dd
-vimexprwait errors.golden.updated GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
 vim expr 'getqflist({\"idx\": 0})'
 stdout '{"idx":2}'
 ! stderr .+
@@ -94,6 +96,65 @@ errdave
     "vcol": 0
   }
 ]
+-- errors.v8.2.3019.golden.orig --
+[
+  {
+    "bufname": "alice/alice.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found erralice",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "bob.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found errbob",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "charly.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found errcharly",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "dave.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found errdave",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- errors.golden.updated --
 [
   {
@@ -123,6 +184,51 @@ errdave
   {
     "bufname": "dave.go",
     "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found errdave",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden.updated --
+[
+  {
+    "bufname": "alice/alice.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found erralice",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "bob.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found errbob",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "dave.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 3,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_last.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_last.txt
@@ -2,7 +2,8 @@
 # selected entry file, if this one isn't found and if there's no next entry.
 
 vim ex 'e main.go'
-vimexprwait errors.golden.orig GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
 
 # Verify we have the first entry selected
 vim expr 'getqflist({\"idx\": 0})'
@@ -18,7 +19,8 @@ stdout '{"idx":4}'
 # Now fix selected error and assert the index points to the last entry of the file
 vim ex 'call cursor(7,1)'
 vim normal dd
-vimexprwait errors.golden.updated GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
 vim expr 'getqflist({\"idx\": 0})'
 stdout '{"idx":3}'
 ! stderr .+
@@ -91,6 +93,65 @@ func main() {
     "vcol": 0
   }
 ]
+-- errors.v8.2.3019.golden.orig --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err2",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err3",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err4",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- errors.golden.updated --
 [
   {
@@ -120,6 +181,51 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err3",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden.updated --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err2",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 6,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_next.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_next.txt
@@ -2,7 +2,8 @@
 # entry file if this one isn't found.
 
 vim ex 'e main.go'
-vimexprwait errors.golden.orig GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
 
 # Verify we have the first entry selected
 vim expr 'getqflist({\"idx\": 0})'
@@ -18,7 +19,8 @@ stdout '{"idx":2}'
 # Now fix selected error and assert the index points to the next entry
 vim ex 'call cursor(5,1)'
 vim normal dd
-vimexprwait errors.golden.updated GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
 vim expr 'getqflist({\"idx\": 0})'
 stdout '{"idx":2}'
 ! stderr .+
@@ -91,6 +93,65 @@ func main() {
     "vcol": 0
   }
 ]
+-- errors.v8.2.3019.golden.orig --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err2",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err3",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err4",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- errors.golden.updated --
 [
   {
@@ -120,6 +181,51 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err4",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden.updated --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: err3",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 6,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix_from_other.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_from_other.txt
@@ -1,23 +1,28 @@
 # Test that the quickfix window is updated by diagnostics only in some situations
 
 vim ex 'e main.go'
-vimexprwait errors.golden1 GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden1 GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden1 GOVIMTest_getqflist()
 vim ex 'call setqflist([{\"filename\":\"foo\"}, {\"filename\":\"bar\"}, {\"filename\":\"baz\"}], \"r\")'
-vimexprwait errors.other GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.other GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.other GOVIMTest_getqflist()
 
 # Add an error, the quickfix should remain because it's not already filled with diagnostics
 vim ex 'call cursor(6, 1)'
 vim ex 'call feedkeys(\"yyp\")'
-vimexprwait errors.other GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.other GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.other GOVIMTest_getqflist()
 
 # Force display diagnostics now
 vim ex 'GOVIMQuickfixDiagnostics'
-vimexprwait errors.golden2 GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden2 GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden2 GOVIMTest_getqflist()
 
 # Fill quickfix with empty array, this time it shouldn't remain because it's empty
 vim ex 'call setqflist([])'
 vim ex 'call feedkeys(\"dd\")'
-vimexprwait errors.golden1 GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden1 GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden1 GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -74,11 +79,73 @@ func main() {
     "vcol": 0
   }
 ]
+-- errors.v8.2.3019.other --
+[
+  {
+    "bufname": "foo",
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 0,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "",
+    "type": "",
+    "valid": 0,
+    "vcol": 0
+  },
+  {
+    "bufname": "bar",
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 0,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "",
+    "type": "",
+    "valid": 0,
+    "vcol": 0
+  },
+  {
+    "bufname": "baz",
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 0,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "",
+    "type": "",
+    "valid": 0,
+    "vcol": 0
+  }
+]
 -- errors.golden1 --
 [
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden1 --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 6,
     "module": "",
     "nr": 0,
@@ -106,6 +173,37 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden2 --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 7,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix_new_files.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_new_files.txt
@@ -28,8 +28,10 @@ vim ex 'noau w! check'
 cmp check p/x_test.go.orig
 
 # Expect the errors
-[!go1.16] vimexprwait errors.golden GOVIMTest_getqflist()
-[go1.16]  vimexprwait errors.go1.16.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] [!go1.16] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] [go1.16] vimexprwait errors.go1.16.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] [!go1.16] vimexprwait errors.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] [go1.16] vimexprwait errors.go1.16.golden GOVIMTest_getqflist()
 
 # Change p.DoIt to accept an integer
 vim ex 'sp p/p.go'
@@ -123,6 +125,51 @@ func TestDoIt(t *testing.T) {
     "vcol": 0
   }
 ]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 9,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot convert 5 (untyped int constant) to string",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "p/p_test.go",
+    "col": 7,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot convert 5 (untyped int constant) to string",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "p/x_test.go",
+    "col": 9,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 10,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot convert 5 (untyped int constant) to string",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- errors.go1.16.golden --
 [
   {
@@ -152,6 +199,51 @@ func TestDoIt(t *testing.T) {
   {
     "bufname": "p/x_test.go",
     "col": 9,
+    "lnum": 10,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to p.DoIt",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.go1.16.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 9,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to p.DoIt",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "p/p_test.go",
+    "col": 7,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "cannot use 5 (untyped int constant) as string value in argument to DoIt",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "p/x_test.go",
+    "col": 9,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 10,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix_replaced_dep.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_replaced_dep.txt
@@ -6,6 +6,8 @@
 
 # Expand $WORK within our golden file
 envsubst error.golden
+[vim:v8.2.3019] envsubst error.v8.2.3019.golden
+[!vim:v8.2.3019] envsubst error.golden
 
 # Open dependency via GoToDef
 vim ex 'e main.go'
@@ -18,7 +20,8 @@ stdout '^\Q"'$WORK'/p/blah.go"\E$'
 vim call append '[3, "asd"]'
 
 # Expect the error to be reported
-vimexprwait error.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait error.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait error.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -53,6 +56,23 @@ const Name = "example.com/blah"
   {
     "bufname": "$WORK/p/blah.go",
     "col": 1,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found asd",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- error.v8.2.3019.golden --
+[
+  {
+    "bufname": "$WORK/p/blah.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 4,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/quickfix_retain_position.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_retain_position.txt
@@ -1,7 +1,8 @@
 # Test that the quickfix window logic around retaining its selected item
 
 vim ex 'e main.go'
-vimexprwait errors.golden.orig GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
 
 # Verify we have the first entry selected
 vim expr 'getqflist({\"idx\": 0})'
@@ -18,7 +19,8 @@ stdout '{"idx":2}'
 vim ex 'e other.go'
 vim ex 'call cursor(3,1)'
 vim normal Sasdf
-vimexprwait errors.golden.updated GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
 vim expr 'getqflist({\"idx\": 0})'
 stdout '{"idx":2}'
 ! stderr .+
@@ -72,6 +74,37 @@ package main
     "vcol": 0
   }
 ]
+-- errors.v8.2.3019.golden.orig --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: asdf",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 8,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: fdas",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- errors.golden.updated --
 [
   {
@@ -101,6 +134,51 @@ package main
   {
     "bufname": "other.go",
     "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "expected declaration, found asdf",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden.updated --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: asdf",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 8,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: fdas",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "other.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 3,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/references.txt
+++ b/cmd/govim/testdata/scenario_default/references.txt
@@ -8,17 +8,20 @@ vim ex 'e main.go'
 vim ex 'call cursor(15,24)'
 vim ex 'GOVIMReferences' # note this moves the cursor to the quickfix window
 vim ex 'call win_gotoid(win_findbuf(bufnr(\"main.go\"))[0])'
-vimexprwait locations.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
 
 # Introduce an error - locations should remain
 vim ex 'call cursor(15,1)'
 vim ex 'call feedkeys(\"ofmt.Printf(\\\"%v\\\")\\<ESC>\", \"xt\")'
 sleep $GOVIM_ERRLOGMATCH_WAIT
-vimexprwait locations.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
 
 # Now use quickfix for errors
 vim ex 'GOVIMQuickfixDiagnostics'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -237,11 +240,241 @@ func DoIt() {
     "vcol": 0
   }
 ]
+-- locations.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 5,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "var v int",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 8,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv = 5",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 9,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += 1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 10,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += 1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 11,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += v + v + v + v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 7,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 11,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += v + v + v + v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 11,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 11,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += v + v + v + v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 15,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 11,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += v + v + v + v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 19,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 11,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += v + v + v + v",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 12,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += 1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 13,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += 1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 14,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += 1",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 24,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 15,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tfmt.Printf(\"v: %v\\n\", v)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "a.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += 5",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "a.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "\tv += 6",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- errors.golden --
 [
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 16,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 16,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
+++ b/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
@@ -1,7 +1,8 @@
 # Test that signs are placed when opening a file that already has diagnostics.
 
 vim ex 'e main.go'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 vim ex 'e other.go'
 vimexprwait placed.golden 'GOVIMTest_sign_getplaced(\"other.go\", {\"group\": \"*\"})'
 
@@ -46,6 +47,37 @@ func foo() {
   {
     "bufname": "other.go",
     "col": 5,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 5,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 5,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "self-assignment of z to z",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "other.go",
+    "col": 5,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 6,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/signs_unload_load_buffer.txt
+++ b/cmd/govim/testdata/scenario_default/signs_unload_load_buffer.txt
@@ -7,12 +7,14 @@ vimexprwait placed_main.golden 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\"
 # open other.go and add a broken statement to get an error that masks the warnings
 vim ex 'e other.go'
 vim call append '[6,"asd"]'
-vimexprwait tmp_error.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait tmp_error.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait tmp_error.golden GOVIMTest_getqflist()
 
 # remove the broken statement
 vim ex 'call cursor(7,1)'
 vim ex 'normal dd'
-vimexprwait warnings.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait warnings.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait warnings.golden GOVIMTest_getqflist()
 
 # jump back to main and check that the sign is still present
 vim ex 'w'
@@ -70,11 +72,59 @@ func foo() {
     "vcol": 0
   }
 ]
+-- warnings.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "other.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- tmp_error.golden --
 [
   {
     "bufname": "other.go",
     "col": 1,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: asd",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- tmp_error.v8.2.3019.golden --
+[
+  {
+    "bufname": "other.go",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 7,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/suggested_fixes.txt
+++ b/cmd/govim/testdata/scenario_default/suggested_fixes.txt
@@ -6,7 +6,8 @@
 
 # Tests basic case with a single diagnostic, no fix selected
 vim ex 'e main.go'
-vimexprwait initial_errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait initial_errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait initial_errors.golden GOVIMTest_getqflist()
 
 vim ex 'call cursor(6,2)'
 vim ex 'GOVIMSuggestedFixes'
@@ -29,7 +30,8 @@ cmp main.go main.go.single.golden
 # second one since that is the cursor position line.
 cp main.go.different_lines main.go
 vim ex 'e! main.go'
-vimexprwait different_lines_errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait different_lines_errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait different_lines_errors.golden GOVIMTest_getqflist()
 
 vim ex 'call cursor(7,2)'
 vim ex 'GOVIMSuggestedFixes'
@@ -40,7 +42,8 @@ errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"title\
 # title to indicate more than one. It shall also be possible to cycle forward and backwards.
 cp main.go.same_line main.go
 vim ex 'e! main.go'
-vimexprwait same_line_errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait same_line_errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait same_line_errors.golden GOVIMTest_getqflist()
 
 vim ex 'call cursor(6,2)'
 vim ex 'GOVIMSuggestedFixes'
@@ -130,6 +133,23 @@ func main() {
     "vcol": 0
   }
 ]
+-- initial_errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "self-assignment of x to x",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- different_lines_errors.golden --
 [
   {
@@ -147,6 +167,37 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "self-assignment of y to y",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- different_lines_errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "self-assignment of x to x",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 7,
     "module": "",
     "nr": 0,
@@ -198,6 +249,65 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "self-assignment of y to y",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- same_line_errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "self-assignment of a to a",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "self-assignment of b to b",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "self-assignment of x to x",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 6,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_default/watcher.txt
+++ b/cmd/govim/testdata/scenario_default/watcher.txt
@@ -13,12 +13,14 @@ cmp main.go main.go.golden
 # Update const.go with an error
 cp const.go.updated const.go
 errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const.go'", Type:2\}'
-vimexprwait errors.undeclared GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.undeclared GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.undeclared GOVIMTest_getqflist()
 
 # Add a const2.go that conflicts with const.go
 cp const2.go.orig const2.go
 errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const2.go'", Type:1\}'
-vimexprwait errors.otherdeclaration GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.otherdeclaration GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.otherdeclaration GOVIMTest_getqflist()
 
 # Remove const.go to resolve the conflict
 rm const.go
@@ -92,6 +94,23 @@ const Bar = 1
     "vcol": 0
   }
 ]
+-- errors.v8.2.3019.undeclared --
+[
+  {
+    "bufname": "main.go",
+    "col": 14,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "undeclared name: Const2",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
 -- errors.otherdeclaration --
 [
   {
@@ -109,6 +128,37 @@ const Bar = 1
   {
     "bufname": "const2.go",
     "col": 2,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Const1 redeclared in this block",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.otherdeclaration --
+[
+  {
+    "bufname": "const.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 4,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "Const1 redeclared in this block (this error: other declaration of Const1)",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "const2.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 4,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_modreadonly/config_set_env_goflags_mod_readonly.txt
+++ b/cmd/govim/testdata/scenario_modreadonly/config_set_env_goflags_mod_readonly.txt
@@ -5,7 +5,8 @@
 [short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'
 
 vim ex 'e main.go'
-vimexprwait pre.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait pre.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait pre.golden GOVIMTest_getqflist()
 vim ex 'w'
 
 # We have to sleep here because there is no event we are waiting for
@@ -56,6 +57,23 @@ func main() {
   {
     "bufname": "main.go",
     "col": 8,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "could not import example.com/blah (no required module provides package \"example.com/blah\")",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- pre.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 8,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 3,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_staticcheck/staticcheck.txt
+++ b/cmd/govim/testdata/scenario_staticcheck/staticcheck.txt
@@ -5,7 +5,8 @@
 # for now in this test to give exposure to the staticcheck work
 
 vim ex 'e main.go'
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103
@@ -43,6 +44,37 @@ func main() {
   {
     "bufname": "main.go",
     "col": 2,
+    "lnum": 9,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "fmt.Printf format %v reads arg #1, but call has 0 args",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 6,
+    "end_col": 0,
+    "end_lnum": 0,
+    "lnum": 7,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "the argument is already a string, there's no need to use fmt.Sprintf",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  },
+  {
+    "bufname": "main.go",
+    "col": 2,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 9,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_go_get_package.txt
+++ b/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_go_get_package.txt
@@ -8,7 +8,8 @@ vim call 'govim#config#Set' '["ExperimentalAllowModfileModifications",0]'
 vim ex 'e main.go'
 
 # Wait for the diag and open up suggested fixes
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 vim ex 'call cursor(6,4)'
 vim ex 'GOVIMSuggestedFixes'
 
@@ -65,6 +66,23 @@ func main() {
   {
     "bufname": "main.go",
     "col": 4,
+    "lnum": 6,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "could not import example.com/withdeps/foo (no required module provides package \"example.com/withdeps/foo\")",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "main.go",
+    "col": 4,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 6,
     "module": "",
     "nr": 0,

--- a/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_remove_dep.txt
+++ b/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_remove_dep.txt
@@ -6,7 +6,8 @@
 vim ex 'e go.mod'
 
 # Wait for the diag and open up suggested fixes
-vimexprwait errors.golden GOVIMTest_getqflist()
+[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 vim ex 'call cursor(3,1)'
 vim ex 'GOVIMSuggestedFixes'
 
@@ -55,6 +56,23 @@ func main() {}
   {
     "bufname": "go.mod",
     "col": 1,
+    "lnum": 3,
+    "module": "",
+    "nr": 0,
+    "pattern": "",
+    "text": "example.com/blah is not used in this module",
+    "type": "",
+    "valid": 1,
+    "vcol": 0
+  }
+]
+-- errors.v8.2.3019.golden --
+[
+  {
+    "bufname": "go.mod",
+    "col": 1,
+    "end_col": 0,
+    "end_lnum": 0,
     "lnum": 3,
     "module": "",
     "nr": 0,


### PR DESCRIPTION
In Vim v8.2.3019, locations now include end position information,
documented as follows:

   end_lnum - end of line number if the item is multiline
   end_col - end of column number if the item has range

Update all of our golden test output to reflect this change. All values
are 0 because we do not have any range-based values.