### PR TITLE
cmd/govim: support multi-lined diagnostics in hover

### DIFF
--- a/cmd/govim/hover.go
+++ b/cmd/govim/hover.go
@@ -94,7 +94,13 @@ func (v *vimstate) showHover(posExpr string, opts map[string]interface{}, userOp
 			if (b.Num != d.Buf) || !pos.IsWithin(d.Range) {
 				continue
 			}
-			lines = append(lines, formatPopupline(d.Text, d.Source, d.Severity))
+			for i, l := range strings.Split(d.Text, "\n") {
+				if i == 0 {
+					lines = append(lines, formatPopupline(l, d.Source, d.Severity))
+					continue
+				}
+				lines = append(lines, formatPopupline(l, "", d.Severity))
+			}
 		}
 	}
 	msg, err := v.hoverMsgAt(pos, b.ToTextDocumentIdentifier())


### PR DESCRIPTION
Type parameter support in gotip has a few diagnostics that is
multi-lined. We now properly show them in hover popups as multiple
lines, and appends the source to the first line only.