### PR TITLE
testdriver: simplify condition version logic

### DIFF
--- a/cmd/govim/testdata/scenario_autoreadloadedbuffers/autoread_loaded_buffers.txt
+++ b/cmd/govim/testdata/scenario_autoreadloadedbuffers/autoread_loaded_buffers.txt
@@ -13,8 +13,8 @@ vim ex 'e main.go'
 # "edit" the loaded file from outside of vim
 cp const.go.commented const.go
 
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.undeclared GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.undeclared GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.undeclared GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.undeclared GOVIMTest_getqflist()
 
 # No warnings or errors during the test
 

--- a/cmd/govim/testdata/scenario_bugs/bug_gopls_36144.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_gopls_36144.txt
@@ -11,8 +11,8 @@
 # cancellation of the initial diagnostics for the package, or the diagnostics
 # that are sent when a file is opened.
 
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_error_error_error.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_error_error_error.txt
@@ -9,20 +9,20 @@
 
 # Expect the initial state
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Make a change that shouldn't alter the diagnostics
 vim call append '[4,"\t"]'
 sleep $GOVIM_ERRLOGMATCH_WAIT
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Undo that change and ensure we still have the diagnostics
 vim ex 5delete
 sleep $GOVIM_ERRLOGMATCH_WAIT
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_error_no-error_error.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_error_no-error_error.txt
@@ -7,8 +7,8 @@
 
 # Expect the initial state
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Make a change that removes diagnostics
 vim call append '[4,"\tprintln(x)"]'
@@ -16,8 +16,8 @@ vimexprwait empty.golden GOVIMTest_getqflist()
 
 # Undo that change and ensure we have the original diagnostics
 vim ex 5delete
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_no-error_error_no-error.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_gopls_36601_no-error_error_no-error.txt
@@ -14,8 +14,8 @@ vimexprwait empty.golden GOVIMTest_getqflist()
 
 # Make a change that adds diagnostics
 vim call append '[4,"\tx := 123"]'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Undo that change and ensure we still zero diagnostics again
 vim ex 5delete

--- a/cmd/govim/testdata/scenario_bugs/bug_govim_1013.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_govim_1013.txt
@@ -2,7 +2,8 @@
 
 [!vim] [!gvim] skip 'Test only known to work in Vim and GVim'
 
-[!vim:v8.1.1649] skip 'New style popup tests do not work on gvim https://github.com/govim/govim/issues/351'
+[!v8.1.1649] skip 'New style popup tests do not work on gvim >= v8.1.1659 https://github.com/govim/govim/issues/351'
+[gvim] skip 'New style popup tests do not work on gvim >= v8.1.1659 https://github.com/govim/govim/issues/351'
 
 vim ex 'call govim#config#Set(\"ExperimentalMouseTriggeredHoverPopupOptions\", { \"pos\": \"topright\", \"col\": 9999, \"line\": -9999  })'
 

--- a/cmd/govim/testdata/scenario_bugs/bug_govim_680.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_govim_680.txt
@@ -2,8 +2,8 @@
 
 # Open main.go and verify we have one error
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Find references to x then select the second instance
 vim ex 'call cursor(5,5)'

--- a/cmd/govim/testdata/scenario_bugs/bug_govim_940.txt
+++ b/cmd/govim/testdata/scenario_bugs/bug_govim_940.txt
@@ -4,8 +4,8 @@
 
 # Open main.go that lacks import statement for "fmt"
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Save the file so the import statment is added (and cursor is moved)
 vim ex 'call cursor(4,15)'

--- a/cmd/govim/testdata/scenario_default/codelens_gc_details.txt
+++ b/cmd/govim/testdata/scenario_default/codelens_gc_details.txt
@@ -6,10 +6,10 @@
 # Compiler details are reported using "information" severity
 vim ex 'e main.go'
 vim ex 'GOVIMGCDetails'
