### PR TITLE
deps: update x/tools and gopls to 3395cb03

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/parse.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/parse.go
@@ -1072,10 +1072,10 @@ func fixArrayType(bad *ast.BadExpr, parent ast.Node, tok *token.File, src []byte
 	// Avoid doing tok.Offset(to) since that panics if badExpr ends at EOF.
 	// It also panics if the position is not in the range of the file, and
 	// badExprs may not necessarily have good positions, so check first.
-	if !inRange(tok, from) {
+	if !source.InRange(tok, from) {
 		return false
 	}
-	if !inRange(tok, to-1) {
+	if !source.InRange(tok, to-1) {
 		return false
 	}
 	fromOffset := tok.Offset(from)
@@ -1110,12 +1110,6 @@ func fixArrayType(bad *ast.BadExpr, parent ast.Node, tok *token.File, src []byte
 	}
 
 	return replaceNode(parent, bad, at)
-}
-
-// inRange reports whether the given position is in the given token.File.
-func inRange(tok *token.File, pos token.Pos) bool {
-	size := tok.Pos(tok.Size())
-	return int(pos) >= tok.Base() && pos <= size
 }
 
 // precedingToken scans src to find the token preceding pos.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
@@ -1902,20 +1902,6 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 			shouldLoad: v.shouldLoad || invalidateMetadata,
 		}
 	}
