### PR TITLE
deps: update x/tools and gopls to 07bc1bf4

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/pkg.go
@@ -61,6 +61,10 @@ func (p *pkg) PkgPath() string {
 	return string(p.m.pkgPath)
 }
 
+func (p *pkg) ParseMode() source.ParseMode {
+	return p.mode
+}
+
 func (p *pkg) CompiledGoFiles() []*source.ParsedGoFile {
 	return p.compiledGoFiles
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
@@ -140,13 +140,15 @@ func (s *Session) SetProgressTracker(tracker *progress.Tracker) {
 }
 
 func (s *Session) Shutdown(ctx context.Context) {
+	var views []*View
 	s.viewMu.Lock()
-	defer s.viewMu.Unlock()
-	for _, view := range s.views {
-		view.shutdown(ctx)
-	}
+	views = append(views, s.views...)
 	s.views = nil
 	s.viewMap = nil
+	s.viewMu.Unlock()
+	for _, view := range views {
+		view.shutdown(ctx)
+	}
 	event.Log(ctx, "Shutdown session", KeyShutdownSession.Of(s))
 }
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/cmdtest.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cmd/test/cmdtest.go
@@ -100,6 +100,10 @@ func (r *runner) FunctionExtraction(t *testing.T, start span.Span, end span.Span
 	//TODO: function extraction not supported on command line
 }
 
+func (r *runner) MethodExtraction(t *testing.T, start span.Span, end span.Span) {
+	//TODO: function extraction not supported on command line
+}
+
 func (r *runner) AddImport(t *testing.T, uri span.URI, expectedImport string) {
 	//TODO: import addition not supported on command line
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/code_action.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/code_action.go
@@ -289,8 +289,8 @@ func extractionFixes(ctx context.Context, snapshot source.Snapshot, pkg source.P
 	}
 	puri := protocol.URIFromSpanURI(uri)
 	var commands []protocol.Command
-	if _, ok, _ := source.CanExtractFunction(snapshot.FileSet(), srng, pgf.Src, pgf.File); ok {
-		cmd, err := command.NewApplyFixCommand("Extract to function", command.ApplyFixArgs{
+	if _, ok, methodOk, _ := source.CanExtractFunction(snapshot.FileSet(), srng, pgf.Src, pgf.File); ok {
+		cmd, err := command.NewApplyFixCommand("Extract function", command.ApplyFixArgs{
 			URI:   puri,
 			Fix:   source.ExtractFunction,
 			Range: rng,
@@ -299,6 +299,17 @@ func extractionFixes(ctx context.Context, snapshot source.Snapshot, pkg source.P
 			return nil, err
 		}
 		commands = append(commands, cmd)
+		if methodOk {
+			cmd, err := command.NewApplyFixCommand("Extract method", command.ApplyFixArgs{
+				URI:   puri,
+				Fix:   source.ExtractMethod,
+				Range: rng,
+			})
+			if err != nil {
+				return nil, err
+			}
+			commands = append(commands, cmd)
+		}
 	}
 	if _, _, ok, _ := source.CanExtractVariable(srng, pgf.File); ok {
 		cmd, err := command.NewApplyFixCommand("Extract variable", command.ApplyFixArgs{
@@ -312,11 +323,11 @@ func extractionFixes(ctx context.Context, snapshot source.Snapshot, pkg source.P
 		commands = append(commands, cmd)
 	}
 	var actions []protocol.CodeAction
-	for _, cmd := range commands {
+	for i := range commands {
 		actions = append(actions, protocol.CodeAction{
-			Title:   cmd.Title,
+			Title:   commands[i].Title,
 			Kind:    protocol.RefactorExtract,
-			Command: &cmd,
+			Command: &commands[i],
 		})
 	}
 	return actions, nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fake/sandbox.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fake/sandbox.go
@@ -163,7 +163,7 @@ func UnpackTxt(txt string) map[string][]byte {
 }
 
 func validateConfig(config SandboxConfig) error {
-	if filepath.IsAbs(config.Workdir) && (config.Files != nil || config.InGoPath) {
+	if filepath.IsAbs(config.Workdir) && (len(config.Files) > 0 || config.InGoPath) {
 		return errors.New("absolute Workdir cannot be set in conjunction with Files or InGoPath")
 	}
 	if config.Workdir != "" && config.InGoPath {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/lsppos/lsppos.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/lsppos/lsppos.go
@@ -1,0 +1,89 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package lsppos provides utilities for working with LSP positions.
+//
+// See https://microsoft.github.io/language-server-protocol/specification#textDocuments
+// for a description of LSP positions. Notably:
+//  - Positions are specified by a 0-based line count and 0-based utf-16
+//    character offset.
+//  - Positions are line-ending agnostic: there is no way to specify \r|\n or
+//    \n|. Instead the former maps to the end of the current line, and the
+//    latter to the start of the next line.
+package lsppos
+
+import (
+	"sort"
+	"unicode/utf8"
+)
+
+type Mapper struct {
+	nonASCII bool
+	src      []byte
+
+	// Start-of-line positions. If src is newline-terminated, the final entry will be empty.
+	lines []int
+}
+
+func NewMapper(src []byte) *Mapper {
+	m := &Mapper{src: src}
+	if len(src) == 0 {
+		return m
+	}
+	m.lines = []int{0}
+	for offset, b := range src {
+		if b == '\n' {
+			m.lines = append(m.lines, offset+1)
+		}
+		if b >= utf8.RuneSelf {
+			m.nonASCII = true
+		}
+	}
+	return m
+}
+
+func (m *Mapper) Position(offset int) (line, char int) {
+	if offset < 0 || offset > len(m.src) {
+		return -1, -1
+	}
+	nextLine := sort.Search(len(m.lines), func(i int) bool {
+		return offset < m.lines[i]
+	})
+	if nextLine == 0 {
+		return -1, -1
+	}
+	line = nextLine - 1
+	start := m.lines[line]
+	var charOffset int
+	if m.nonASCII {
+		charOffset = UTF16len(m.src[start:offset])
+	} else {
+		charOffset = offset - start
+	}
+
+	var eol int
+	if line == len(m.lines)-1 {
+		eol = len(m.src)
+	} else {
+		eol = m.lines[line+1] - 1
+	}
+
+	// Adjustment for line-endings: \r|\n is the same as |\r\n.
+	if offset == eol && offset > 0 && m.src[offset-1] == '\r' {
+		charOffset--
+	}
+
+	return line, charOffset
+}
+
+func UTF16len(buf []byte) int {
+	cnt := 0
+	for _, r := range string(buf) {
+		cnt++
+		if r >= 1<<16 {
+			cnt++
+		}
+	}
+	return cnt
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/autostart_default.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/autostart_default.go
@@ -11,13 +11,13 @@ import (
 )
 
 var (
-	startRemote           = startRemoteDefault
+	daemonize             = func(*exec.Cmd) {}
 	autoNetworkAddress    = autoNetworkAddressDefault
 	verifyRemoteOwnership = verifyRemoteOwnershipDefault
 )
 
-func startRemoteDefault(goplsPath string, args ...string) error {
-	cmd := exec.Command(goplsPath, args...)
+func runRemote(cmd *exec.Cmd) error {
+	daemonize(cmd)
 	if err := cmd.Start(); err != nil {
 		return errors.Errorf("starting remote gopls: %w", err)
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/autostart_posix.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/autostart_posix.go
@@ -11,7 +11,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	exec "golang.org/x/sys/execabs"
 	"log"
 	"os"
 	"os/user"
@@ -19,24 +18,21 @@ import (
 	"strconv"
 	"syscall"
 
+	exec "golang.org/x/sys/execabs"
+
 	"golang.org/x/xerrors"
 )
 
 func init() {
-	startRemote = startRemotePosix
+	daemonize = daemonizePosix
 	autoNetworkAddress = autoNetworkAddressPosix
 	verifyRemoteOwnership = verifyRemoteOwnershipPosix
 }
 
-func startRemotePosix(goplsPath string, args ...string) error {
-	cmd := exec.Command(goplsPath, args...)
+func daemonizePosix(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setsid: true,
 	}
-	if err := cmd.Start(); err != nil {
-		return xerrors.Errorf("starting remote gopls: %w", err)
-	}
-	return nil
 }
 
 // autoNetworkAddress resolves an id on the 'auto' pseduo-network to a

--- a/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/dialer.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/dialer.go
@@ -1,0 +1,115 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package lsprpc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	exec "golang.org/x/sys/execabs"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
+	errors "golang.org/x/xerrors"
+)
+
+// AutoNetwork is the pseudo network type used to signal that gopls should use
+// automatic discovery to resolve a remote address.
+const AutoNetwork = "auto"
+
+// An AutoDialer is a jsonrpc2 dialer that understands the 'auto' network.
+type AutoDialer struct {
+	network, addr string // the 'real' network and address
+	isAuto        bool   // whether the server is on the 'auto' network
+
+	executable string
+	argFunc    func(network, addr string) []string
+}
+
+func NewAutoDialer(rawAddr string, argFunc func(network, addr string) []string) (*AutoDialer, error) {
+	d := AutoDialer{
+		argFunc: argFunc,
+	}
+	d.network, d.addr = ParseAddr(rawAddr)
+	if d.network == AutoNetwork {
+		d.isAuto = true
+		bin, err := os.Executable()
+		if err != nil {
+			return nil, errors.Errorf("getting executable: %w", err)
+		}
+		d.executable = bin
+		d.network, d.addr = autoNetworkAddress(bin, d.addr)
+	}
+	return &d, nil
+}
+
+// Dial implements the jsonrpc2.Dialer interface.
+func (d *AutoDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
+	conn, err := d.dialNet(ctx)
+	return conn, err
+}
+
+// TODO(rFindley): remove this once we no longer need to integrate with v1 of
+// the jsonrpc2 package.
+func (d *AutoDialer) dialNet(ctx context.Context) (net.Conn, error) {
+	// Attempt to verify that we own the remote. This is imperfect, but if we can
+	// determine that the remote is owned by a different user, we should fail.
+	ok, err := verifyRemoteOwnership(d.network, d.addr)
+	if err != nil {
+		// If the ownership check itself failed, we fail open but log an error to
+		// the user.
+		event.Error(ctx, "unable to check daemon socket owner, failing open", err)
+	} else if !ok {
+		// We successfully checked that the socket is not owned by us, we fail
+		// closed.
+		return nil, fmt.Errorf("socket %q is owned by a different user", d.addr)
+	}
+	const dialTimeout = 1 * time.Second
+	// Try dialing our remote once, in case it is already running.
+	netConn, err := net.DialTimeout(d.network, d.addr, dialTimeout)
+	if err == nil {
+		return netConn, nil
+	}
+	if d.isAuto && d.argFunc != nil {
+		if d.network == "unix" {
+			// Sometimes the socketfile isn't properly cleaned up when the server
+			// shuts down. Since we have already tried and failed to dial this
+			// address, it should *usually* be safe to remove the socket before
+			// binding to the address.
+			// TODO(rfindley): there is probably a race here if multiple server
+			// instances are simultaneously starting up.
+			if _, err := os.Stat(d.addr); err == nil {
+				if err := os.Remove(d.addr); err != nil {
+					return nil, errors.Errorf("removing remote socket file: %w", err)
+				}
+			}
+		}
+		args := d.argFunc(d.network, d.addr)
+		cmd := exec.Command(d.executable, args...)
+		if err := runRemote(cmd); err != nil {
+			return nil, err
+		}
+	}
+
+	const retries = 5
+	// It can take some time for the newly started server to bind to our address,
+	// so we retry for a bit.
+	for retry := 0; retry < retries; retry++ {
+		startDial := time.Now()
+		netConn, err = net.DialTimeout(d.network, d.addr, dialTimeout)
+		if err == nil {
+			return netConn, nil
+		}
+		event.Log(ctx, fmt.Sprintf("failed attempt #%d to connect to remote: %v\n", retry+2, err))
+		// In case our failure was a fast-failure, ensure we wait at least
+		// f.dialTimeout before trying again.
+		if retry != retries-1 {
+			time.Sleep(dialTimeout - time.Since(startDial))
+		}
+	}
+	return nil, errors.Errorf("dialing remote: %w", err)
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/lsprpc.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/lsprpc.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/jsonrpc2"
-	jsonrpc2_v2 "github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/jsonrpc2_v2"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/cache"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/command"
@@ -30,10 +29,6 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	errors "golang.org/x/xerrors"
 )
-
-// AutoNetwork is the pseudo network type used to signal that gopls should use
-// automatic discovery to resolve a remote address.
-const AutoNetwork = "auto"
 
 // Unique identifiers for client/server.
 var serverIndex int64
@@ -113,13 +108,7 @@ func (s *StreamServer) ServeStream(ctx context.Context, conn jsonrpc2.Conn) erro
 // be instrumented with telemetry, and want to be able to in some cases hijack
 // the jsonrpc2 connection with the daemon.
 type Forwarder struct {
-	network, addr string
-
-	// goplsPath is the path to the current executing gopls binary.
-	goplsPath string
-
-	// configuration for the auto-started gopls remote.
-	remoteConfig remoteConfig
+	dialer *AutoDialer
 
 	mu sync.Mutex
 	// Hold on to the server connection so that we can redo the handshake if any
@@ -128,68 +117,19 @@ type Forwarder struct {
 	serverID   string
 }
 
-type remoteConfig struct {
-	debug         string
-	listenTimeout time.Duration
-	logfile       string
-}
-
-// A RemoteOption configures the behavior of the auto-started remote.
-type RemoteOption interface {
-	set(*remoteConfig)
-}
-
-// RemoteDebugAddress configures the address used by the auto-started Gopls daemon
-// for serving debug information.
-type RemoteDebugAddress string
-
-func (d RemoteDebugAddress) set(cfg *remoteConfig) {
-	cfg.debug = string(d)
-}
-
-// RemoteListenTimeout configures the amount of time the auto-started gopls
-// daemon will wait with no client connections before shutting down.
-type RemoteListenTimeout time.Duration
-
-func (d RemoteListenTimeout) set(cfg *remoteConfig) {
-	cfg.listenTimeout = time.Duration(d)
-}
-
-// RemoteLogfile configures the logfile location for the auto-started gopls
-// daemon.
-type RemoteLogfile string
-
-func (l RemoteLogfile) set(cfg *remoteConfig) {
-	cfg.logfile = string(l)
-}
-
-func defaultRemoteConfig() remoteConfig {
-	return remoteConfig{
-		listenTimeout: 1 * time.Minute,
-	}
-}
-
 // NewForwarder creates a new Forwarder, ready to forward connections to the
-// remote server specified by network and addr.
-func NewForwarder(network, addr string, opts ...RemoteOption) *Forwarder {
-	gp, err := os.Executable()
+// remote server specified by rawAddr. If provided and rawAddr indicates an
+// 'automatic' address (starting with 'auto;'), argFunc may be used to start a
+// remote server for the auto-discovered address.
+func NewForwarder(rawAddr string, argFunc func(network, address string) []string) (*Forwarder, error) {
+	dialer, err := NewAutoDialer(rawAddr, argFunc)
 	if err != nil {
-		log.Printf("error getting gopls path for forwarder: %v", err)
-		gp = ""
+		return nil, err
 	}
-
-	rcfg := defaultRemoteConfig()
-	for _, opt := range opts {
-		opt.set(&rcfg)
-	}
-
 	fwd := &Forwarder{
-		network:      network,
-		addr:         addr,
-		goplsPath:    gp,
-		remoteConfig: rcfg,
+		dialer: dialer,
 	}
-	return fwd
+	return fwd, nil
 }
 
 // QueryServerState queries the server state of the current server.
@@ -247,7 +187,7 @@ func ExecuteCommand(ctx context.Context, addr string, id string, request, result
 func (f *Forwarder) ServeStream(ctx context.Context, clientConn jsonrpc2.Conn) error {
 	client := protocol.ClientDispatcher(clientConn)
 
-	netConn, err := f.connectToRemote(ctx)
+	netConn, err := f.dialer.dialNet(ctx)
 	if err != nil {
 		return errors.Errorf("forwarder: connecting to remote: %w", err)
 	}
@@ -293,19 +233,19 @@ func (f *Forwarder) ServeStream(ctx context.Context, clientConn jsonrpc2.Conn) e
 	return err
 }
 
-func (f *Forwarder) Binder() *ForwardBinder {
-	network, address := realNetworkAddress(f.network, f.addr, f.goplsPath)
-	dialer := jsonrpc2_v2.NetDialer(network, address, net.Dialer{
-		Timeout: 5 * time.Second,
-	})
-	return NewForwardBinder(dialer)
-}
-
+// TODO(rfindley): remove this handshaking in favor of middleware.
 func (f *Forwarder) handshake(ctx context.Context) {
+	// This call to os.Execuable is redundant, and will be eliminated by the
+	// transition to the V2 API.
+	goplsPath, err := os.Executable()
+	if err != nil {
+		event.Error(ctx, "getting executable for handshake", err)
+		goplsPath = ""
+	}
 	var (
 		hreq = handshakeRequest{
 			ServerID:  f.serverID,
-			GoplsPath: f.goplsPath,
+			GoplsPath: goplsPath,
 		}
 		hresp handshakeResponse
 	)
@@ -318,8 +258,8 @@ func (f *Forwarder) handshake(ctx context.Context) {
 		// here.  Handshakes have become functional in nature.
 		event.Error(ctx, "forwarder: gopls handshake failed", err)
 	}
-	if hresp.GoplsPath != f.goplsPath {
-		event.Error(ctx, "", fmt.Errorf("forwarder: gopls path mismatch: forwarder is %q, remote is %q", f.goplsPath, hresp.GoplsPath))
+	if hresp.GoplsPath != goplsPath {
+		event.Error(ctx, "", fmt.Errorf("forwarder: gopls path mismatch: forwarder is %q, remote is %q", goplsPath, hresp.GoplsPath))
 	}
 	event.Log(ctx, "New server",
 		tag.NewServer.Of(f.serverID),
@@ -330,108 +270,12 @@ func (f *Forwarder) handshake(ctx context.Context) {
 	)
 }
 
-func (f *Forwarder) connectToRemote(ctx context.Context) (net.Conn, error) {
-	return connectToRemote(ctx, f.network, f.addr, f.goplsPath, f.remoteConfig)
-}
-
-func ConnectToRemote(ctx context.Context, addr string, opts ...RemoteOption) (net.Conn, error) {
-	rcfg := defaultRemoteConfig()
-	for _, opt := range opts {
-		opt.set(&rcfg)
-	}
-	// This is not strictly necessary, as it won't be used if not connecting to
-	// the 'auto' remote.
-	goplsPath, err := os.Executable()
+func ConnectToRemote(ctx context.Context, addr string) (net.Conn, error) {
+	dialer, err := NewAutoDialer(addr, nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to resolve gopls path: %v", err)
+		return nil, err
 	}
-	network, address := ParseAddr(addr)
-	return connectToRemote(ctx, network, address, goplsPath, rcfg)
-}
-
-func realNetworkAddress(inNetwork, inAddr, goplsPath string) (network, address string) {
-	if inNetwork != AutoNetwork {
-		return inNetwork, inAddr
-	}
-	// The "auto" network is a fake network used for service discovery. It
-	// resolves a known address based on gopls binary path.
-	return autoNetworkAddress(goplsPath, inAddr)
-}
-
-func connectToRemote(ctx context.Context, inNetwork, inAddr, goplsPath string, rcfg remoteConfig) (net.Conn, error) {
-	var (
-		netConn          net.Conn
-		err              error
-		network, address = realNetworkAddress(inNetwork, inAddr, goplsPath)
-	)
-	// Attempt to verify that we own the remote. This is imperfect, but if we can
-	// determine that the remote is owned by a different user, we should fail.
-	ok, err := verifyRemoteOwnership(network, address)
-	if err != nil {
-		// If the ownership check itself failed, we fail open but log an error to
-		// the user.
-		event.Error(ctx, "unable to check daemon socket owner, failing open", err)
-	} else if !ok {
-		// We successfully checked that the socket is not owned by us, we fail
-		// closed.
-		return nil, fmt.Errorf("socket %q is owned by a different user", address)
-	}
-	const dialTimeout = 1 * time.Second
-	// Try dialing our remote once, in case it is already running.
-	netConn, err = net.DialTimeout(network, address, dialTimeout)
-	if err == nil {
-		return netConn, nil
-	}
-	// If our remote is on the 'auto' network, start it if it doesn't exist.
-	if inNetwork == AutoNetwork {
-		if goplsPath == "" {
-			return nil, fmt.Errorf("cannot auto-start remote: gopls path is unknown")
-		}
-		if network == "unix" {
-			// Sometimes the socketfile isn't properly cleaned up when gopls shuts
-			// down. Since we have already tried and failed to dial this address, it
-			// should *usually* be safe to remove the socket before binding to the
-			// address.
-			// TODO(rfindley): there is probably a race here if multiple gopls
-			// instances are simultaneously starting up.
-			if _, err := os.Stat(address); err == nil {
-				if err := os.Remove(address); err != nil {
-					return nil, errors.Errorf("removing remote socket file: %w", err)
-				}
-			}
-		}
-		args := []string{"serve",
-			"-listen", fmt.Sprintf(`%s;%s`, network, address),
-			"-listen.timeout", rcfg.listenTimeout.String(),
-		}
-		if rcfg.logfile != "" {
-			args = append(args, "-logfile", rcfg.logfile)
-		}
-		if rcfg.debug != "" {
-			args = append(args, "-debug", rcfg.debug)
-		}
-		if err := startRemote(goplsPath, args...); err != nil {
-			return nil, errors.Errorf("startRemote(%q, %v): %w", goplsPath, args, err)
-		}
-	}
-
-	const retries = 5
-	// It can take some time for the newly started server to bind to our address,
-	// so we retry for a bit.
-	for retry := 0; retry < retries; retry++ {
-		startDial := time.Now()
-		netConn, err = net.DialTimeout(network, address, dialTimeout)
-		if err == nil {
-			return netConn, nil
-		}
-		event.Log(ctx, fmt.Sprintf("failed attempt #%d to connect to remote: %v\n", retry+2, err))
-		// In case our failure was a fast-failure, ensure we wait at least
-		// f.dialTimeout before trying again.
-		if retry != retries-1 {
-			time.Sleep(dialTimeout - time.Since(startDial))
-		}
-	}
-	return nil, errors.Errorf("dialing remote: %w", err)
+	return dialer.dialNet(ctx)
 }
 
 // handler intercepts messages to the daemon to enrich them with local

--- a/cmd/govim/internal/golang_org_x_tools/lsp/mod/diagnostics.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/mod/diagnostics.go
@@ -86,7 +86,7 @@ func DiagnosticsForMod(ctx context.Context, snapshot source.Snapshot, fh source.
 	}
 
 	// Packages in the workspace can contribute diagnostics to go.mod files.
-	wspkgs, err := snapshot.WorkspacePackages(ctx)
+	wspkgs, err := snapshot.ActivePackages(ctx)
 	if err != nil && !source.IsNonFatalGoModError(err) {
 		event.Error(ctx, fmt.Sprintf("workspace packages: diagnosing %s", pm.URI), err)
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/regtest/expectation.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/regtest/expectation.go
@@ -539,7 +539,7 @@ func EmptyDiagnostics(name string) Expectation {
 // send at least one diagnostic set for open files.
 func EmptyOrNoDiagnostics(name string) Expectation {
 	check := func(s State) Verdict {
-		if diags := s.diagnostics[name]; len(diags.Diagnostics) == 0 {
+		if diags := s.diagnostics[name]; diags == nil || len(diags.Diagnostics) == 0 {
 			return Met
 		}
 		return Unmet

--- a/cmd/govim/internal/golang_org_x_tools/lsp/regtest/runner.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/regtest/runner.go
@@ -29,6 +29,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/xcontext"
 )
 
 // Mode is a bitmask that defines for which execution modes a test should run.
@@ -177,10 +178,6 @@ func DebugAddress(addr string) RunOption {
 	})
 }
 
-var WindowsLineEndings = optionSetter(func(opts *runConfig) {
-	opts.editor.WindowsLineEndings = true
-})
-
 // SkipLogs skips the buffering of logs during test execution. It is intended
 // for long-running stress tests.
 func SkipLogs() RunOption {
@@ -307,7 +304,13 @@ func (r *Runner) Run(t *testing.T, files string, test TestFunc, opts ...RunOptio
 				if t.Failed() || testing.Verbose() {
 					ls.printBuffers(t.Name(), os.Stderr)
 				}
-				env.CloseEditor()
+				// For tests that failed due to a timeout, don't fail to shutdown
+				// because ctx is done.
+				closeCtx, cancel := context.WithTimeout(xcontext.Detach(ctx), 5*time.Second)
+				defer cancel()
+				if err := env.Editor.Close(closeCtx); err != nil {
+					t.Errorf("closing editor: %v", err)
+				}
 			}()
 			// Always await the initial workspace load.
 			env.Await(InitialWorkspaceLoad)
@@ -408,7 +411,7 @@ func experimentalServer(_ context.Context, t *testing.T, optsHook func(*source.O
 
 func (r *Runner) forwardedServer(ctx context.Context, t *testing.T, optsHook func(*source.Options)) jsonrpc2.StreamServer {
 	ts := r.getTestServer(optsHook)
-	return lsprpc.NewForwarder("tcp", ts.Addr)
+	return newForwarder("tcp", ts.Addr)
 }
 
 // getTestServer gets the shared test server instance to connect to, or creates
@@ -429,7 +432,16 @@ func (r *Runner) separateProcessServer(ctx context.Context, t *testing.T, optsHo
 	// TODO(rfindley): can we use the autostart behavior here, instead of
 	// pre-starting the remote?
 	socket := r.getRemoteSocket(t)
-	return lsprpc.NewForwarder("unix", socket)
+	return newForwarder("unix", socket)
+}
+
+func newForwarder(network, address string) *lsprpc.Forwarder {
+	server, err := lsprpc.NewForwarder(network+";"+address, nil)
+	if err != nil {
+		// This should never happen, as we are passing an explicit address.
+		panic(fmt.Sprintf("internal error: unable to create forwarder: %v", err))
+	}
+	return server
 }
 
 // runTestAsGoplsEnvvar triggers TestMain to run gopls instead of running

--- a/cmd/govim/internal/golang_org_x_tools/lsp/regtest/wrappers.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/regtest/wrappers.go
@@ -6,14 +6,12 @@ package regtest
 
 import (
 	"encoding/json"
-	"io"
 	"path"
 	"testing"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/command"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/fake"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
-	errors "golang.org/x/xerrors"
 )
 
 func (e *Env) ChangeFilesOnDisk(events []fake.FileEvent) {
@@ -245,19 +243,6 @@ func (e *Env) DocumentHighlight(name string, pos fake.Pos) []protocol.DocumentHi
 		e.T.Fatal(err)
 	}
 	return highlights
-}
-
-func checkIsFatal(t testing.TB, err error) {
-	t.Helper()
-	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrClosedPipe) {
-		t.Fatal(err)
-	}
-}
-
-// CloseEditor shuts down the editor, calling t.Fatal on any error.
-func (e *Env) CloseEditor() {
-	e.T.Helper()
-	checkIsFatal(e.T, e.Editor.Close(e.Ctx))
 }
 
 // RunGenerate runs go:generate on the given dir, calling t.Fatal on any error.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/format.go
@@ -143,6 +143,7 @@ Suffixes:
 	// add the additional text edits needed.
 	if cand.imp != nil {
 		addlEdits, err := c.importEdits(cand.imp)
+
 		if err != nil {
 			return CompletionItem{}, err
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/package.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/completion/package.go
@@ -213,7 +213,7 @@ func (c *completer) packageNameCompletions(ctx context.Context, fileURI span.URI
 // file. This also includes test packages for these packages (<pkg>_test) and
 // the directory name itself.
 func packageSuggestions(ctx context.Context, snapshot source.Snapshot, fileURI span.URI, prefix string) (packages []candidate, err error) {
-	workspacePackages, err := snapshot.WorkspacePackages(ctx)
+	workspacePackages, err := snapshot.ActivePackages(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/fix.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/fix.go
@@ -32,6 +32,7 @@ const (
 	UndeclaredName  = "undeclared_name"
 	ExtractVariable = "extract_variable"
 	ExtractFunction = "extract_function"
+	ExtractMethod   = "extract_method"
 )
 
 // suggestedFixes maps a suggested fix command id to its handler.
@@ -40,6 +41,7 @@ var suggestedFixes = map[string]SuggestedFixFunc{
 	UndeclaredName:  undeclaredname.SuggestedFix,
 	ExtractVariable: extractVariable,
 	ExtractFunction: extractFunction,
+	ExtractMethod:   extractMethod,
 }
 
 func SuggestedFixFromCommand(cmd protocol.Command, kind protocol.CodeActionKind) SuggestedFix {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/format.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/format.go
@@ -19,7 +19,9 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/imports"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/diff"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/lsppos"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 )
 
 // Format formats a file with a given range.
@@ -177,7 +179,7 @@ func computeFixEdits(snapshot Snapshot, pgf *ParsedGoFile, options *imports.Opti
 	if err != nil {
 		return nil, err
 	}
-	return ToProtocolEdits(pgf.Mapper, edits)
+	return ProtocolEditsFromSource([]byte(left), edits, pgf.Mapper.Converter)
 }
 
 // importPrefix returns the prefix of the given file content through the final
@@ -278,6 +280,37 @@ func computeTextEdits(ctx context.Context, snapshot Snapshot, pgf *ParsedGoFile,
 		return nil, err
 	}
 	return ToProtocolEdits(pgf.Mapper, edits)
+}
+
+// ProtocolEditsFromSource converts text edits to LSP edits using the original
+// source.
+func ProtocolEditsFromSource(src []byte, edits []diff.TextEdit, converter span.Converter) ([]protocol.TextEdit, error) {
+	m := lsppos.NewMapper(src)
+	var result []protocol.TextEdit
+	for _, edit := range edits {
+		spn, err := edit.Span.WithOffset(converter)
+		if err != nil {
+			return nil, fmt.Errorf("computing offsets: %v", err)
+		}
+		startLine, startChar := m.Position(spn.Start().Offset())
+		endLine, endChar := m.Position(spn.End().Offset())
+		if startLine < 0 || endLine < 0 {
+			return nil, fmt.Errorf("out of bound span: %v", spn)
+		}
+
+		pstart := protocol.Position{Line: uint32(startLine), Character: uint32(startChar)}
+		pend := protocol.Position{Line: uint32(endLine), Character: uint32(endChar)}
+		if pstart == pend && edit.NewText == "" {
+			// Degenerate case, which may result from a diff tool wanting to delete
+			// '\r' in line endings. Filter it out.
+			continue
+		}
+		result = append(result, protocol.TextEdit{
+			Range:   protocol.Range{Start: pstart, End: pend},
+			NewText: edit.NewText,
+		})
+	}
+	return result, nil
 }
 
 func ToProtocolEdits(m *protocol.ColumnMapper, edits []diff.TextEdit) ([]protocol.TextEdit, error) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/identifier.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/identifier.go
@@ -57,10 +57,11 @@ type Declaration struct {
 
 	// The typechecked node.
 	node ast.Node
-	// Optional: the fully parsed spec, to be used for formatting in cases where
+
+	// Optional: the fully parsed node, to be used for formatting in cases where
 	// node has missing information. This could be the case when node was parsed
 	// in ParseExported mode.
-	fullSpec ast.Spec
+	fullDecl ast.Decl
 
 	// The typechecked object.
 	obj types.Object
@@ -85,6 +86,10 @@ func Identifier(ctx context.Context, snapshot Snapshot, fh FileHandle, pos proto
 		return nil, fmt.Errorf("no packages for file %v", fh.URI())
 	}
 	sort.Slice(pkgs, func(i, j int) bool {
+		// Prefer packages with a more complete parse mode.
+		if pkgs[i].ParseMode() != pkgs[j].ParseMode() {
+			return pkgs[i].ParseMode() > pkgs[j].ParseMode()
+		}
 		return len(pkgs[i].CompiledGoFiles()) < len(pkgs[j].CompiledGoFiles())
 	})
 	var findErr error
@@ -286,8 +291,7 @@ func findIdentifier(ctx context.Context, snapshot Snapshot, pkg Package, pgf *Pa
 	}
 	// Ensure that we have the full declaration, in case the declaration was
 	// parsed in ParseExported and therefore could be missing information.
-	result.Declaration.fullSpec, err = fullSpec(snapshot, result.Declaration.obj, declPkg)
-	if err != nil {
+	if result.Declaration.fullDecl, err = fullNode(snapshot, result.Declaration.obj, declPkg); err != nil {
 		return nil, err
 	}
 	typ := pkg.GetTypesInfo().TypeOf(result.ident)
@@ -310,10 +314,10 @@ func findIdentifier(ctx context.Context, snapshot Snapshot, pkg Package, pgf *Pa
 	return result, nil
 }
 
-// fullSpec tries to extract the full spec corresponding to obj's declaration.
+// fullNode tries to extract the full spec corresponding to obj's declaration.
 // If the package was not parsed in full, the declaration file will be
 // re-parsed to ensure it has complete syntax.
-func fullSpec(snapshot Snapshot, obj types.Object, pkg Package) (ast.Spec, error) {
+func fullNode(snapshot Snapshot, obj types.Object, pkg Package) (ast.Decl, error) {
 	// declaration in a different package... make sure we have full AST information.
 	tok := snapshot.FileSet().File(obj.Pos())
 	uri := span.URIFromPath(tok.Name())
@@ -334,9 +338,9 @@ func fullSpec(snapshot Snapshot, obj types.Object, pkg Package) (ast.Spec, error
 		}
 	}
 	path, _ := astutil.PathEnclosingInterval(file, pos, pos)
-	if len(path) > 1 {
-		if spec, _ := path[1].(*ast.TypeSpec); spec != nil {
-			return spec, nil
+	for _, n := range path {
+		if decl, ok := n.(ast.Decl); ok {
+			return decl, nil
 		}
 	}
 	return nil, nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/signature_help.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/signature_help.go
@@ -51,7 +51,12 @@ FindCall:
 			// which may be the parameter to the *ast.CallExpr.
 			// Don't show signature help in this case.
 			return nil, 0, errors.Errorf("no signature help within a function declaration")
+		case *ast.BasicLit:
+			if node.Kind == token.STRING {
+				return nil, 0, errors.Errorf("no signature help within a string literal")
+			}
 		}
+
 	}
 	if callExpr == nil || callExpr.Fun == nil {
 		return nil, 0, errors.Errorf("cannot find an enclosing function")

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -156,8 +156,11 @@ type Snapshot interface {
 	// in TypecheckWorkspace mode.
 	KnownPackages(ctx context.Context) ([]Package, error)
 
-	// WorkspacePackages returns the snapshot's top-level packages.
-	WorkspacePackages(ctx context.Context) ([]Package, error)
+	// ActivePackages returns the packages considered 'active' in the workspace.
+	//
+	// In normal memory mode, this is all workspace packages. In degraded memory
+	// mode, this is just the reverse transitive closure of open packages.
+	ActivePackages(ctx context.Context) ([]Package, error)
 
 	// GetCriticalError returns any critical errors in the workspace.
 	GetCriticalError(ctx context.Context) *CriticalError
@@ -581,6 +584,7 @@ type Package interface {
 	Version() *module.Version
 	HasListOrParseErrors() bool
 	HasTypeErrors() bool
+	ParseMode() ParseMode
 }
 
 type CriticalError struct {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/workspace_symbol.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/workspace_symbol.go
@@ -57,77 +57,75 @@ func WorkspaceSymbols(ctx context.Context, matcherType SymbolMatcher, style Symb
 // See the comment for symbolCollector for more information.
 type matcherFunc func(name string) float64
 
-// A symbolizer returns the best symbol match for name with pkg, according to
-// some heuristic.
+// A symbolizer returns the best symbol match for a name with pkg, according to
+// some heuristic. The symbol name is passed as the slice nameParts of logical
+// name pieces. For example, for myType.field the caller can pass either
+// []string{"myType.field"} or []string{"myType.", "field"}.
 //
 // See the comment for symbolCollector for more information.
-type symbolizer func(name string, pkg Package, m matcherFunc) (string, float64)
+type symbolizer func(nameParts []string, pkg Package, m matcherFunc) (string, float64)
 
-func fullyQualifiedSymbolMatch(name string, pkg Package, matcher matcherFunc) (string, float64) {
-	_, score := dynamicSymbolMatch(name, pkg, matcher)
+func fullyQualifiedSymbolMatch(nameParts []string, pkg Package, matcher matcherFunc) (string, float64) {
+	_, score := dynamicSymbolMatch(nameParts, pkg, matcher)
+	path := append([]string{pkg.PkgPath() + "."}, nameParts...)
 	if score > 0 {
-		return pkg.PkgPath() + "." + name, score
+		return strings.Join(path, ""), score
 	}
 	return "", 0
 }
 
-func dynamicSymbolMatch(name string, pkg Package, matcher matcherFunc) (string, float64) {
-	// Prefer any package-qualified match.
-	pkgQualified := pkg.Name() + "." + name
-	if match, score := bestMatch(pkgQualified, matcher); match != "" {
-		return match, score
+func dynamicSymbolMatch(nameParts []string, pkg Package, matcher matcherFunc) (string, float64) {
+	var best string
+	fullName := strings.Join(nameParts, "")
+	var score float64
+	var name string
+
+	// Compute the match score by finding the highest scoring suffix. In these
+	// cases the matched symbol is still the full name: it is confusing to match
+	// an unqualified nested field or method.
+	if match := bestMatch("", nameParts, matcher); match > score {
+		best = fullName
+		score = match
 	}
-	fullyQualified := pkg.PkgPath() + "." + name
-	if match, score := bestMatch(fullyQualified, matcher); match != "" {
-		return match, score
+
+	// Next: try to match a package-qualified name.
+	name = pkg.Name() + "." + fullName
+	if match := matcher(name); match > score {
+		best = name
+		score = match
 	}
-	return "", 0
+
+	// Finally: consider a fully qualified name.
+	prefix := pkg.PkgPath() + "."
+	fullyQualified := prefix + fullName
+	// As with field/method selectors, consider suffixes from right to left, but
+	// always return a fully-qualified symbol.
+	pathParts := strings.SplitAfter(prefix, "/")
+	if match := bestMatch(fullName, pathParts, matcher); match > score {
+		best = fullyQualified
+		score = match
+	}
+	return best, score
 }
 
-func packageSymbolMatch(name string, pkg Package, matcher matcherFunc) (string, float64) {
-	qualified := pkg.Name() + "." + name
+func bestMatch(name string, prefixParts []string, matcher matcherFunc) float64 {
+	var score float64
+	for i := len(prefixParts) - 1; i >= 0; i-- {
+		name = prefixParts[i] + name
+		if match := matcher(name); match > score {
+			score = match
+		}
+	}
+	return score
+}
+
+func packageSymbolMatch(components []string, pkg Package, matcher matcherFunc) (string, float64) {
+	path := append([]string{pkg.Name() + "."}, components...)
+	qualified := strings.Join(path, "")
 	if matcher(qualified) > 0 {
 		return qualified, 1
 	}
 	return "", 0
-}
-
-// bestMatch returns the highest scoring symbol suffix of fullPath, starting
-// from the right and splitting on selectors and path components.
-//
-// e.g. given a symbol path of the form 'host.com/dir/pkg.type.field', we
-// check the match quality of the following:
-//  - field
-//  - type.field
-//  - pkg.type.field
-//  - dir/pkg.type.field
-//  - host.com/dir/pkg.type.field
-//
-// and return the best match, along with its score.
-//
-// This is used to implement the 'dynamic' symbol style.
-func bestMatch(fullPath string, matcher matcherFunc) (string, float64) {
-	pathParts := strings.Split(fullPath, "/")
-	dottedParts := strings.Split(pathParts[len(pathParts)-1], ".")
-
-	var best string
-	var score float64
-
-	for i := 0; i < len(dottedParts); i++ {
-		path := strings.Join(dottedParts[len(dottedParts)-1-i:], ".")
-		if match := matcher(path); match > score {
-			best = path
-			score = match
-		}
-	}
-	for i := 0; i < len(pathParts); i++ {
-		path := strings.Join(pathParts[len(pathParts)-1-i:], "/")
-		if match := matcher(path); match > score {
-			best = path
-			score = match
-		}
-	}
-	return best, score
 }
 
 // symbolCollector holds context as we walk Packages, gathering symbols that
@@ -313,7 +311,9 @@ func (sc *symbolCollector) collectPackages(ctx context.Context, views []View) ([
 		if err != nil {
 			return nil, err
 		}
-		workspacePackages, err := snapshot.WorkspacePackages(ctx)
+		// TODO(rfindley): this can result in incomplete information in degraded
+		// memory mode.
+		workspacePackages, err := snapshot.ActivePackages(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -420,7 +420,13 @@ func (sc *symbolCollector) walkType(typ ast.Expr, path ...*ast.Ident) {
 // or named. path is the path of nested identifiers containing the field.
 func (sc *symbolCollector) walkField(field *ast.Field, unnamedKind, namedKind protocol.SymbolKind, path ...*ast.Ident) {
 	if len(field.Names) == 0 {
-		sc.match(types.ExprString(field.Type), unnamedKind, field, path...)
+		switch typ := field.Type.(type) {
+		case *ast.SelectorExpr:
+			// embedded qualified type
+			sc.match(typ.Sel.Name, unnamedKind, field, path...)
+		default:
+			sc.match(types.ExprString(field.Type), unnamedKind, field, path...)
+		}
 	}
 	for _, name := range field.Names {
 		sc.match(name.Name, namedKind, name, path...)
@@ -466,18 +472,14 @@ func (sc *symbolCollector) match(name string, kind protocol.SymbolKind, node ast
 	}
 
 	isExported := isExported(name)
-	if len(path) > 0 {
-		var nameBuilder strings.Builder
-		for _, ident := range path {
-			nameBuilder.WriteString(ident.Name)
-			nameBuilder.WriteString(".")
-			if !ident.IsExported() {
-				isExported = false
-			}
+	var names []string
+	for _, ident := range path {
+		names = append(names, ident.Name+".")
+		if !ident.IsExported() {
+			isExported = false
 		}
-		nameBuilder.WriteString(name)
-		name = nameBuilder.String()
 	}
+	names = append(names, name)
 
 	// Factors to apply to the match score for the purpose of downranking
 	// results.
@@ -501,7 +503,7 @@ func (sc *symbolCollector) match(name string, kind protocol.SymbolKind, node ast
 		// can be noisy.
 		fieldFactor = 0.5
 	)
-	symbol, score := sc.symbolizer(name, sc.current.pkg, sc.matcher)
+	symbol, score := sc.symbolizer(names, sc.current.pkg, sc.matcher)
 
 	// Downrank symbols outside of the workspace.
 	if !sc.current.isWorkspace {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/text_synchronization.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/text_synchronization.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/jsonrpc2"
@@ -241,7 +242,11 @@ func (s *Server) didModifyFiles(ctx context.Context, modifications []source.File
 	//     process changes in order.
 	s.pendingOnDiskChanges = append(s.pendingOnDiskChanges, pending)
 	ctx = xcontext.Detach(ctx)
-	delayed := func() {
+	okc := s.watchedFileDebouncer.debounce("", 0, time.After(delay))
+	go func() {
+		if ok := <-okc; !ok {
+			return
+		}
 		s.fileChangeMu.Lock()
 		var allChanges []source.FileModification
 		// For accurate progress notifications, we must notify all goroutines
@@ -263,8 +268,7 @@ func (s *Server) didModifyFiles(ctx context.Context, modifications []source.File
 		for _, done := range dones {
 			close(done)
 		}
-	}
-	go s.watchedFileDebouncer.debounce("", 0, delay, delayed)
+	}()
 	return nil
 }
 
@@ -278,6 +282,7 @@ func (s *Server) processModifications(ctx context.Context, modifications []sourc
 		// produce a better error message. The actual race to the cache should be
 		// guarded by Session.viewMu.
 		s.stateMu.Unlock()
+		close(diagnoseDone)
 		return errors.New("server is shut down")
 	}
 	s.stateMu.Unlock()
@@ -287,6 +292,7 @@ func (s *Server) processModifications(ctx context.Context, modifications []sourc
 
 	snapshots, releases, err := s.session.DidModifyFiles(ctx, modifications)
 	if err != nil {
+		close(diagnoseDone)
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
-	golang.org/x/tools v0.1.5-0.20210708231608-69948257bde7
-	golang.org/x/tools/gopls v0.0.0-20210708231608-69948257bde7
+	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2
+	golang.org/x/tools/gopls v0.0.0-20210726203631-07bc1bf47fb2
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -80,10 +80,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.5-0.20210708231608-69948257bde7 h1:SibCusD7QqyUXqDhocM0mxP50U93XQ18LWR8JLgxnOM=
-golang.org/x/tools v0.1.5-0.20210708231608-69948257bde7/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools/gopls v0.0.0-20210708231608-69948257bde7 h1:/n4EHdXnDw762moODVWkMAypkcQUAReWeuZvmccc6gQ=
-golang.org/x/tools/gopls v0.0.0-20210708231608-69948257bde7/go.mod h1:ekCtf0GOS1JSF+KM46LZvJUyEsyKfFZOfcytlR7aBfg=
+golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2 h1:BonxutuHCTL0rBDnZlKjpGIQFTjyUVTexFOdWkB6Fg0=
+golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools/gopls v0.0.0-20210726203631-07bc1bf47fb2 h1:ge85cIIDez08sKTO728muWWoCIVG+XRJz/GcgLl47CQ=
+golang.org/x/tools/gopls v0.0.0-20210726203631-07bc1bf47fb2/go.mod h1:ekCtf0GOS1JSF+KM46LZvJUyEsyKfFZOfcytlR7aBfg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
*  internal/lsp: in degraded mode, limit the workspace to active packages 07bc1bf4
*  internal/lsp/source: improve logic for finding full syntax in hover f0938710
*  file2fuzz: add fuzzer corpus conversion tool 4ad98e96
*  txtar/archive: ignore invalid file separators ebce39e5
*  internal/lsp: skip signature help within a string literal 4fe0d6c8
*  internal/lsp/source: evaluate bin/hex literal on hover 0c506a27
*  internal/lsp: add extract to method code action 46d1522a
*  internal/lsp: handle incorrect import with CRLF line endings c740bfd9
*  internal/lsp/source: compute imports text edits from scratch 251092de
*  all: add SliceToArrayPointer instruction 412ee174
*  internal/lsp/source: workspace symbol improvements for selectors 7f68387a
*  internal/lsp: handle panic in fix AST 7aa82944
*  gopls/doc: fix imports function for Neovim LSP 6e9046bf
*  internal/lsp/semantic: improve semantic token processing 0cf4e270
*  internal/lsp: signal diagnostic completion if modification failed 5061c412
*  gopls/doc: add vetted examples for Sublime Text ef97713d
*  internal/lsp: adopt bcmills' suggestion for an improved debouncer API 8e85a283
*  internal/lsp: fix variable reuse bug in code actions ae0deb7a
*  internal/lsp: improve package search in a couple places d36a54b5
*  gopls/internal/regtest: add a flag to profile didChange handling 38446009
*  gopls/doc: Neovim v0.5 is now stable de447761
*  internal/lsp/source: fix comment update during rename for short variable declarations ccff7327
*  internal/lsp: attempt to make TestDebouncer more robust a7dfe3d2
*  internal/lsp/lsprpc: add an AutoDialer abstraction 980829d8
*  Revert "internal/lsp/semantic.go: repress useless messages and tighten logic" cb1acef8
*  internal/lsp/semantic.go: repress useless messages and tighten logic 5b540d34
*  go/packages: skip tests that link binaries in short mode e33c0f29
*  internal/lsp/regtest: fix a panic TestResolveImportCycle 8e32e9f1
*  go/packages: fix data race in TestCgoNoSyntax 2583041a