-[vim:v8.2.3019] [go1.14] [!go1.15] vimexprwait errors.go114.v8.2.3019.golden GOVIMTest_getqflist()
-[vim:v8.2.3019] [go1.15] vimexprwait errors.go115.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] [go1.14] [!go1.15] vimexprwait errors.go114.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] [go1.15] vimexprwait errors.go115.golden GOVIMTest_getqflist()
+[v8.2.3019] [go1.14] [!go1.15] vimexprwait errors.go114.v8.2.3019.golden GOVIMTest_getqflist()
+[v8.2.3019] [go1.15] vimexprwait errors.go115.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] [go1.14] [!go1.15] vimexprwait errors.go114.golden GOVIMTest_getqflist()
+[!v8.2.3019] [go1.15] vimexprwait errors.go115.golden GOVIMTest_getqflist()
 
 
 [short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'

--- a/cmd/govim/testdata/scenario_default/function_hover.txt
+++ b/cmd/govim/testdata/scenario_default/function_hover.txt
@@ -14,8 +14,8 @@ cmp stdout popup.golden
 # Single warning (unreachable code) + docs as popup content
 vim call append '[5,"\treturn"]'
 vim ex 'call feedkeys(\"\\<CursorHold>\", \"xt\")'
-[vim:v8.2.3019] vimexprwait warning.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait warning.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait warning.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait warning.golden GOVIMTest_getqflist()
 vim expr 'GOVIMHover()'
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout warning_popup.golden
@@ -25,8 +25,8 @@ cmp stdout warning_popup.golden
 # Two warnings (unreachable code + formatting directive %v) + docs
 vim ex '7s/Hello, world/%v/'
 vim ex 'call cursor(7,8)'
-[vim:v8.2.3019] vimexprwait warnings.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait warnings.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait warnings.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait warnings.golden GOVIMTest_getqflist()
 vim expr 'GOVIMHover()'
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout warnings_popup.golden
@@ -46,8 +46,8 @@ vim ex 'call cursor(6,1)'
 vim ex 'normal dd'
 vim ex 'call cursor(6,7)'
 vim ex 'normal x'
-[vim:v8.2.3019] vimexprwait error.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait error.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait error.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait error.golden GOVIMTest_getqflist()
 vim expr 'GOVIMHover()'
 vim -stringout expr 'GOVIM_internal_DumpPopups()'
 cmp stdout error_popup.golden

--- a/cmd/govim/testdata/scenario_default/gofmt.txt
+++ b/cmd/govim/testdata/scenario_default/gofmt.txt
@@ -19,8 +19,8 @@ cp file.go.bad file.go
 vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.bad
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
 

--- a/cmd/govim/testdata/scenario_default/goimports.txt
+++ b/cmd/govim/testdata/scenario_default/goimports.txt
@@ -19,8 +19,8 @@ cp file.go.bad file.go
 vim ex 'e! file.go'
 vim ex 'w'
 cmp file.go file.go.bad
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 skip 'Temporarily disable pending https://github.com/golang/go/issues/31150'
 

--- a/cmd/govim/testdata/scenario_default/hover.txt
+++ b/cmd/govim/testdata/scenario_default/hover.txt
@@ -2,7 +2,8 @@
 
 [!vim] [!gvim] skip 'Test only known to work in Vim and GVim'
 
-[!vim:v8.1.1649] skip 'New style popup tests do not work on gvim https://github.com/govim/govim/issues/351'
+[!v8.1.1649] skip 'New style popup tests do not work on gvim >= v8.1.1649 https://github.com/govim/govim/issues/351'
+[gvim] skip 'New style popup tests do not work on gvim >= v8.1.1649 https://github.com/govim/govim/issues/351'
 
 vim ex 'e main.go'
 vim ex 'call test_setmouse(screenpos(bufwinid(\"main.go\"),6,13)[\"row\"],screenpos(bufwinid(\"main.go\"),6,13)[\"col\"])'

--- a/cmd/govim/testdata/scenario_default/implements.txt
+++ b/cmd/govim/testdata/scenario_default/implements.txt
@@ -8,20 +8,20 @@ vim ex 'e main.go'
 vim ex 'call cursor (9,6)' #TODO: replcae with my values
 vim ex 'GOVIMImplements' # note this moves the cursor to the quickfix window
 vim ex 'call win_gotoid(win_findbuf(bufnr(\"main.go\"))[0])'
-[vim:v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
 
 # Introduce an error - locations should remain
 vim ex 'call cursor(14, 1)'
 vim ex 'call feedkeys(\"ofmt.Printf(\\\"%v\\\")\\<ESC>\", \"xt\")'
 sleep $GOVIM_ERRLOGMATCH_WAIT
-[vim:v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
 
 # Now use quickfix for errors
 vim ex 'GOVIMQuickfixDiagnostics'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/load_initial_file.txt
+++ b/cmd/govim/testdata/scenario_default/load_initial_file.txt
@@ -4,8 +4,8 @@
 vim expr 'bufname(\"\")'
 stdout '^"main.go"$'
 ! stderr .+
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/quickfix.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix.txt
@@ -1,8 +1,8 @@
 # Test that the quickfix window gets populated with error messages from gopls
 
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/quickfix_config.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_config.txt
@@ -2,8 +2,8 @@
 
 # Default behaviour is quickfix autodiagnostics & sign placment enabled
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden1 GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden1 GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden1 GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden1 GOVIMTest_getqflist()
 vimexprwait signs.golden1 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 
 # There must be no quickfix entries or signs when both are explicitly disabled
@@ -15,14 +15,14 @@ vimexprwait nosigns.golden 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"
 
 # Enabling quickfix autodiagnostics should give quickfix entries but no signs
 vim call 'govim#config#Set' '["QuickfixAutoDiagnostics", 1]'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden2 GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden2 GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden2 GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden2 GOVIMTest_getqflist()
 vimexprwait nosigns.golden 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 
 # Enabling signs should place signs again
 vim call 'govim#config#Set' '["QuickfixSigns", 1]'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden2 GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden2 GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden2 GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden2 GOVIMTest_getqflist()
 vimexprwait signs.golden2 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"*\"})'
 
 # Signs should be placed with quickfix autodiagnostics disabled
@@ -33,8 +33,8 @@ vimexprwait signs.golden3 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\": \"*
 
 # Calling :GOVIMQuickfixDiagnostics should force-populate the quickfix window
 vim ex 'GOVIMQuickfixDiagnostics'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden3 GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden3 GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden3 GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden3 GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/quickfix_dependency_package_error.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_dependency_package_error.txt
@@ -2,8 +2,8 @@
 # where the error is in a dependency of the current file's package.
 
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_empty_files.txt
@@ -31,8 +31,8 @@ vim ex 'noau w! check'
 cmp check p/x_test.go.orig
 
 # Expect the errors
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Change p.DoIt to accept an integer
 vim ex 'sp p/p.go'

--- a/cmd/govim/testdata/scenario_default/quickfix_eof.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_eof.txt
@@ -2,8 +2,8 @@
 # in the edge case of an error that references the end of file.
 
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_directory.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_directory.txt
@@ -3,8 +3,8 @@
 # there's no other errors in this entry file.
 
 vim ex 'e charly.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
 
 # Now move to error 'errc' and check the position
 vim expr 'setqflist([], \"r\", {\"idx\": 3})'
@@ -15,8 +15,8 @@ stdout '{"idx":3}'
 # Now fix selected error and assert the index points to the first file of the directory
 vim ex 'call cursor(3,1)'
 vim normal dd
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
 vim expr 'getqflist({\"idx\": 0})'
 stdout '{"idx":2}'
 ! stderr .+

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_last.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_last.txt
@@ -2,8 +2,8 @@
 # selected entry file, if this one isn't found and if there's no next entry.
 
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
 
 # Verify we have the first entry selected
 vim expr 'getqflist({\"idx\": 0})'
@@ -19,8 +19,8 @@ stdout '{"idx":4}'
 # Now fix selected error and assert the index points to the last entry of the file
 vim ex 'call cursor(7,1)'
 vim normal dd
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
 vim expr 'getqflist({\"idx\": 0})'
 stdout '{"idx":3}'
 ! stderr .+

--- a/cmd/govim/testdata/scenario_default/quickfix_fallback_next.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_fallback_next.txt
@@ -2,8 +2,8 @@
 # entry file if this one isn't found.
 
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
 
 # Verify we have the first entry selected
 vim expr 'getqflist({\"idx\": 0})'
@@ -19,8 +19,8 @@ stdout '{"idx":2}'
 # Now fix selected error and assert the index points to the next entry
 vim ex 'call cursor(5,1)'
 vim normal dd
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
 vim expr 'getqflist({\"idx\": 0})'
 stdout '{"idx":2}'
 ! stderr .+

--- a/cmd/govim/testdata/scenario_default/quickfix_from_other.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_from_other.txt
@@ -1,28 +1,28 @@
 # Test that the quickfix window is updated by diagnostics only in some situations
 
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden1 GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden1 GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden1 GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden1 GOVIMTest_getqflist()
 vim ex 'call setqflist([{\"filename\":\"foo\"}, {\"filename\":\"bar\"}, {\"filename\":\"baz\"}], \"r\")'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.other GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.other GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.other GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.other GOVIMTest_getqflist()
 
 # Add an error, the quickfix should remain because it's not already filled with diagnostics
 vim ex 'call cursor(6, 1)'
 vim ex 'call feedkeys(\"yyp\")'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.other GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.other GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.other GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.other GOVIMTest_getqflist()
 
 # Force display diagnostics now
 vim ex 'GOVIMQuickfixDiagnostics'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden2 GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden2 GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden2 GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden2 GOVIMTest_getqflist()
 
 # Fill quickfix with empty array, this time it shouldn't remain because it's empty
 vim ex 'call setqflist([])'
 vim ex 'call feedkeys(\"dd\")'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden1 GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden1 GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden1 GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden1 GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/quickfix_new_files.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_new_files.txt
@@ -28,10 +28,10 @@ vim ex 'noau w! check'
 cmp check p/x_test.go.orig
 
 # Expect the errors
-[vim:v8.2.3019] [!go1.16] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[vim:v8.2.3019] [go1.16] vimexprwait errors.go1.16.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] [!go1.16] vimexprwait errors.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] [go1.16] vimexprwait errors.go1.16.golden GOVIMTest_getqflist()
+[v8.2.3019] [!go1.16] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[v8.2.3019] [go1.16] vimexprwait errors.go1.16.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] [!go1.16] vimexprwait errors.golden GOVIMTest_getqflist()
+[!v8.2.3019] [go1.16] vimexprwait errors.go1.16.golden GOVIMTest_getqflist()
 
 # Change p.DoIt to accept an integer
 vim ex 'sp p/p.go'