-	// Copy the URI to package ID mappings, skipping only those URIs whose
-	// metadata will be reloaded in future calls to load.
-	for k, ids := range s.ids {
-		var newIDs []packageID
-		for _, id := range ids {
-			if invalidateMetadata, ok := idsToInvalidate[id]; invalidateMetadata && ok {
-				continue
-			}
-			newIDs = append(newIDs, id)
-		}
-		if len(newIDs) != 0 {
-			result.ids[k] = newIDs
-		}
-	}
 
 	// Copy the set of initially loaded packages.
 	for id, pkgPath := range s.workspacePackages {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/semantic.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/semantic.go
@@ -236,9 +236,13 @@ func (e *encoded) strStack() string {
 	}
 	if len(e.stack) > 0 {
 		loc := e.stack[len(e.stack)-1].Pos()
-		add := e.pgf.Tok.PositionFor(loc, false)
-		nm := filepath.Base(add.Filename)
-		msg = append(msg, fmt.Sprintf("(%s:%d,col:%d)", nm, add.Line, add.Column))
+		if !source.InRange(e.pgf.Tok, loc) {
+			msg = append(msg, fmt.Sprintf("invalid position %v for %s", loc, e.pgf.URI))
+		} else {
+			add := e.pgf.Tok.PositionFor(loc, false)
+			nm := filepath.Base(add.Filename)
+			msg = append(msg, fmt.Sprintf("(%s:%d,col:%d)", nm, add.Line, add.Column))
+		}
 	}
 	msg = append(msg, "]")
 	return strings.Join(msg, " ")

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/extract.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/extract.go
@@ -80,14 +80,14 @@ func extractVariable(fset *token.FileSet, rng span.Range, src []byte, file *ast.
 	return &analysis.SuggestedFix{
 		TextEdits: []analysis.TextEdit{
 			{
-				Pos:     rng.Start,
-				End:     rng.End,
-				NewText: []byte(lhs),
-			},
-			{
 				Pos:     insertBeforeStmt.Pos(),
 				End:     insertBeforeStmt.Pos(),
 				NewText: []byte(assignment),
+			},
+			{
+				Pos:     rng.Start,
+				End:     rng.End,
+				NewText: []byte(lhs),
 			},
 		},
 	}, nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/fix.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/fix.go
@@ -71,7 +71,7 @@ func ApplyFix(ctx context.Context, fix string, snapshot Snapshot, fh VersionedFi
 		return nil, nil
 	}
 
-	var edits []protocol.TextDocumentEdit
+	var edits []protocol.TextEdit
 	for _, edit := range suggestion.TextEdits {
 		rng := span.NewRange(fset, edit.Pos, edit.End)
 		spn, err := rng.Span()
@@ -82,22 +82,20 @@ func ApplyFix(ctx context.Context, fix string, snapshot Snapshot, fh VersionedFi
 		if err != nil {
 			return nil, err
 		}
-		edits = append(edits, protocol.TextDocumentEdit{
-			TextDocument: protocol.OptionalVersionedTextDocumentIdentifier{
-				Version: fh.Version(),
-				TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-					URI: protocol.URIFromSpanURI(fh.URI()),
-				},
-			},
-			Edits: []protocol.TextEdit{
-				{
-					Range:   clRng,
-					NewText: string(edit.NewText),
-				},
-			},
+		edits = append(edits, protocol.TextEdit{
+			Range:   clRng,
+			NewText: string(edit.NewText),
 		})
 	}
-	return edits, nil
+	return []protocol.TextDocumentEdit{{
+		TextDocument: protocol.OptionalVersionedTextDocumentIdentifier{
+			Version: fh.Version(),
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
+				URI: protocol.URIFromSpanURI(fh.URI()),
+			},
+		},
+		Edits: edits,
+	}}, nil
 }
 
 // getAllSuggestedFixInputs is a helper function to collect all possible needed

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/implementation.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/implementation.go
@@ -349,11 +349,6 @@ func pathEnclosingObjNode(f *ast.File, pos token.Pos) []ast.Node {
 			if pos == n.Star {
 				pos = n.X.Pos()
 			}
-		case *ast.SelectorExpr:
-			// If pos is on the ".", move it into the selector.
-			if pos == n.X.End() {
-				pos = n.Sel.Pos()
-			}
 		}
 
 		return !found

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/util.go
@@ -544,3 +544,9 @@ func IsValidImport(pkgPath, importPkgPath string) bool {
 func IsCommandLineArguments(s string) bool {
 	return strings.Contains(s, "command-line-arguments")
 }
+
+// InRange reports whether the given position is in the given token.File.
+func InRange(tok *token.File, pos token.Pos) bool {
+	size := tok.Pos(tok.Size())
+	return int(pos) >= tok.Base() && pos <= size
+}

--- a/cmd/govim/testdata/scenario_default/go_to_def_module_cache.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_module_cache.txt
@@ -7,7 +7,7 @@ vim ex 'set splitright'
 
 # Definition in same file
 vim ex 'e '$WORK/p.go
-vim ex 'call cursor(5,18)'
+vim ex 'call cursor(5,19)'
 vim ex 'GOVIMGoToDef'
 vim expr 'expand(''%:p'')'
 stdout '^\Q"'$WORK'/.home/gopath/pkg/mod/example.com/blah@v1.0.0/main.go"\E$'
@@ -17,7 +17,7 @@ vim ex 'GOVIMGoToPrevDef'
 vim expr 'expand(''%:p'')'
 stdout '^\Q"'$WORK'/p.go"\E$'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
-stdout '^\Q[5,18]\E$'
+stdout '^\Q[5,19]\E$'
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/go_to_def_std_lib.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_std_lib.txt
@@ -6,7 +6,7 @@ vim ex 'set splitright'
 
 # Definition in same file
 vim ex 'e '$WORK/p.go
-vim ex 'call cursor(5,18)'
+vim ex 'call cursor(5,19)'
 vim ex 'GOVIMGoToDef'
 vim expr 'expand(''%:p'')'
 
@@ -18,7 +18,7 @@ vim ex 'GOVIMGoToPrevDef'
 vim expr 'expand(''%:p'')'
 stdout '^\Q"'$WORK'/p.go"\E$'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
-stdout '^\Q[5,18]\E$'
+stdout '^\Q[5,19]\E$'
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/cmd/govim/testdata/scenario_default/go_to_def_upper_case.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_upper_case.txt
@@ -7,7 +7,7 @@ vim ex 'set splitright'
 
 # Definition in same file
 vim ex 'e '$WORK/p.go
-vim ex 'call cursor(5,18)'
+vim ex 'call cursor(5,19)'
 vim ex 'GOVIMGoToDef'
 vim expr 'expand(''%:p'')'
 stdout '^\Q"'$WORK'/.home/gopath/pkg/mod/example.com/bla!h@v1.0.0/main.go"\E$'
@@ -17,7 +17,7 @@ vim ex 'GOVIMGoToPrevDef'
 vim expr 'expand(''%:p'')'
 stdout '^\Q"'$WORK'/p.go"\E$'
 vim expr '[getcurpos()[1], getcurpos()[2]]'
-stdout '^\Q[5,18]\E$'
+stdout '^\Q[5,19]\E$'
 
 # Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
 # Disabled pending resolution to https://github.com/golang/go/issues/34103

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
-	golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2
-	golang.org/x/tools/gopls v0.0.0-20210726203631-07bc1bf47fb2
+	golang.org/x/tools v0.1.6-0.20210802212211-3395cb03f1be
+	golang.org/x/tools/gopls v0.0.0-20210802212211-3395cb03f1be
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -80,10 +80,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2 h1:BonxutuHCTL0rBDnZlKjpGIQFTjyUVTexFOdWkB6Fg0=
-golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools/gopls v0.0.0-20210726203631-07bc1bf47fb2 h1:ge85cIIDez08sKTO728muWWoCIVG+XRJz/GcgLl47CQ=
-golang.org/x/tools/gopls v0.0.0-20210726203631-07bc1bf47fb2/go.mod h1:ekCtf0GOS1JSF+KM46LZvJUyEsyKfFZOfcytlR7aBfg=
+golang.org/x/tools v0.1.6-0.20210802212211-3395cb03f1be h1:6/XhjIsqo3NebJDer/aZ0sZfAd+vLhtVKXO0kvBkW+A=
+golang.org/x/tools v0.1.6-0.20210802212211-3395cb03f1be/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools/gopls v0.0.0-20210802212211-3395cb03f1be h1:EBpv9ecTFohN8yh1xU52yOw1xSwjocj5nr9bli6KMlA=
+golang.org/x/tools/gopls v0.0.0-20210802212211-3395cb03f1be/go.mod h1:ekCtf0GOS1JSF+KM46LZvJUyEsyKfFZOfcytlR7aBfg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
CL 338789 fixed a bug on the gopls side with respect to finding
references. This highlighted a couple of bad tests on the govim side: we
where trying to jump to definition with the cursor over the '.' in, say,
'time.Kitchen' - this is ambiguous at best.

Update to the latest tools/gopls and fix our test assertions in the
process, by adjusting the cursor position to the right by one.

* go/types/objectpath: minor doc fix 3395cb03
* internal/lsp: send "extract variable" edits ordered bb69444e
* internal/lsp: handle invalid positions in semantic token debug logic f8cfadac
* internal/lsp: remove duplicated loop that copies IDs 45eff0fd
* internal/lsp: find references for ident before selector a6684984
* go/ssa/interp: handle nil slice convert to array pointer 3810fa82
* go/pointer: fix constraint gen for *ssa.Next ab1fe720