### PR TITLE
plugin/govim: drop .log suffix on vim channel log

### DIFF
--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -31,7 +31,6 @@ if index(split(system("echo -n ${GOVIM_LOG-on}"), ","), "on") >= 0
   if s:filetmpl == ""
     let s:filetmpl = "%v_%v_%v"
   endif
-  let s:filetmpl .= ".log"
   let s:filetmpl = substitute(s:filetmpl, "%v", "vim_channel", "")
   let s:filetmpl = substitute(s:filetmpl, "%v", strftime("%Y%m%d_%H%M_%S"), "")
   if s:filetmpl =~ "%v"


### PR DESCRIPTION
Some flavors of "mktemp", at least macOS and possibly OpenBSD) require
that the template ends with X's (instead of just having them anywhere in
the template). On macOS they won't be converted to a random number at
all.

This change drops the .log extension from the vim channel log. We could
have run mktemp in "dry-run" mode to just generate a file name, but that
actually creates and removes the file on macOS. That introduces a race
that makes it fairly easy for other users on the same system to "hijack"
the logfile.