--- a/cmd/govim/testdata/scenario_default/quickfix_replaced_dep.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_replaced_dep.txt
@@ -6,8 +6,8 @@
 
 # Expand $WORK within our golden file
 envsubst error.golden
-[vim:v8.2.3019] envsubst error.v8.2.3019.golden
-[!vim:v8.2.3019] envsubst error.golden
+[v8.2.3019] envsubst error.v8.2.3019.golden
+[!v8.2.3019] envsubst error.golden
 
 # Open dependency via GoToDef
 vim ex 'e main.go'
@@ -20,8 +20,8 @@ stdout '^\Q"'$WORK'/p/blah.go"\E$'
 vim call append '[3, "asd"]'
 
 # Expect the error to be reported
-[vim:v8.2.3019] vimexprwait error.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait error.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait error.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait error.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/quickfix_retain_position.txt
+++ b/cmd/govim/testdata/scenario_default/quickfix_retain_position.txt
@@ -1,8 +1,8 @@
 # Test that the quickfix window logic around retaining its selected item
 
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden.orig GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden.orig GOVIMTest_getqflist()
 
 # Verify we have the first entry selected
 vim expr 'getqflist({\"idx\": 0})'
@@ -19,8 +19,8 @@ stdout '{"idx":2}'
 vim ex 'e other.go'
 vim ex 'call cursor(3,1)'
 vim normal Sasdf
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden.updated GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden.updated GOVIMTest_getqflist()
 vim expr 'getqflist({\"idx\": 0})'
 stdout '{"idx":2}'
 ! stderr .+

