### PR TITLE
deps: update x/tools and gopls to 7bc3c281

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/load.go
@@ -52,6 +52,16 @@ type metadata struct {
 	isIntermediateTestVariant bool
 }
 
+// Name implements the source.Metadata interface.
+func (m *metadata) Name() string {
+	return string(m.name)
+}
+
+// PkgPath implements the source.Metadata interface.
+func (m *metadata) PkgPath() string {
+	return string(m.pkgPath)
+}
+
 // load calls packages.Load for the given scopes, updating package metadata,
 // import graph, and mapped files with the result.
 func (s *snapshot) load(ctx context.Context, allowNetwork bool, scopes ...interface{}) (err error) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/os_darwin.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/os_darwin.go
@@ -52,7 +52,7 @@ func darwinCheckPathCase(path string) error {
 			break
 		}
 		if g != w {
-			return fmt.Errorf("case mismatch in path %q: component %q should be %q", path, g, w)
+			return fmt.Errorf("case mismatch in path %q: component %q is listed by macOS as %q", path, g, w)
 		}
 	}
 	return nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/os_windows.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/os_windows.go
@@ -48,7 +48,7 @@ func windowsCheckPathCase(path string) error {
 	}
 	for got, want := path, longstr; !isRoot(got) && !isRoot(want); got, want = filepath.Dir(got), filepath.Dir(want) {
 		if g, w := filepath.Base(got), filepath.Base(want); g != w {
-			return fmt.Errorf("case mismatch in path %q: component %q should be %q", path, g, w)
+			return fmt.Errorf("case mismatch in path %q: component %q is listed by Windows as %q", path, g, w)
 		}
 	}
 	return nil

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
@@ -234,6 +234,7 @@ func (s *Session) createView(ctx context.Context, name string, folder, tempWorks
 		metadata:          make(map[packageID]*knownMetadata),
 		files:             make(map[span.URI]source.VersionedFileHandle),
 		goFiles:           make(map[parseKey]*parseGoHandle),
+		symbols:           make(map[span.URI]*symbolHandle),
 		importedBy:        make(map[packageID][]packageID),
 		actions:           make(map[actionKey]*actionHandle),
 		workspacePackages: make(map[packageID]packagePath),

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
@@ -85,6 +85,9 @@ type snapshot struct {
 	// goFiles maps a parseKey to its parseGoHandle.
 	goFiles map[parseKey]*parseGoHandle
 
+	// TODO(rfindley): consider merging this with files to reduce burden on clone.
+	symbols map[span.URI]*symbolHandle
+
 	// packages maps a packageKey to a set of packageHandles to which that file belongs.
 	// It may be invalidated when a file's content changes.
 	packages map[packageKey]*packageHandle
@@ -523,32 +526,9 @@ func (s *snapshot) packageHandlesForFile(ctx context.Context, uri span.URI, mode
 	if fh.Kind() != source.Go {
 		return nil, fmt.Errorf("no packages for non-Go file %s", uri)
 	}
-	knownIDs := s.getIDsForURI(uri)
-	reload := len(knownIDs) == 0
-	for _, id := range knownIDs {
-		// Reload package metadata if any of the metadata has missing
-		// dependencies, in case something has changed since the last time we
-		// reloaded it.
-		if s.noValidMetadataForID(id) {
-			reload = true
-			break
-		}
-		// TODO(golang/go#36918): Previously, we would reload any package with
-		// missing dependencies. This is expensive and results in too many
-		// calls to packages.Load. Determine what we should do instead.
-	}
-	if reload {
-		err = s.load(ctx, false, fileURI(uri))
-
-		if !s.useInvalidMetadata() && err != nil {
-			return nil, err
-		}
-		// We've tried to reload and there are still no known IDs for the URI.
-		// Return the load error, if there was one.
-		knownIDs = s.getIDsForURI(uri)
-		if len(knownIDs) == 0 {
-			return nil, err
-		}
+	knownIDs, err := s.getOrLoadIDsForURI(ctx, uri)
+	if err != nil {
+		return nil, err
 	}
 
 	var phs []*packageHandle
@@ -581,6 +561,37 @@ func (s *snapshot) packageHandlesForFile(ctx context.Context, uri span.URI, mode
 		}
 	}
 	return phs, nil
+}
+
+func (s *snapshot) getOrLoadIDsForURI(ctx context.Context, uri span.URI) ([]packageID, error) {
+	knownIDs := s.getIDsForURI(uri)
+	reload := len(knownIDs) == 0
+	for _, id := range knownIDs {
+		// Reload package metadata if any of the metadata has missing
+		// dependencies, in case something has changed since the last time we
+		// reloaded it.
+		if s.noValidMetadataForID(id) {
+			reload = true
+			break
+		}
+		// TODO(golang/go#36918): Previously, we would reload any package with
+		// missing dependencies. This is expensive and results in too many
+		// calls to packages.Load. Determine what we should do instead.
+	}
+	if reload {
+		err := s.load(ctx, false, fileURI(uri))
+
+		if !s.useInvalidMetadata() && err != nil {
+			return nil, err
+		}
+		// We've tried to reload and there are still no known IDs for the URI.
+		// Return the load error, if there was one.
+		knownIDs = s.getIDsForURI(uri)
+		if len(knownIDs) == 0 {
+			return nil, err
+		}
+	}
+	return knownIDs, nil
 }
 
 // Only use invalid metadata for Go versions >= 1.13. Go 1.12 and below has
@@ -960,6 +971,33 @@ func (s *snapshot) activePackageHandles(ctx context.Context) ([]*packageHandle, 
 	return phs, nil
 }
 
+func (s *snapshot) Symbols(ctx context.Context) (map[span.URI][]source.Symbol, error) {
+	result := make(map[span.URI][]source.Symbol)
+	for uri, f := range s.files {
+		sh := s.buildSymbolHandle(ctx, f)
+		v, err := sh.handle.Get(ctx, s.generation, s)
+		if err != nil {
+			return nil, err
+		}
+		data := v.(*symbolData)
+		result[uri] = data.symbols
+	}
+	return result, nil
+}
+
+func (s *snapshot) MetadataForFile(ctx context.Context, uri span.URI) ([]source.Metadata, error) {
+	knownIDs, err := s.getOrLoadIDsForURI(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	var mds []source.Metadata
+	for _, id := range knownIDs {
+		md := s.getMetadata(id)
+		mds = append(mds, md)
+	}
+	return mds, nil
+}
+
 func (s *snapshot) KnownPackages(ctx context.Context) ([]source.Package, error) {
 	if err := s.awaitLoaded(ctx); err != nil {
 		return nil, err
@@ -1044,6 +1082,26 @@ func (s *snapshot) getPackage(id packageID, mode source.ParseMode) *packageHandl
 	return s.packages[key]
 }
 
+func (s *snapshot) getSymbolHandle(uri span.URI) *symbolHandle {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.symbols[uri]
+}
+
+func (s *snapshot) addSymbolHandle(sh *symbolHandle) *symbolHandle {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	uri := sh.fh.URI()
+	// If the package handle has already been cached,
+	// return the cached handle instead of overriding it.
+	if sh, ok := s.symbols[uri]; ok {
+		return sh
+	}
+	s.symbols[uri] = sh
+	return sh
+}
 func (s *snapshot) getActionHandle(id packageID, m source.ParseMode, a *analysis.Analyzer) *actionHandle {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1633,6 +1691,7 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 		actions:           make(map[actionKey]*actionHandle, len(s.actions)),
 		files:             make(map[span.URI]source.VersionedFileHandle, len(s.files)),
 		goFiles:           make(map[parseKey]*parseGoHandle, len(s.goFiles)),
+		symbols:           make(map[span.URI]*symbolHandle, len(s.symbols)),
 		workspacePackages: make(map[packageID]packagePath, len(s.workspacePackages)),
 		unloadableFiles:   make(map[span.URI]struct{}, len(s.unloadableFiles)),
 		parseModHandles:   make(map[span.URI]*parseModHandle, len(s.parseModHandles)),
@@ -1650,6 +1709,16 @@ func (s *snapshot) clone(ctx, bgCtx context.Context, changes map[span.URI]*fileC
 	// Copy all of the FileHandles.
 	for k, v := range s.files {
 		result.files[k] = v
+	}
+	for k, v := range s.symbols {
+		if change, ok := changes[k]; ok {
+			if change.exists {
+				result.symbols[k] = result.buildSymbolHandle(ctx, change.fileHandle)
+			}
+			continue
+		}
+		newGen.Inherit(v.handle)
+		result.symbols[k] = v
 	}
 
 	// Copy the set of unloadable files.
@@ -2042,8 +2111,8 @@ func fileWasSaved(originalFH, currentFH source.FileHandle) bool {
 	return !o.saved && c.saved
 }
 
-// shouldInvalidateMetadata reparses a file's package and import declarations to
-// determine if the file requires a metadata reload.
+// shouldInvalidateMetadata reparses the full file's AST to determine
+// if the file requires a metadata reload.
 func (s *snapshot) shouldInvalidateMetadata(ctx context.Context, newSnapshot *snapshot, originalFH, currentFH source.FileHandle) (invalidate, pkgNameChanged, importDeleted bool) {
 	if originalFH == nil {
 		return true, false, false
@@ -2055,8 +2124,8 @@ func (s *snapshot) shouldInvalidateMetadata(ctx context.Context, newSnapshot *sn
 	// Get the original and current parsed files in order to check package name
 	// and imports. Use the new snapshot to parse to avoid modifying the
 	// current snapshot.
-	original, originalErr := newSnapshot.ParseGo(ctx, originalFH, source.ParseHeader)
-	current, currentErr := newSnapshot.ParseGo(ctx, currentFH, source.ParseHeader)
+	original, originalErr := newSnapshot.ParseGo(ctx, originalFH, source.ParseFull)
+	current, currentErr := newSnapshot.ParseGo(ctx, currentFH, source.ParseFull)
 	if originalErr != nil || currentErr != nil {
 		return (originalErr == nil) != (currentErr == nil), false, (currentErr != nil) // we don't know if an import was deleted
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/symbols.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/symbols.go
@@ -1,0 +1,211 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cache
+
+import (
+	"context"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/source"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/memoize"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
+)
+
+type symbolHandle struct {
+	handle *memoize.Handle
+
+	fh source.FileHandle
+
+	// key is the hashed key for the package.
+	key symbolHandleKey
+}
+
+// symbolData contains the data produced by extracting symbols from a file.
+type symbolData struct {
+	symbols []source.Symbol
+	err     error
+}
+
+type symbolHandleKey string
+
+func (s *snapshot) buildSymbolHandle(ctx context.Context, fh source.FileHandle) *symbolHandle {
+	if h := s.getSymbolHandle(fh.URI()); h != nil {
+		return h
+	}
+	key := symbolHandleKey(fh.FileIdentity().Hash)
+	h := s.generation.Bind(key, func(ctx context.Context, arg memoize.Arg) interface{} {
+		snapshot := arg.(*snapshot)
+		data := &symbolData{}
+		data.symbols, data.err = symbolize(ctx, snapshot, fh)
+		return data
+	}, nil)
+
+	sh := &symbolHandle{
+		handle: h,
+		fh:     fh,
+		key:    key,
+	}
+	return s.addSymbolHandle(sh)
+}
+
+// symbolize extracts symbols from a file. It does not parse the file through the cache.
+func symbolize(ctx context.Context, snapshot *snapshot, fh source.FileHandle) ([]source.Symbol, error) {
+	var w symbolWalker
+	fset := token.NewFileSet() // don't use snapshot.FileSet, as that would needlessly leak memory.
+	data := parseGo(ctx, fset, fh, source.ParseFull)
+	if data.parsed != nil && data.parsed.File != nil {
+		w.curFile = data.parsed
+		w.curURI = protocol.URIFromSpanURI(data.parsed.URI)
+		w.fileDecls(data.parsed.File.Decls)
+	}
+	return w.symbols, w.firstError
+}
+
+type symbolWalker struct {
+	curFile    *source.ParsedGoFile
+	pkgName    string
+	curURI     protocol.DocumentURI
+	symbols    []source.Symbol
+	firstError error
+}
+
+func (w *symbolWalker) atNode(node ast.Node, name string, kind protocol.SymbolKind, path ...*ast.Ident) {
+	var b strings.Builder
+	for _, ident := range path {
+		if ident != nil {
+			b.WriteString(ident.Name)
+			b.WriteString(".")
+		}
+	}
+	b.WriteString(name)
+
+	rng, err := fileRange(w.curFile, node.Pos(), node.End())
+	if err != nil {
+		w.error(err)
+		return
+	}
+	sym := source.Symbol{
+		Name:  b.String(),
+		Kind:  kind,
+		Range: rng,
+	}
+	w.symbols = append(w.symbols, sym)
+}
+
+func (w *symbolWalker) error(err error) {
+	if err != nil && w.firstError == nil {
+		w.firstError = err
+	}
+}
+
+func fileRange(pgf *source.ParsedGoFile, start, end token.Pos) (protocol.Range, error) {
+	s, err := span.FileSpan(pgf.Tok, pgf.Mapper.Converter, start, end)
+	if err != nil {
+		return protocol.Range{}, nil
+	}
+	return pgf.Mapper.Range(s)
+}
+
+func (w *symbolWalker) fileDecls(decls []ast.Decl) {
+	for _, decl := range decls {
+		switch decl := decl.(type) {
+		case *ast.FuncDecl:
+			kind := protocol.Function
+			var recv *ast.Ident
+			if decl.Recv.NumFields() > 0 {
+				kind = protocol.Method
+				recv = unpackRecv(decl.Recv.List[0].Type)
+			}
+			w.atNode(decl.Name, decl.Name.Name, kind, recv)
+		case *ast.GenDecl:
+			for _, spec := range decl.Specs {
+				switch spec := spec.(type) {
+				case *ast.TypeSpec:
+					kind := guessKind(spec)
+					w.atNode(spec.Name, spec.Name.Name, kind)
+					w.walkType(spec.Type, spec.Name)
+				case *ast.ValueSpec:
+					for _, name := range spec.Names {
+						kind := protocol.Variable
+						if decl.Tok == token.CONST {
+							kind = protocol.Constant
+						}
+						w.atNode(name, name.Name, kind)
+					}
+				}
+			}
+		}
+	}
+}
+
+func guessKind(spec *ast.TypeSpec) protocol.SymbolKind {
+	switch spec.Type.(type) {
+	case *ast.InterfaceType:
+		return protocol.Interface
+	case *ast.StructType:
+		return protocol.Struct
+	case *ast.FuncType:
+		return protocol.Function
+	}
+	return protocol.Class
+}
+
+func unpackRecv(rtyp ast.Expr) *ast.Ident {
+	// Extract the receiver identifier. Lifted from go/types/resolver.go
+L:
+	for {
+		switch t := rtyp.(type) {
+		case *ast.ParenExpr:
+			rtyp = t.X
+		case *ast.StarExpr:
+			rtyp = t.X
+		default:
+			break L
+		}
+	}
+	if name, _ := rtyp.(*ast.Ident); name != nil {
+		return name
+	}
+	return nil
+}
+
+// walkType processes symbols related to a type expression. path is path of
+// nested type identifiers to the type expression.
+func (w *symbolWalker) walkType(typ ast.Expr, path ...*ast.Ident) {
+	switch st := typ.(type) {
+	case *ast.StructType:
+		for _, field := range st.Fields.List {
+			w.walkField(field, protocol.Field, protocol.Field, path...)
+		}
+	case *ast.InterfaceType:
+		for _, field := range st.Methods.List {
+			w.walkField(field, protocol.Interface, protocol.Method, path...)
+		}
+	}
+}
+
+// walkField processes symbols related to the struct field or interface method.
+//
+// unnamedKind and namedKind are the symbol kinds if the field is resp. unnamed
+// or named. path is the path of nested identifiers containing the field.
+func (w *symbolWalker) walkField(field *ast.Field, unnamedKind, namedKind protocol.SymbolKind, path ...*ast.Ident) {
+	if len(field.Names) == 0 {
+		switch typ := field.Type.(type) {
+		case *ast.SelectorExpr:
+			// embedded qualified type
+			w.atNode(field, typ.Sel.Name, unnamedKind, path...)
+		default:
+			w.atNode(field, types.ExprString(field.Type), unnamedKind, path...)
+		}
+	}
+	for _, name := range field.Names {
+		w.atNode(name, name.Name, namedKind, path...)
+		w.walkType(field.Type, append(path, name)...)
+	}
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
@@ -727,7 +727,7 @@ func (v *View) updateWorkspaceLocked(ctx context.Context) error {
 
 func (s *Session) getWorkspaceInformation(ctx context.Context, folder span.URI, options *source.Options) (*workspaceInformation, error) {
 	if err := checkPathCase(folder.Filename()); err != nil {
-		return nil, errors.Errorf("invalid workspace configuration: %w", err)
+		return nil, errors.Errorf("invalid workspace folder path: %w; check that the casing of the configured workspace folder path agrees with the casing reported by the operating system", err)
 	}
 	var err error
 	inv := gocommand.Invocation{

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fuzzy/input.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fuzzy/input.go
@@ -27,23 +27,23 @@ const (
 // RuneRoles detects the roles of each byte rune in an input string and stores it in the output
 // slice. The rune role depends on the input type. Stops when it parsed all the runes in the string
 // or when it filled the output. If output is nil, then it gets created.
-func RuneRoles(str string, reuse []RuneRole) []RuneRole {
+func RuneRoles(candidate []byte, reuse []RuneRole) []RuneRole {
 	var output []RuneRole
-	if cap(reuse) < len(str) {
-		output = make([]RuneRole, 0, len(str))
+	if cap(reuse) < len(candidate) {
+		output = make([]RuneRole, 0, len(candidate))
 	} else {
 		output = reuse[:0]
 	}
 
 	prev, prev2 := rtNone, rtNone
-	for i := 0; i < len(str); i++ {
-		r := rune(str[i])
+	for i := 0; i < len(candidate); i++ {
+		r := rune(candidate[i])
 
 		role := RNone
 
 		curr := rtLower
-		if str[i] <= unicode.MaxASCII {
-			curr = runeType(rt[str[i]] - '0')
+		if candidate[i] <= unicode.MaxASCII {
+			curr = runeType(rt[candidate[i]] - '0')
 		}
 
 		if curr == rtLower {
@@ -58,7 +58,7 @@ func RuneRoles(str string, reuse []RuneRole) []RuneRole {
 			if prev == rtUpper {
 				// This and previous characters are both upper case.
 
-				if i+1 == len(str) {
+				if i+1 == len(candidate) {
 					// This is last character, previous was also uppercase -> this is UCTail
 					// i.e., (current char is C): aBC / BC / ABC
 					role = RUCTail
@@ -118,11 +118,26 @@ func LastSegment(input string, roles []RuneRole) string {
 	return input[start+1 : end+1]
 }
 
-// ToLower transforms the input string to lower case, which is stored in the output byte slice.
+// fromChunks copies string chunks into the given buffer.
+func fromChunks(chunks []string, buffer []byte) []byte {
+	ii := 0
+	for _, chunk := range chunks {
+		for i := 0; i < len(chunk); i++ {
+			if ii >= cap(buffer) {
+				break
+			}
+			buffer[ii] = chunk[i]
+			ii++
+		}
+	}
+	return buffer[:ii]
+}
+
+// toLower transforms the input string to lower case, which is stored in the output byte slice.
 // The lower casing considers only ASCII values - non ASCII values are left unmodified.
 // Stops when parsed all input or when it filled the output slice. If output is nil, then it gets
 // created.
-func ToLower(input string, reuse []byte) []byte {
+func toLower(input []byte, reuse []byte) []byte {
 	output := reuse
 	if cap(reuse) < len(input) {
 		output = make([]byte, len(input))
@@ -130,7 +145,7 @@ func ToLower(input string, reuse []byte) []byte {
 
 	for i := 0; i < len(input); i++ {
 		r := rune(input[i])
-		if r <= unicode.MaxASCII {
+		if input[i] <= unicode.MaxASCII {
 			if 'A' <= r && r <= 'Z' {
 				r += 'a' - 'A'
 			}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/fuzzy/symbol.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/fuzzy/symbol.go
@@ -1,0 +1,224 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fuzzy
+
+import (
+	"unicode"
+)
+
+// SymbolMatcher implements a fuzzy matching algorithm optimized for Go symbols
+// of the form:
+//  example.com/path/to/package.object.field
+//
+// Knowing that we are matching symbols like this allows us to make the
+// following optimizations:
+//  - We can incorporate right-to-left relevance directly into the score
+//    calculation.
+//  - We can match from right to left, discarding leading bytes if the input is
+//    too long.
+//  - We just take the right-most match without losing too much precision. This
+//    allows us to use an O(n) algorithm.
+//  - We can operate directly on chunked strings; in many cases we will
+//    be storing the package path and/or package name separately from the
+//    symbol or identifiers, so doing this avoids allocating strings.
+//  - We can return the index of the right-most match, allowing us to trim
+//    irrelevant qualification.
+//
+// This implementation is experimental, serving as a reference fast algorithm
+// to compare to the fuzzy algorithm implemented by Matcher.
+type SymbolMatcher struct {
+	// Using buffers of length 256 is both a reasonable size for most qualified
+	// symbols, and makes it easy to avoid bounds checks by using uint8 indexes.
+	pattern     [256]rune
+	patternLen  uint8
+	inputBuffer [256]rune   // avoid allocating when considering chunks
+	roles       [256]uint32 // which roles does a rune play (word start, etc.)
+	segments    [256]uint8  // how many segments from the right is each rune
+}
+
+const (
+	segmentStart uint32 = 1 << iota
+	wordStart
+	separator
+)
+
+// NewSymbolMatcher creates a SymbolMatcher that may be used to match the given
+// search pattern.
+//
+// Currently this matcher only accepts case-insensitive fuzzy patterns.
+//
+// TODO(rfindley):
+//  - implement smart-casing
+//  - implement space-separated groups
+//  - implement ', ^, and $ modifiers
+//
+// An empty pattern matches no input.
+func NewSymbolMatcher(pattern string) *SymbolMatcher {
+	m := &SymbolMatcher{}
+	for _, p := range pattern {
+		m.pattern[m.patternLen] = unicode.ToLower(p)
+		m.patternLen++
+		if m.patternLen == 255 || int(m.patternLen) == len(pattern) {
+			// break at 255 so that we can represent patternLen with a uint8.
+			break
+		}
+	}
+	return m
+}
+
+// Match looks for the right-most match of the search pattern within the symbol
+// represented by concatenating the given chunks, returning its offset and
+// score.
+//
+// If a match is found, the first return value will hold the absolute byte
+// offset within all chunks for the start of the symbol. In other words, the
+// index of the match within strings.Join(chunks, ""). If no match is found,
+// the first return value will be -1.
+//
+// The second return value will be the score of the match, which is always
+// between 0 and 1, inclusive. A score of 0 indicates no match.
+func (m *SymbolMatcher) Match(chunks []string) (int, float64) {
+	// Explicit behavior for an empty pattern.
+	//
+	// As a minor optimization, this also avoids nilness checks later on, since
+	// the compiler can prove that m != nil.
+	if m.patternLen == 0 {
+		return -1, 0
+	}
+
+	// First phase: populate the input buffer with lower-cased runes.
+	//
+	// We could also check for a forward match here, but since we'd have to write
+	// the entire input anyway this has negligible impact on performance.
+
+	var (
+		inputLen  = uint8(0)
+		modifiers = wordStart | segmentStart
+	)
+
+input:
+	for _, chunk := range chunks {
+		for _, r := range chunk {
+			if r == '.' || r == '/' {
+				modifiers |= separator
+			}
+			// optimization: avoid calls to unicode.ToLower, which can't be inlined.
+			l := r
+			if r <= unicode.MaxASCII {
+				if 'A' <= r && r <= 'Z' {
+					l = r + 'a' - 'A'
+				}
+			} else {
+				l = unicode.ToLower(r)
+			}
+			if l != r {
+				modifiers |= wordStart
+			}
+			m.inputBuffer[inputLen] = l
+			m.roles[inputLen] = modifiers
+			inputLen++
+			if m.roles[inputLen-1]&separator != 0 {
+				modifiers = wordStart | segmentStart
+			} else {
+				modifiers = 0
+			}
+			// TODO: we should prefer the right-most input if it overflows, rather
+			//       than the left-most as we're doing here.
+			if inputLen == 255 {
+				break input
+			}
+		}
+	}
+
+	// Second phase: find the right-most match, and count segments from the
+	// right.
+
+	var (
+		pi    = uint8(m.patternLen - 1) // pattern index
+		p     = m.pattern[pi]           // pattern rune
+		start = -1                      // start offset of match
+		rseg  = uint8(0)
+	)
+	const maxSeg = 3 // maximum number of segments from the right to count, for scoring purposes.
+
+	for ii := inputLen - 1; ; ii-- {
+		r := m.inputBuffer[ii]
+		if rseg < maxSeg && m.roles[ii]&separator != 0 {
+			rseg++
+		}
+		m.segments[ii] = rseg
+		if p == r {
+			if pi == 0 {
+				start = int(ii)
+				break
+			}
+			pi--
+			p = m.pattern[pi]
+		}
+		// Don't check ii >= 0 in the loop condition: ii is a uint8.
+		if ii == 0 {
+			break
+		}
+	}
+
+	if start < 0 {
+		// no match: skip scoring
+		return -1, 0
+	}
+
+	// Third phase: find the shortest match, and compute the score.
+
+	// Score is the average score for each character.
+	//
+	// A character score is the multiple of:
+	//   1. 1.0 if the character starts a segment, .8 if the character start a
+	//      mid-segment word, otherwise 0.6. This carries over to immediately
+	//      following characters.
+	//   2. 1.0 if the character is part of the last segment, otherwise
+	//      1.0-.2*<segments from the right>, with a max segment count of 3.
+	//
+	// This is a very naive algorithm, but it is fast. There's lots of prior art
+	// here, and we should leverage it. For example, we could explicitly consider
+	// character distance, and exact matches of words or segments.
+	//
+	// Also note that this might not actually find the highest scoring match, as
+	// doing so could require a non-linear algorithm, depending on how the score
+	// is calculated.
+
+	pi = 0
+	p = m.pattern[pi]
+
+	const (
+		segStreak  = 1.0
+		wordStreak = 0.8
+		noStreak   = 0.6
+		perSegment = 0.2 // we count at most 3 segments above
+	)
+
+	streakBonus := noStreak
+	totScore := 0.0
+	for ii := uint8(start); ii < inputLen; ii++ {
+		r := m.inputBuffer[ii]
+		if r == p {
+			pi++
+			p = m.pattern[pi]
+			// Note: this could be optimized with some bit operations.
+			switch {
+			case m.roles[ii]&segmentStart != 0 && segStreak > streakBonus:
+				streakBonus = segStreak
+			case m.roles[ii]&wordStart != 0 && wordStreak > streakBonus:
+				streakBonus = wordStreak
+			}
+			totScore += streakBonus * (1.0 - float64(m.segments[ii])*perSegment)
+			if pi >= m.patternLen {
+				break
+			}
+		} else {
+			streakBonus = noStreak
+		}
+	}
+
+	return start, totScore / float64(m.patternLen)
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/lsprpc.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/lsprpc/lsprpc.go
@@ -225,9 +225,9 @@ func (f *Forwarder) ServeStream(ctx context.Context, clientConn jsonrpc2.Conn) e
 
 	err = nil
 	if serverConn.Err() != nil {
-		err = errors.Errorf("remote disconnected: %v", err)
+		err = errors.Errorf("remote disconnected: %v", serverConn.Err())
 	} else if clientConn.Err() != nil {
-		err = errors.Errorf("client disconnected: %v", err)
+		err = errors.Errorf("client disconnected: %v", clientConn.Err())
 	}
 	event.Log(ctx, fmt.Sprintf("forwarder: exited with error: %v", err))
 	return err

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsclient.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsclient.go
@@ -6,8 +6,8 @@ package protocol
 
 // Package protocol contains data types and code for LSP jsonrpcs
 // generated automatically from vscode-languageserver-node
-// commit: 092c2afc3ad7e4d2b03fe8ac0deb418ec4276915
-// last fetched Sat Jul 03 2021 10:17:05 GMT-0700 (Pacific Daylight Time)
+// commit: 0cb3812e7d540ef3a904e96df795bc37a21de9b0
+// last fetched Mon Aug 02 2021 10:08:19 GMT-0400 (Eastern Daylight Time)
 
 // Code generated (see typescript/README.md) DO NOT EDIT.
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsprotocol.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsprotocol.go
@@ -4,8 +4,8 @@
 
 // Package protocol contains data types and code for LSP jsonrpcs
 // generated automatically from vscode-languageserver-node
-// commit: 092c2afc3ad7e4d2b03fe8ac0deb418ec4276915
-// last fetched Sat Jul 03 2021 10:17:05 GMT-0700 (Pacific Daylight Time)
+// commit: 0cb3812e7d540ef3a904e96df795bc37a21de9b0
+// last fetched Mon Aug 02 2021 10:08:19 GMT-0400 (Eastern Daylight Time)
 package protocol
 
 // Code generated (see typescript/README.md) DO NOT EDIT.
@@ -976,17 +976,15 @@ type CompletionItemKind float64
  */
 type CompletionItemLabelDetails struct {
 	/**
-	 * The parameters without the return type.
+	 * An optional string which is rendered less prominently directly after {@link CompletionItemLabel.label label},
+	 * without any spacing. Should be used for function signatures or type annotations.
 	 */
-	Parameters string `json:"parameters,omitempty"`
+	Detail string `json:"detail,omitempty"`
 	/**
-	 * The fully qualified name, like package name or file path.
+	 * An optional string which is rendered less prominently after {@link CompletionItemLabel.detail}. Should be used
+	 * for fully qualified names or file path.
 	 */
-	Qualifier string `json:"qualifier,omitempty"`
-	/**
-	 * The return-type of a function or type of a property/variable.
-	 */
-	Type string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 /**

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsserver.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsserver.go
@@ -6,8 +6,8 @@ package protocol
 
 // Package protocol contains data types and code for LSP jsonrpcs
 // generated automatically from vscode-languageserver-node
-// commit: 092c2afc3ad7e4d2b03fe8ac0deb418ec4276915
-// last fetched Sat Jul 03 2021 10:17:05 GMT-0700 (Pacific Daylight Time)
+// commit: 0cb3812e7d540ef3a904e96df795bc37a21de9b0
+// last fetched Mon Aug 02 2021 10:08:19 GMT-0400 (Eastern Daylight Time)
 
 // Code generated (see typescript/README.md) DO NOT EDIT.
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/util.ts
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/util.ts
@@ -15,7 +15,7 @@ export const fnames = [
   `${dir}/${srcDir}/protocol/src/browser/main.ts`, `${dir}${srcDir}/types/src/main.ts`,
   `${dir}${srcDir}/jsonrpc/src/node/main.ts`
 ];
-export const gitHash = '092c2afc3ad7e4d2b03fe8ac0deb418ec4276915';
+export const gitHash = '0cb3812e7d540ef3a904e96df795bc37a21de9b0';
 let outFname = 'tsprotocol.go';
 let fda: number, fdb: number, fde: number;  // file descriptors
 

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -326,6 +326,10 @@ var GeneratedAPIJSON = &APIJSON{
 						Doc:   "",
 					},
 					{
+						Value: "\"FastFuzzy\"",
+						Doc:   "",
+					},
+					{
 						Value: "\"Fuzzy\"",
 						Doc:   "",
 					},

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/identifier.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/identifier.go
@@ -371,21 +371,24 @@ func inferredSignature(info *types.Info, path []ast.Node) *types.Signature {
 	case *ast.CallExpr:
 		_, sig := typeparams.GetInferred(info, n)
 		return sig
-	case *ast.IndexExpr:
-		// If the IndexExpr is fully instantiated, we consider that 'inference' for
-		// gopls' purposes.
-		sig, _ := info.TypeOf(n).(*types.Signature)
-		if sig != nil && len(typeparams.ForSignature(sig)) == 0 {
-			return sig
-		}
-		_, sig = typeparams.GetInferred(info, n)
-		if sig != nil {
-			return sig
-		}
-		if len(path) >= 2 {
-			if call, _ := path[2].(*ast.CallExpr); call != nil {
-				_, sig := typeparams.GetInferred(info, call)
+	default:
+		if ix := typeparams.GetIndexExprData(n); ix != nil {
+			e := n.(ast.Expr)
+			// If the IndexExpr is fully instantiated, we consider that 'inference' for
+			// gopls' purposes.
+			sig, _ := info.TypeOf(e).(*types.Signature)
+			if sig != nil && len(typeparams.ForSignature(sig)) == 0 {
 				return sig
+			}
+			_, sig = typeparams.GetInferred(info, e)
+			if sig != nil {
+				return sig
+			}
+			if len(path) >= 2 {
+				if call, _ := path[2].(*ast.CallExpr); call != nil {
+					_, sig := typeparams.GetInferred(info, call)
+					return sig
+				}
 			}
 		}
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/options.go
@@ -543,6 +543,7 @@ type SymbolMatcher string
 
 const (
 	SymbolFuzzy           SymbolMatcher = "Fuzzy"
+	SymbolFastFuzzy       SymbolMatcher = "FastFuzzy"
 	SymbolCaseInsensitive SymbolMatcher = "CaseInsensitive"
 	SymbolCaseSensitive   SymbolMatcher = "CaseSensitive"
 )
@@ -834,6 +835,7 @@ func (o *Options) set(name string, value interface{}, seen map[string]struct{}) 
 	case "symbolMatcher":
 		if s, ok := result.asOneOf(
 			string(SymbolFuzzy),
+			string(SymbolFastFuzzy),
 			string(SymbolCaseInsensitive),
 			string(SymbolCaseSensitive),
 		); ok {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -162,6 +162,12 @@ type Snapshot interface {
 	// mode, this is just the reverse transitive closure of open packages.
 	ActivePackages(ctx context.Context) ([]Package, error)
 
+	// Symbols returns all symbols in the snapshot.
+	Symbols(ctx context.Context) (map[span.URI][]Symbol, error)
+
+	// Metadata returns package metadata associated with the given file URI.
+	MetadataForFile(ctx context.Context, uri span.URI) ([]Metadata, error)
+
 	// GetCriticalError returns any critical errors in the workspace.
 	GetCriticalError(ctx context.Context) *CriticalError
 
@@ -297,6 +303,15 @@ type TidiedModule struct {
 	Diagnostics []*Diagnostic
 	// The bytes of the go.mod file after it was tidied.
 	TidiedContent []byte
+}
+
+// Metadata represents package metadata retrieved from go/packages.
+type Metadata interface {
+	// Name is the package name.
+	Name() string
+
+	// PkgPath is the package path.
+	PkgPath() string
 }
 
 // Session represents a single connection from a client.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/workspace_symbol.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/workspace_symbol.go
@@ -7,19 +7,26 @@ package source
 import (
 	"context"
 	"fmt"
-	"go/ast"
-	"go/token"
 	"go/types"
+	"runtime"
 	"sort"
 	"strings"
 	"unicode"
-	"unicode/utf8"
 
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/event"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/fuzzy"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/span"
 )
+
+// Symbol holds a precomputed symbol value. Note: we avoid using the
+// protocol.SymbolInformation struct here in order to reduce the size of each
+// symbol.
+type Symbol struct {
+	Name  string
+	Kind  protocol.SymbolKind
+	Range protocol.Range
+}
 
 // maxSymbols defines the maximum number of symbol results that should ever be
 // sent in response to a client.
@@ -52,10 +59,10 @@ func WorkspaceSymbols(ctx context.Context, matcherType SymbolMatcher, style Symb
 	return sc.walk(ctx, views)
 }
 
-// A matcherFunc determines the matching score of a symbol.
+// A matcherFunc returns the index and score of a symbol match.
 //
 // See the comment for symbolCollector for more information.
-type matcherFunc func(name string) float64
+type matcherFunc func(chunks []string) (int, float64)
 
 // A symbolizer returns the best symbol match for a name with pkg, according to
 // some heuristic. The symbol name is passed as the slice nameParts of logical
@@ -63,69 +70,69 @@ type matcherFunc func(name string) float64
 // []string{"myType.field"} or []string{"myType.", "field"}.
 //
 // See the comment for symbolCollector for more information.
-type symbolizer func(nameParts []string, pkg Package, m matcherFunc) (string, float64)
+type symbolizer func(name string, pkg Metadata, m matcherFunc) ([]string, float64)
 
-func fullyQualifiedSymbolMatch(nameParts []string, pkg Package, matcher matcherFunc) (string, float64) {
-	_, score := dynamicSymbolMatch(nameParts, pkg, matcher)
-	path := append([]string{pkg.PkgPath() + "."}, nameParts...)
+func fullyQualifiedSymbolMatch(name string, pkg Metadata, matcher matcherFunc) ([]string, float64) {
+	_, score := dynamicSymbolMatch(name, pkg, matcher)
 	if score > 0 {
-		return strings.Join(path, ""), score
+		return []string{pkg.PkgPath(), ".", name}, score
 	}
-	return "", 0
+	return nil, 0
 }
 
-func dynamicSymbolMatch(nameParts []string, pkg Package, matcher matcherFunc) (string, float64) {
-	var best string
-	fullName := strings.Join(nameParts, "")
+func dynamicSymbolMatch(name string, pkg Metadata, matcher matcherFunc) ([]string, float64) {
 	var score float64
-	var name string
 
-	// Compute the match score by finding the highest scoring suffix. In these
-	// cases the matched symbol is still the full name: it is confusing to match
-	// an unqualified nested field or method.
-	if match := bestMatch("", nameParts, matcher); match > score {
-		best = fullName
-		score = match
-	}
+	endsInPkgName := strings.HasSuffix(pkg.PkgPath(), pkg.Name())
 
-	// Next: try to match a package-qualified name.
-	name = pkg.Name() + "." + fullName
-	if match := matcher(name); match > score {
-		best = name
-		score = match
-	}
-
-	// Finally: consider a fully qualified name.
-	prefix := pkg.PkgPath() + "."
-	fullyQualified := prefix + fullName
-	// As with field/method selectors, consider suffixes from right to left, but
-	// always return a fully-qualified symbol.
-	pathParts := strings.SplitAfter(prefix, "/")
-	if match := bestMatch(fullName, pathParts, matcher); match > score {
-		best = fullyQualified
-		score = match
-	}
-	return best, score
-}
-
-func bestMatch(name string, prefixParts []string, matcher matcherFunc) float64 {
-	var score float64
-	for i := len(prefixParts) - 1; i >= 0; i-- {
-		name = prefixParts[i] + name
-		if match := matcher(name); match > score {
-			score = match
+	// If the package path does not end in the package name, we need to check the
+	// package-qualified symbol as an extra pass first.
+	if !endsInPkgName {
+		pkgQualified := []string{pkg.Name(), ".", name}
+		idx, score := matcher(pkgQualified)
+		nameStart := len(pkg.Name()) + 1
+		if score > 0 {
+			// If our match is contained entirely within the unqualified portion,
+			// just return that.
+			if idx >= nameStart {
+				return []string{name}, score
+			}
+			// Lower the score for matches that include the package name.
+			return pkgQualified, score * 0.8
 		}
 	}
-	return score
+
+	// Now try matching the fully qualified symbol.
+	fullyQualified := []string{pkg.PkgPath(), ".", name}
+	idx, score := matcher(fullyQualified)
+
+	// As above, check if we matched just the unqualified symbol name.
+	nameStart := len(pkg.PkgPath()) + 1
+	if idx >= nameStart {
+		return []string{name}, score
+	}
+
+	// If our package path ends in the package name, we'll have skipped the
+	// initial pass above, so check if we matched just the package-qualified
+	// name.
+	if endsInPkgName && idx >= 0 {
+		pkgStart := len(pkg.PkgPath()) - len(pkg.Name())
+		if idx >= pkgStart {
+			return []string{pkg.Name(), ".", name}, score
+		}
+	}
+
+	// Our match was not contained within the unqualified or package qualified
+	// symbol. Return the fully qualified symbol but discount the score.
+	return fullyQualified, score * 0.6
 }
 
-func packageSymbolMatch(components []string, pkg Package, matcher matcherFunc) (string, float64) {
-	path := append([]string{pkg.Name() + "."}, components...)
-	qualified := strings.Join(path, "")
-	if matcher(qualified) > 0 {
-		return qualified, 1
+func packageSymbolMatch(name string, pkg Metadata, matcher matcherFunc) ([]string, float64) {
+	qualified := []string{pkg.Name(), ".", name}
+	if _, s := matcher(qualified); s > 0 {
+		return qualified, s
 	}
-	return "", 0
+	return nil, 0
 }
 
 // symbolCollector holds context as we walk Packages, gathering symbols that
@@ -139,39 +146,14 @@ func packageSymbolMatch(components []string, pkg Package, matcher matcherFunc) (
 //    enables the 'symbolStyle' configuration option.
 type symbolCollector struct {
 	// These types parameterize the symbol-matching pass.
-	matcher    matcherFunc
+	matchers   []matcherFunc
 	symbolizer symbolizer
 
-	// current holds metadata for the package we are currently walking.
-	current *pkgView
-	curFile *ParsedGoFile
-
-	res [maxSymbols]symbolInformation
+	seen map[span.URI]bool
+	symbolStore
 }
 
 func newSymbolCollector(matcher SymbolMatcher, style SymbolStyle, query string) *symbolCollector {
-	var m matcherFunc
-	switch matcher {
-	case SymbolFuzzy:
-		m = parseQuery(query)
-	case SymbolCaseSensitive:
-		m = func(s string) float64 {
-			if strings.Contains(s, query) {
-				return 1
-			}
-			return 0
-		}
-	case SymbolCaseInsensitive:
-		q := strings.ToLower(query)
-		m = func(s string) float64 {
-			if strings.Contains(strings.ToLower(s), q) {
-				return 1
-			}
-			return 0
-		}
-	default:
-		panic(fmt.Errorf("unknown symbol matcher: %v", matcher))
-	}
 	var s symbolizer
 	switch style {
 	case DynamicSymbols:
@@ -183,10 +165,33 @@ func newSymbolCollector(matcher SymbolMatcher, style SymbolStyle, query string) 
 	default:
 		panic(fmt.Errorf("unknown symbol style: %v", style))
 	}
-	return &symbolCollector{
-		matcher:    m,
-		symbolizer: s,
+	sc := &symbolCollector{symbolizer: s}
+	sc.matchers = make([]matcherFunc, runtime.GOMAXPROCS(-1))
+	for i := range sc.matchers {
+		sc.matchers[i] = buildMatcher(matcher, query)
 	}
+	return sc
+}
+
+func buildMatcher(matcher SymbolMatcher, query string) matcherFunc {
+	switch matcher {
+	case SymbolFuzzy:
+		return parseQuery(query)
+	case SymbolFastFuzzy:
+		return fuzzy.NewSymbolMatcher(query).Match
+	case SymbolCaseSensitive:
+		return matchExact(query)
+	case SymbolCaseInsensitive:
+		q := strings.ToLower(query)
+		exact := matchExact(q)
+		wrapper := []string{""}
+		return func(chunks []string) (int, float64) {
+			s := strings.Join(chunks, "")
+			wrapper[0] = strings.ToLower(s)
+			return exact(wrapper)
+		}
+	}
+	panic(fmt.Errorf("unknown symbol matcher: %v", matcher))
 }
 
 // parseQuery parses a field-separated symbol query, extracting the special
@@ -204,7 +209,7 @@ func newSymbolCollector(matcher SymbolMatcher, style SymbolStyle, query string) 
 func parseQuery(q string) matcherFunc {
 	fields := strings.Fields(q)
 	if len(fields) == 0 {
-		return func(string) float64 { return 0 }
+		return func([]string) (int, float64) { return -1, 0 }
 	}
 	var funcs []matcherFunc
 	for _, field := range fields {
@@ -212,85 +217,276 @@ func parseQuery(q string) matcherFunc {
 		switch {
 		case strings.HasPrefix(field, "^"):
 			prefix := field[1:]
-			f = smartCase(prefix, func(s string) float64 {
+			f = smartCase(prefix, func(chunks []string) (int, float64) {
+				s := strings.Join(chunks, "")
 				if strings.HasPrefix(s, prefix) {
-					return 1
+					return 0, 1
 				}
-				return 0
+				return -1, 0
 			})
 		case strings.HasPrefix(field, "'"):
 			exact := field[1:]
-			f = smartCase(exact, func(s string) float64 {
-				if strings.Contains(s, exact) {
-					return 1
-				}
-				return 0
-			})
+			f = smartCase(exact, matchExact(exact))
 		case strings.HasSuffix(field, "$"):
 			suffix := field[0 : len(field)-1]
-			f = smartCase(suffix, func(s string) float64 {
+			f = smartCase(suffix, func(chunks []string) (int, float64) {
+				s := strings.Join(chunks, "")
 				if strings.HasSuffix(s, suffix) {
-					return 1
+					return len(s) - len(suffix), 1
 				}
-				return 0
+				return -1, 0
 			})
 		default:
 			fm := fuzzy.NewMatcher(field)
-			f = func(s string) float64 {
-				return float64(fm.Score(s))
+			f = func(chunks []string) (int, float64) {
+				score := float64(fm.ScoreChunks(chunks))
+				ranges := fm.MatchedRanges()
+				if len(ranges) > 0 {
+					return ranges[0], score
+				}
+				return -1, score
 			}
 		}
 		funcs = append(funcs, f)
 	}
+	if len(funcs) == 1 {
+		return funcs[0]
+	}
 	return comboMatcher(funcs).match
+}
+
+func matchExact(exact string) matcherFunc {
+	return func(chunks []string) (int, float64) {
+		s := strings.Join(chunks, "")
+		if idx := strings.LastIndex(s, exact); idx >= 0 {
+			return idx, 1
+		}
+		return -1, 0
+	}
 }
 
 // smartCase returns a matcherFunc that is case-sensitive if q contains any
 // upper-case characters, and case-insensitive otherwise.
 func smartCase(q string, m matcherFunc) matcherFunc {
 	insensitive := strings.ToLower(q) == q
-	return func(s string) float64 {
+	wrapper := []string{""}
+	return func(chunks []string) (int, float64) {
+		s := strings.Join(chunks, "")
 		if insensitive {
 			s = strings.ToLower(s)
 		}
-		return m(s)
+		wrapper[0] = s
+		return m(wrapper)
 	}
 }
 
 type comboMatcher []matcherFunc
 
-func (c comboMatcher) match(s string) float64 {
+func (c comboMatcher) match(chunks []string) (int, float64) {
 	score := 1.0
+	first := 0
 	for _, f := range c {
-		score *= f(s)
+		idx, s := f(chunks)
+		if idx < first {
+			first = idx
+		}
+		score *= s
 	}
-	return score
+	return first, score
 }
 
-// walk walks views, gathers symbols, and returns the results.
-func (sc *symbolCollector) walk(ctx context.Context, views []View) (_ []protocol.SymbolInformation, err error) {
-	toWalk, err := sc.collectPackages(ctx, views)
-	if err != nil {
-		return nil, err
+func (sc *symbolCollector) walk(ctx context.Context, views []View) ([]protocol.SymbolInformation, error) {
+
+	// Use the root view URIs for determining (lexically) whether a uri is in any
+	// open workspace.
+	var roots []string
+	for _, v := range views {
+		roots = append(roots, strings.TrimRight(string(v.Folder()), "/"))
 	}
-	// Make sure we only walk files once (we might see them more than once due to
-	// build constraints).
-	seen := make(map[span.URI]bool)
-	for _, pv := range toWalk {
-		sc.current = pv
-		for _, pgf := range pv.pkg.CompiledGoFiles() {
-			if seen[pgf.URI] {
+
+	results := make(chan *symbolStore)
+	matcherlen := len(sc.matchers)
+	files := make(map[span.URI]symbolFile)
+
+	for _, v := range views {
+		snapshot, release := v.Snapshot(ctx)
+		defer release()
+		psyms, err := snapshot.Symbols(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for uri, syms := range psyms {
+			// Only scan each file once.
+			if _, ok := files[uri]; ok {
 				continue
 			}
-			seen[pgf.URI] = true
-			sc.curFile = pgf
-			sc.walkFilesDecls(pgf.File.Decls)
+			mds, err := snapshot.MetadataForFile(ctx, uri)
+			if err != nil {
+				return nil, err
+			}
+			if len(mds) == 0 {
+				// TODO: should use the bug reporting API
+				continue
+			}
+			files[uri] = symbolFile{uri, mds[0], syms}
+		}
+	}
+
+	var work []symbolFile
+	for _, f := range files {
+		work = append(work, f)
+	}
+
+	// Compute matches concurrently. Each symbolWorker has its own symbolStore,
+	// which we merge at the end.
+	for i, matcher := range sc.matchers {
+		go func(i int, matcher matcherFunc) {
+			w := &symbolWorker{
+				symbolizer: sc.symbolizer,
+				matcher:    matcher,
+				ss:         &symbolStore{},
+				roots:      roots,
+			}
+			for j := i; j < len(work); j += matcherlen {
+				w.matchFile(work[j])
+			}
+			results <- w.ss
+		}(i, matcher)
+	}
+
+	for i := 0; i < matcherlen; i++ {
+		ss := <-results
+		for _, si := range ss.res {
+			sc.store(si)
 		}
 	}
 	return sc.results(), nil
 }
 
-func (sc *symbolCollector) results() []protocol.SymbolInformation {
+// symbolFile holds symbol information for a single file.
+type symbolFile struct {
+	uri  span.URI
+	md   Metadata
+	syms []Symbol
+}
+
+// symbolWorker matches symbols and captures the highest scoring results.
+type symbolWorker struct {
+	symbolizer symbolizer
+	matcher    matcherFunc
+	ss         *symbolStore
+	roots      []string
+}
+
+func (w *symbolWorker) matchFile(i symbolFile) {
+	for _, sym := range i.syms {
+		symbolParts, score := w.symbolizer(sym.Name, i.md, w.matcher)
+
+		// Check if the score is too low before applying any downranking.
+		if w.ss.tooLow(score) {
+			continue
+		}
+
+		// Factors to apply to the match score for the purpose of downranking
+		// results.
+		//
+		// These numbers were crudely calibrated based on trial-and-error using a
+		// small number of sample queries. Adjust as necessary.
+		//
+		// All factors are multiplicative, meaning if more than one applies they are
+		// multiplied together.
+		const (
+			// nonWorkspaceFactor is applied to symbols outside of any active
+			// workspace. Developers are less likely to want to jump to code that they
+			// are not actively working on.
+			nonWorkspaceFactor = 0.5
+			// nonWorkspaceUnexportedFactor is applied to unexported symbols outside of
+			// any active workspace. Since one wouldn't usually jump to unexported
+			// symbols to understand a package API, they are particularly irrelevant.
+			nonWorkspaceUnexportedFactor = 0.5
+			// every field or method nesting level to access the field decreases
+			// the score by a factor of 1.0 - depth*depthFactor, up to a depth of
+			// 3.
+			depthFactor = 0.2
+		)
+
+		startWord := true
+		exported := true
+		depth := 0.0
+		for _, r := range sym.Name {
+			if startWord && !unicode.IsUpper(r) {
+				exported = false
+			}
+			if r == '.' {
+				startWord = true
+				depth++
+			} else {
+				startWord = false
+			}
+		}
+
+		inWorkspace := false
+		for _, root := range w.roots {
+			if strings.HasPrefix(string(i.uri), root) {
+				inWorkspace = true
+				break
+			}
+		}
+
+		// Apply downranking based on workspace position.
+		if !inWorkspace {
+			score *= nonWorkspaceFactor
+			if !exported {
+				score *= nonWorkspaceUnexportedFactor
+			}
+		}
+
+		// Apply downranking based on symbol depth.
+		if depth > 3 {
+			depth = 3
+		}
+		score *= 1.0 - depth*depthFactor
+
+		if w.ss.tooLow(score) {
+			continue
+		}
+
+		si := symbolInformation{
+			score:     score,
+			symbol:    strings.Join(symbolParts, ""),
+			kind:      sym.Kind,
+			uri:       i.uri,
+			rng:       sym.Range,
+			container: i.md.PkgPath(),
+		}
+		w.ss.store(si)
+	}
+}
+
+type symbolStore struct {
+	res [maxSymbols]symbolInformation
+}
+
+// store inserts si into the sorted results, if si has a high enough score.
+func (sc *symbolStore) store(si symbolInformation) {
+	if sc.tooLow(si.score) {
+		return
+	}
+	insertAt := sort.Search(len(sc.res), func(i int) bool {
+		return sc.res[i].score < si.score
+	})
+	if insertAt < len(sc.res)-1 {
+		copy(sc.res[insertAt+1:], sc.res[insertAt:len(sc.res)-1])
+	}
+	sc.res[insertAt] = si
+}
+
+func (sc *symbolStore) tooLow(score float64) bool {
+	return score <= sc.res[len(sc.res)-1].score
+}
+
+func (sc *symbolStore) results() []protocol.SymbolInformation {
 	var res []protocol.SymbolInformation
 	for _, si := range sc.res {
 		if si.score <= 0 {
@@ -299,139 +495,6 @@ func (sc *symbolCollector) results() []protocol.SymbolInformation {
 		res = append(res, si.asProtocolSymbolInformation())
 	}
 	return res
-}
-
-// collectPackages gathers all known packages and sorts for stability.
-func (sc *symbolCollector) collectPackages(ctx context.Context, views []View) ([]*pkgView, error) {
-	var toWalk []*pkgView
-	for _, v := range views {
-		snapshot, release := v.Snapshot(ctx)
-		defer release()
-		knownPkgs, err := snapshot.KnownPackages(ctx)
-		if err != nil {
-			return nil, err
-		}
-		// TODO(rfindley): this can result in incomplete information in degraded
-		// memory mode.
-		workspacePackages, err := snapshot.ActivePackages(ctx)
-		if err != nil {
-			return nil, err
-		}
-		isWorkspacePkg := make(map[Package]bool)
-		for _, wp := range workspacePackages {
-			isWorkspacePkg[wp] = true
-		}
-		for _, pkg := range knownPkgs {
-			toWalk = append(toWalk, &pkgView{
-				pkg:         pkg,
-				isWorkspace: isWorkspacePkg[pkg],
-			})
-		}
-	}
-	// Now sort for stability of results. We order by
-	// (pkgView.isWorkspace, pkgView.p.ID())
-	sort.Slice(toWalk, func(i, j int) bool {
-		lhs := toWalk[i]
-		rhs := toWalk[j]
-		switch {
-		case lhs.isWorkspace == rhs.isWorkspace:
-			return lhs.pkg.ID() < rhs.pkg.ID()
-		case lhs.isWorkspace:
-			return true
-		default:
-			return false
-		}
-	})
-	return toWalk, nil
-}
-
-func (sc *symbolCollector) walkFilesDecls(decls []ast.Decl) {
-	for _, decl := range decls {
-		switch decl := decl.(type) {
-		case *ast.FuncDecl:
-			kind := protocol.Function
-			var recv *ast.Ident
-			if decl.Recv.NumFields() > 0 {
-				kind = protocol.Method
-				recv = unpackRecv(decl.Recv.List[0].Type)
-			}
-			if recv != nil {
-				sc.match(decl.Name.Name, kind, decl.Name, recv)
-			} else {
-				sc.match(decl.Name.Name, kind, decl.Name)
-			}
-		case *ast.GenDecl:
-			for _, spec := range decl.Specs {
-				switch spec := spec.(type) {
-				case *ast.TypeSpec:
-					sc.match(spec.Name.Name, typeToKind(sc.current.pkg.GetTypesInfo().TypeOf(spec.Type)), spec.Name)
-					sc.walkType(spec.Type, spec.Name)
-				case *ast.ValueSpec:
-					for _, name := range spec.Names {
-						kind := protocol.Variable
-						if decl.Tok == token.CONST {
-							kind = protocol.Constant
-						}
-						sc.match(name.Name, kind, name)
-					}
-				}
-			}
-		}
-	}
-}
-
-func unpackRecv(rtyp ast.Expr) *ast.Ident {
-	// Extract the receiver identifier. Lifted from go/types/resolver.go
-L:
-	for {
-		switch t := rtyp.(type) {
-		case *ast.ParenExpr:
-			rtyp = t.X
-		case *ast.StarExpr:
-			rtyp = t.X
-		default:
-			break L
-		}
-	}
-	if name, _ := rtyp.(*ast.Ident); name != nil {
-		return name
-	}
-	return nil
-}
-
-// walkType processes symbols related to a type expression. path is path of
-// nested type identifiers to the type expression.
-func (sc *symbolCollector) walkType(typ ast.Expr, path ...*ast.Ident) {
-	switch st := typ.(type) {
-	case *ast.StructType:
-		for _, field := range st.Fields.List {
-			sc.walkField(field, protocol.Field, protocol.Field, path...)
-		}
-	case *ast.InterfaceType:
-		for _, field := range st.Methods.List {
-			sc.walkField(field, protocol.Interface, protocol.Method, path...)
-		}
-	}
-}
-
-// walkField processes symbols related to the struct field or interface method.
-//
-// unnamedKind and namedKind are the symbol kinds if the field is resp. unnamed
-// or named. path is the path of nested identifiers containing the field.
-func (sc *symbolCollector) walkField(field *ast.Field, unnamedKind, namedKind protocol.SymbolKind, path ...*ast.Ident) {
-	if len(field.Names) == 0 {
-		switch typ := field.Type.(type) {
-		case *ast.SelectorExpr:
-			// embedded qualified type
-			sc.match(typ.Sel.Name, unnamedKind, field, path...)
-		default:
-			sc.match(types.ExprString(field.Type), unnamedKind, field, path...)
-		}
-	}
-	for _, name := range field.Names {
-		sc.match(name.Name, namedKind, name, path...)
-		sc.walkType(field.Type, append(path, name)...)
-	}
 }
 
 func typeToKind(typ types.Type) protocol.SymbolKind {
@@ -461,126 +524,15 @@ func typeToKind(typ types.Type) protocol.SymbolKind {
 	return protocol.Variable
 }
 
-// match finds matches and gathers the symbol identified by name, kind and node
-// via the symbolCollector's matcher after first de-duping against previously
-// seen symbols.
-//
-// path specifies the identifier path to a nested field or interface method.
-func (sc *symbolCollector) match(name string, kind protocol.SymbolKind, node ast.Node, path ...*ast.Ident) {
-	if !node.Pos().IsValid() || !node.End().IsValid() {
-		return
-	}
-
-	isExported := isExported(name)
-	var names []string
-	for _, ident := range path {
-		names = append(names, ident.Name+".")
-		if !ident.IsExported() {
-			isExported = false
-		}
-	}
-	names = append(names, name)
-
-	// Factors to apply to the match score for the purpose of downranking
-	// results.
-	//
-	// These numbers were crudely calibrated based on trial-and-error using a
-	// small number of sample queries. Adjust as necessary.
-	//
-	// All factors are multiplicative, meaning if more than one applies they are
-	// multiplied together.
-	const (
-		// nonWorkspaceFactor is applied to symbols outside of any active
-		// workspace. Developers are less likely to want to jump to code that they
-		// are not actively working on.
-		nonWorkspaceFactor = 0.5
-		// nonWorkspaceUnexportedFactor is applied to unexported symbols outside of
-		// any active workspace. Since one wouldn't usually jump to unexported
-		// symbols to understand a package API, they are particularly irrelevant.
-		nonWorkspaceUnexportedFactor = 0.5
-		// fieldFactor is applied to fields and interface methods. One would
-		// typically jump to the type definition first, so ranking fields highly
-		// can be noisy.
-		fieldFactor = 0.5
-	)
-	symbol, score := sc.symbolizer(names, sc.current.pkg, sc.matcher)
-
-	// Downrank symbols outside of the workspace.
-	if !sc.current.isWorkspace {
-		score *= nonWorkspaceFactor
-		if !isExported {
-			score *= nonWorkspaceUnexportedFactor
-		}
-	}
-
-	// Downrank fields.
-	if len(path) > 0 {
-		score *= fieldFactor
-	}
-
-	// Avoid the work below if we know this score will not be sorted into the
-	// results.
-	if score <= sc.res[len(sc.res)-1].score {
-		return
-	}
-
-	rng, err := fileRange(sc.curFile, node.Pos(), node.End())
-	if err != nil {
-		return
-	}
-	si := symbolInformation{
-		score:     score,
-		name:      name,
-		symbol:    symbol,
-		container: sc.current.pkg.PkgPath(),
-		kind:      kind,
-		location: protocol.Location{
-			URI:   protocol.URIFromSpanURI(sc.curFile.URI),
-			Range: rng,
-		},
-	}
-	insertAt := sort.Search(len(sc.res), func(i int) bool {
-		return sc.res[i].score < score
-	})
-	if insertAt < len(sc.res)-1 {
-		copy(sc.res[insertAt+1:], sc.res[insertAt:len(sc.res)-1])
-	}
-	sc.res[insertAt] = si
-}
-
-func fileRange(pgf *ParsedGoFile, start, end token.Pos) (protocol.Range, error) {
-	s, err := span.FileSpan(pgf.Tok, pgf.Mapper.Converter, start, end)
-	if err != nil {
-		return protocol.Range{}, nil
-	}
-	return pgf.Mapper.Range(s)
-}
-
-// isExported reports if a token is exported. Copied from
-// token.IsExported (go1.13+).
-//
-// TODO: replace usage with token.IsExported once go1.12 is no longer
-// supported.
-func isExported(name string) bool {
-	ch, _ := utf8.DecodeRuneInString(name)
-	return unicode.IsUpper(ch)
-}
-
-// pkgView holds information related to a package that we are going to walk.
-type pkgView struct {
-	pkg         Package
-	isWorkspace bool
-}
-
 // symbolInformation is a cut-down version of protocol.SymbolInformation that
 // allows struct values of this type to be used as map keys.
 type symbolInformation struct {
 	score     float64
-	name      string
 	symbol    string
 	container string
 	kind      protocol.SymbolKind
-	location  protocol.Location
+	uri       span.URI
+	rng       protocol.Range
 }
 
 // asProtocolSymbolInformation converts s to a protocol.SymbolInformation value.
@@ -588,9 +540,12 @@ type symbolInformation struct {
 // TODO: work out how to handle tags if/when they are needed.
 func (s symbolInformation) asProtocolSymbolInformation() protocol.SymbolInformation {
 	return protocol.SymbolInformation{
-		Name:          s.symbol,
-		Kind:          s.kind,
-		Location:      s.location,
+		Name: s.symbol,
+		Kind: s.kind,
+		Location: protocol.Location{
+			URI:   protocol.URIFromSpanURI(s.uri),
+			Range: s.rng,
+		},
 		ContainerName: s.container,
 	}
 }

--- a/cmd/govim/internal/golang_org_x_tools/span/uri.go
+++ b/cmd/govim/internal/golang_org_x_tools/span/uri.go
@@ -45,7 +45,7 @@ func filename(uri URI) (string, error) {
 	if u.Scheme != fileScheme {
 		return "", fmt.Errorf("only file URIs are supported, got %q from %q", u.Scheme, uri)
 	}
-	// If the URI is a Windows URI, we trim the leading "/" and lowercase
+	// If the URI is a Windows URI, we trim the leading "/" and uppercase
 	// the drive letter, which will never be case sensitive.
 	if isWindowsDriveURIPath(u.Path) {
 		u.Path = strings.ToUpper(string(u.Path[1])) + u.Path[2:]

--- a/cmd/govim/internal/golang_org_x_tools/typeparams/common.go
+++ b/cmd/govim/internal/golang_org_x_tools/typeparams/common.go
@@ -9,3 +9,17 @@
 // This package exists to make it easier for tools to work with generic code,
 // while also compiling against older Go versions.
 package typeparams
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// A IndexExprData holds data from both ast.IndexExpr and the new
+// ast.MultiIndexExpr, which was introduced in Go 1.18.
+type IndexExprData struct {
+	X       ast.Expr   // expression
+	Lbrack  token.Pos  // position of "["
+	Indices []ast.Expr // index expressions
+	Rbrack  token.Pos  // position of "]"
+}

--- a/cmd/govim/internal/golang_org_x_tools/typeparams/typeparams.go
+++ b/cmd/govim/internal/golang_org_x_tools/typeparams/typeparams.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build typeparams && go1.17
-// +build typeparams,go1.17
+//go:build typeparams && go1.18
+// +build typeparams,go1.18
 
 package typeparams
 
@@ -18,24 +18,28 @@ import (
 // environment.
 const Enabled = true
 
-// UnpackIndex extracts all index expressions from e. For non-generic code this
-// is always one expression: e.Index, but may be more than one expression for
-// generic type instantiation.
-func UnpackIndex(e *ast.IndexExpr) []ast.Expr {
-	if x, _ := e.Index.(*ast.ListExpr); x != nil {
-		return x.ElemList
-	}
-	if e.Index != nil {
-		return []ast.Expr{e.Index}
+// GetIndexExprData extracts data from AST nodes that represent index
+// expressions.
+//
+// For an ast.IndexExpr, the resulting IndexExprData will have exactly one
+// index expression. For an ast.MultiIndexExpr (go1.18+), it may have a
+// variable number of index expressions.
+//
+// For nodes that don't represent index expressions, GetIndexExprData returns
+// nil.
+func GetIndexExprData(n ast.Node) *IndexExprData {
+	switch e := n.(type) {
+	case *ast.IndexExpr:
+		return &IndexExprData{
+			X:       e.X,
+			Lbrack:  e.Lbrack,
+			Indices: []ast.Expr{e.Index},
+			Rbrack:  e.Rbrack,
+		}
+	case *ast.MultiIndexExpr:
+		return (*IndexExprData)(e)
 	}
 	return nil
-}
-
-// IsListExpr reports whether n is an *ast.ListExpr, which is a new node type
-// introduced to hold type arguments for generic type instantiation.
-func IsListExpr(n ast.Node) bool {
-	_, ok := n.(*ast.ListExpr)
-	return ok
 }
 
 // ForTypeDecl extracts the (possibly nil) type parameter node list from n.
@@ -54,12 +58,7 @@ func ForFuncDecl(n *ast.FuncDecl) *ast.FieldList {
 // ForSignature extracts the (possibly empty) type parameter object list from
 // sig.
 func ForSignature(sig *types.Signature) []*types.TypeName {
-	return sig.TParams()
-}
-
-// HasTypeSet reports if iface has a type set.
-func HasTypeSet(iface *types.Interface) bool {
-	return iface.HasTypeList()
+	return tparamsSlice(sig.TParams())
 }
 
 // IsComparable reports if iface is the comparable interface.
@@ -76,7 +75,18 @@ func IsConstraint(iface *types.Interface) bool {
 // ForNamed extracts the (possibly empty) type parameter object list from
 // named.
 func ForNamed(named *types.Named) []*types.TypeName {
-	return named.TParams()
+	return tparamsSlice(named.TParams())
+}
+
+func tparamsSlice(tparams *types.TypeParams) []*types.TypeName {
+	if tparams.Len() == 0 {
+		return nil
+	}
+	result := make([]*types.TypeName, tparams.Len())
+	for i := 0; i < tparams.Len(); i++ {
+		result[i] = tparams.At(i)
+	}
+	return result
 }
 
 // NamedTArgs extracts the (possibly empty) type argument list from named.

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
-	golang.org/x/tools v0.1.6-0.20210802212211-3395cb03f1be
-	golang.org/x/tools/gopls v0.0.0-20210802212211-3395cb03f1be
+	golang.org/x/tools v0.1.6-0.20210810003850-7bc3c281e1f3
+	golang.org/x/tools/gopls v0.0.0-20210810003850-7bc3c281e1f3
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -80,10 +80,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.6-0.20210802212211-3395cb03f1be h1:6/XhjIsqo3NebJDer/aZ0sZfAd+vLhtVKXO0kvBkW+A=
-golang.org/x/tools v0.1.6-0.20210802212211-3395cb03f1be/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools/gopls v0.0.0-20210802212211-3395cb03f1be h1:EBpv9ecTFohN8yh1xU52yOw1xSwjocj5nr9bli6KMlA=
-golang.org/x/tools/gopls v0.0.0-20210802212211-3395cb03f1be/go.mod h1:ekCtf0GOS1JSF+KM46LZvJUyEsyKfFZOfcytlR7aBfg=
+golang.org/x/tools v0.1.6-0.20210810003850-7bc3c281e1f3 h1:FFwHmGqGqrlMDc3uJqn/ukBNjDpTJp+barRLSByXSXM=
+golang.org/x/tools v0.1.6-0.20210810003850-7bc3c281e1f3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools/gopls v0.0.0-20210810003850-7bc3c281e1f3 h1:CGrP9OO8CCNyZv0/TQfihKB/5FPJN0u/CY2QX84nBf4=
+golang.org/x/tools/gopls v0.0.0-20210810003850-7bc3c281e1f3/go.mod h1:ekCtf0GOS1JSF+KM46LZvJUyEsyKfFZOfcytlR7aBfg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/lsp/source: fix race in workspace symbols with multiple views 7bc3c281
* go/analysis/passes/asmdecl: support in-register result in ABIInternal 337cebd2
* internal/lsp/source: parallelize workspace symbols fcc905b2
* internal/lsp/source: don't build low scoring workspace symbols 28b26823
* internal/lsp/source: offer the fast fuzzy matcher as an option f35d7dcc
* internal/lsp/fuzzy: add a new fuzzy matcher optimized for Go symbols bfe69c31
* internal/lsp: update the fuzzy matcher to operate on chunks 15eebf7e
* internal/lsp/source: change symbol matcherFuncs to accept chunks 0d28b7d7
* internal/lsp: precompute workspace symbols 0f3931c7
* internal/lsp/source: use match indexes to compute dynamic symbols 48691842
* internal/lsp/cache: parse files with ParseFull mode to check if metadata reload is required d529aec5
* go/callgraph/vta: not panic on the SliceToArrayPointer instruction f367f012
* gopls/internal/regtest: fix the workspace symbols benchmark f68a40bc
* internal/lsp/lsprpc: fix returning connection error on disconnect 309db044
* internal/lsp/protocol: bring LSP protocol up to date 2f64839e
* internal/span: fix a comment about windows drive letters 32c652e3
* internal/lsp/cache: clarify an error message about mismatching casing 7a2ec097
* internal/lsp/template: improve error and quote handling 594b3a2b
* internal/typeparams: update x/tools for recent typeparams changes 32281604