--- a/cmd/govim/testdata/scenario_default/references.txt
+++ b/cmd/govim/testdata/scenario_default/references.txt
@@ -8,20 +8,20 @@ vim ex 'e main.go'
 vim ex 'call cursor(15,24)'
 vim ex 'GOVIMReferences' # note this moves the cursor to the quickfix window
 vim ex 'call win_gotoid(win_findbuf(bufnr(\"main.go\"))[0])'
-[vim:v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
 
 # Introduce an error - locations should remain
 vim ex 'call cursor(15,1)'
 vim ex 'call feedkeys(\"ofmt.Printf(\\\"%v\\\")\\<ESC>\", \"xt\")'
 sleep $GOVIM_ERRLOGMATCH_WAIT
-[vim:v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait locations.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait locations.golden GOVIMTest_getqflist()
 
 # Now use quickfix for errors
 vim ex 'GOVIMQuickfixDiagnostics'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
+++ b/cmd/govim/testdata/scenario_default/signs_existing_diags.txt
@@ -1,8 +1,8 @@
 # Test that signs are placed when opening a file that already has diagnostics.
 
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 vim ex 'e other.go'
 vimexprwait placed.golden 'GOVIMTest_sign_getplaced(\"other.go\", {\"group\": \"*\"})'
 

--- a/cmd/govim/testdata/scenario_default/signs_unload_load_buffer.txt
+++ b/cmd/govim/testdata/scenario_default/signs_unload_load_buffer.txt
@@ -7,14 +7,14 @@ vimexprwait placed_main.golden 'GOVIMTest_sign_getplaced(\"main.go\", {\"group\"
 # open other.go and add a broken statement to get an error that masks the warnings
 vim ex 'e other.go'
 vim call append '[6,"asd"]'
-[vim:v8.2.3019] vimexprwait tmp_error.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait tmp_error.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait tmp_error.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait tmp_error.golden GOVIMTest_getqflist()
 
 # remove the broken statement
 vim ex 'call cursor(7,1)'
 vim ex 'normal dd'
-[vim:v8.2.3019] vimexprwait warnings.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait warnings.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait warnings.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait warnings.golden GOVIMTest_getqflist()
 
 # jump back to main and check that the sign is still present
 vim ex 'w'

--- a/cmd/govim/testdata/scenario_default/suggested_fixes.txt
+++ b/cmd/govim/testdata/scenario_default/suggested_fixes.txt
@@ -6,8 +6,8 @@
 
 # Tests basic case with a single diagnostic, no fix selected
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait initial_errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait initial_errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait initial_errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait initial_errors.golden GOVIMTest_getqflist()
 
 vim ex 'call cursor(6,2)'
 vim ex 'GOVIMSuggestedFixes'
@@ -30,8 +30,8 @@ cmp main.go main.go.single.golden
 # second one since that is the cursor position line.
 cp main.go.different_lines main.go
 vim ex 'e! main.go'
-[vim:v8.2.3019] vimexprwait different_lines_errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait different_lines_errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait different_lines_errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait different_lines_errors.golden GOVIMTest_getqflist()
 
 vim ex 'call cursor(7,2)'
 vim ex 'GOVIMSuggestedFixes'
@@ -42,8 +42,8 @@ errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\"Remove\"\],{.*\"title\
 # title to indicate more than one. It shall also be possible to cycle forward and backwards.
 cp main.go.same_line main.go
 vim ex 'e! main.go'
-[vim:v8.2.3019] vimexprwait same_line_errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait same_line_errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait same_line_errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait same_line_errors.golden GOVIMTest_getqflist()
 
 vim ex 'call cursor(6,2)'
 vim ex 'GOVIMSuggestedFixes'

--- a/cmd/govim/testdata/scenario_default/watcher.txt
+++ b/cmd/govim/testdata/scenario_default/watcher.txt
@@ -13,14 +13,14 @@ cmp main.go main.go.golden
 # Update const.go with an error
 cp const.go.updated const.go
 errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const.go'", Type:2\}'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.undeclared GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.undeclared GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.undeclared GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.undeclared GOVIMTest_getqflist()
 
 # Add a const2.go that conflicts with const.go
 cp const2.go.orig const2.go
 errlogmatch '&protocol\.DidChangeWatchedFilesParams\{\n\S+:\s+Changes: \{\n\S+:\s+\{URI:"file://'$WORK/const2.go'", Type:1\}'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.otherdeclaration GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.otherdeclaration GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.otherdeclaration GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.otherdeclaration GOVIMTest_getqflist()
 
 # Remove const.go to resolve the conflict
 rm const.go

--- a/cmd/govim/testdata/scenario_goimports_local/existing_import.txt
+++ b/cmd/govim/testdata/scenario_goimports_local/existing_import.txt
@@ -1,6 +1,6 @@
 # Test that GoImportsLocalPrefix works for existing imports
 
-[gvim:v8.1.1711] skip 'Known to be flake with GVim v8.1.1711'
+[v8.1.1711] [gvim] skip 'Known to be flake with GVim v8.1.1711'
 
 # Verify that new imports get correctly placed
 go mod download all

--- a/cmd/govim/testdata/scenario_modreadonly/config_set_env_goflags_mod_readonly.txt
+++ b/cmd/govim/testdata/scenario_modreadonly/config_set_env_goflags_mod_readonly.txt
@@ -5,8 +5,8 @@
 [short] skip 'Skip short because we sleep for GOVIM_ERRLOGMATCH_WAIT to ensure we don''t have any errors'
 
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait pre.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait pre.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait pre.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait pre.golden GOVIMTest_getqflist()
 vim ex 'w'
 
 # We have to sleep here because there is no event we are waiting for

--- a/cmd/govim/testdata/scenario_staticcheck/staticcheck.txt
+++ b/cmd/govim/testdata/scenario_staticcheck/staticcheck.txt
@@ -5,8 +5,8 @@
 # for now in this test to give exposure to the staticcheck work
 
 vim ex 'e main.go'
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_go_get_package.txt
+++ b/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_go_get_package.txt
@@ -8,8 +8,8 @@ vim call 'govim#config#Set' '["ExperimentalAllowModfileModifications",0]'
 vim ex 'e main.go'
 
 # Wait for the diag and open up suggested fixes
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 vim ex 'call cursor(6,4)'
 vim ex 'GOVIMSuggestedFixes'
 

--- a/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_remove_dep.txt
+++ b/cmd/govim/testdata/scenario_tempmodfile/suggested_fix_remove_dep.txt
@@ -6,8 +6,8 @@
 vim ex 'e go.mod'
 
 # Wait for the diag and open up suggested fixes
-[vim:v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
-[!vim:v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
+[v8.2.3019] vimexprwait errors.v8.2.3019.golden GOVIMTest_getqflist()
+[!v8.2.3019] vimexprwait errors.golden GOVIMTest_getqflist()
 vim ex 'call cursor(3,1)'
 vim ex 'GOVIMSuggestedFixes'
 

--- a/testdriver/testdriver_test.go
+++ b/testdriver/testdriver_test.go
@@ -1,0 +1,129 @@
+package testdriver
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/govim/govim/testsetup"
+	"github.com/rogpeppe/go-internal/semver"
+)
+
+func TestCondition(t *testing.T) {
+	t.Cleanup(cleanupEnvVars(testsetup.EnvTestscriptIssues))
+	t.Cleanup(cleanupEnvVars(testsetup.EnvVimFlavor))
+
+	_, cmd, err := testsetup.EnvLookupFlavorCommand()
+	if err != nil {
+		t.Fatalf("failed to derive flavor command: %v", err)
+	}
+	vimVersion, err := getVimFlavourVersion(cmd)
+	if err != nil {
+		t.Fatalf("failed to get vim flavour version: %v", err)
+	}
+
+	var conditionTests = []struct {
+		desc      string
+		flavorenv *string
+		issueenv  *string
+		cond      string
+		satisfied bool
+		err       error
+	}{
+		{
+			desc:     "match all golang issues",
+			issueenv: pS("."),
+			cond:     "golang.org/issues/1234",
+		},
+		{
+			desc:     "match all govim issues",
+			issueenv: pS("."),
+			cond:     "github.com/govim/govim/issues/1234",
+		},
+		{
+			desc:      "bad issue condition",
+			issueenv:  pS("."),
+			flavorenv: pS("vim"),
+			cond:      "github.com/apple/pear/issues/1234",
+			satisfied: false,
+			err:       errors.New("unknown condition github.com/apple/pear/issues/1234"),
+		},
+		{
+			desc:      "vim test",
+			flavorenv: pS("vim"),
+			cond:      "vim",
+			satisfied: true,
+		},
+		{
+			desc:      "gvim test",
+			flavorenv: pS("gvim"),
+			cond:      "gvim",
+			satisfied: true,
+		},
+		{
+			desc:      "gvim test running with vim",
+			flavorenv: pS("vim"),
+			cond:      "gvim",
+		},
+		{
+			desc:      "vim test running with gvim",
+			flavorenv: pS("gvim"),
+			cond:      "vim",
+		},
+		{
+			// This is a bit like marking our own homework because we
+			// are contriving the result of satisfied, but that's fine;
+			// all we are looking to do is exercise the condition
+			// matching logic.
+			desc:      "vim version exercise",
+			flavorenv: pS("vim"),
+			cond:      "v8.2.3333",
+			satisfied: semver.Compare(vimVersion, "v8.2.3333") >= 0,
+		},
+	}
+
+	for _, tc := range conditionTests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if tc.issueenv != nil {
+				os.Setenv(testsetup.EnvTestscriptIssues, *tc.issueenv)
+			}
+			if tc.flavorenv != nil {
+				os.Setenv(testsetup.EnvVimFlavor, *tc.flavorenv)
+			}
+			got, err := Condition(tc.cond)
+			if got != tc.satisfied {
+				t.Errorf("wanted %v; got %v", tc.satisfied, got)
+			}
+			if err == nil {
+				if tc.err != nil {
+					t.Errorf("expected error %q; got none", tc.err)
+				}
+			} else {
+				if tc.err == nil {
+					t.Errorf("did not expect error; got %q", err)
+				} else {
+					if err.Error() != tc.err.Error() {
+						t.Errorf("got error %q; wanted %q", err, tc.err)
+					}
+				}
+			}
+			os.Unsetenv(testsetup.EnvTestscriptIssues)
+			os.Unsetenv(testsetup.EnvVimFlavor)
+		})
+	}
+}
+
+func pS(s string) *string {
+	return &s
+}
+
+func cleanupEnvVars(ev string) func() {
+	v, ok := os.LookupEnv(ev)
+	return func() {
+		if ok {
+			os.Setenv(ev, v)
+		} else {
+			os.Unsetenv(ev)
+		}
+	}
+}


### PR DESCRIPTION
vim/gvim conditions can currently take these forms:

    vim          # only run if vim
    gvim         # only run if gvim
    vim:v1.2.3   # only run if vim >= v1.2.3
    gvim:v1.2.3  # only run if gvim >= v1.2.3

The gvim version specifier is really superfluous however, because we
could simply use vim:v1.2.3 to mean the version of the editor, and then
the plain vim/gvim to specify the flavour.

Doing so helps cut down the number of exceptions we need to write in
case a later version of Vim (or Gvim) introduces a breaking change
(typically in the marshalled encoding of a function return value).