### PR TITLE
deps: update x/tools and gopls to bcc6fa83

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/analysis/infertypeargs/run_go118.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/analysis/infertypeargs/run_go118.go
@@ -74,22 +74,23 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 		if required < len(ix.Indices) {
 			var start, end token.Pos
+			var edit analysis.TextEdit
 			if required == 0 {
 				start, end = ix.Lbrack, ix.Rbrack+1 // erase the entire index
+				edit = analysis.TextEdit{Pos: start, End: end}
 			} else {
-				start = ix.Indices[required-1].End()
+				start = ix.Indices[required].Pos()
 				end = ix.Rbrack
+				//  erase from end of last arg to include last comma & white-spaces
+				edit = analysis.TextEdit{Pos: ix.Indices[required-1].End(), End: end}
 			}
 			pass.Report(analysis.Diagnostic{
 				Pos:     start,
 				End:     end,
 				Message: "unnecessary type arguments",
 				SuggestedFixes: []analysis.SuggestedFix{{
-					Message: "simplify type arguments",
-					TextEdits: []analysis.TextEdit{{
-						Pos: start,
-						End: end,
-					}},
+					Message:   "simplify type arguments",
+					TextEdits: []analysis.TextEdit{edit},
 				}},
 			})
 		}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/session.go
@@ -159,6 +159,11 @@ func (s *Session) Cache() interface{} {
 func (s *Session) NewView(ctx context.Context, name string, folder, tempWorkspace span.URI, options *source.Options) (source.View, source.Snapshot, func(), error) {
 	s.viewMu.Lock()
 	defer s.viewMu.Unlock()
+	for _, view := range s.views {
+		if span.CompareURI(view.folder, folder) == 0 {
+			return nil, nil, nil, source.ErrViewExists
+		}
+	}
 	view, snapshot, release, err := s.createView(ctx, name, folder, tempWorkspace, options, 0)
 	if err != nil {
 		return nil, nil, func() {}, err

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
@@ -159,10 +159,15 @@ func (s *snapshot) ModFiles() []span.URI {
 }
 
 func (s *snapshot) Templates() map[span.URI]source.VersionedFileHandle {
-	if !s.view.options.ExperimentalTemplateSupport {
+	if !s.view.Options().ExperimentalTemplateSupport {
 		return nil
 	}
+
 	ans := map[span.URI]source.VersionedFileHandle{}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	for k, x := range s.files {
 		if strings.HasSuffix(filepath.Ext(k.Filename()), "tmpl") {
 			ans[k] = x

--- a/cmd/govim/internal/golang_org_x_tools/lsp/general.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/general.go
@@ -232,6 +232,9 @@ func (s *Server) addFolders(ctx context.Context, folders []protocol.WorkspaceFol
 		}
 		work := s.progress.Start(ctx, "Setting up workspace", "Loading packages...", nil, nil)
 		snapshot, release, err := s.addView(ctx, folder.Name, uri)
+		if err == source.ErrViewExists {
+			continue
+		}
 		if err != nil {
 			viewErrors[uri] = err
 			work.End(fmt.Sprintf("Error loading packages: %s", err))

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/view.go
@@ -373,6 +373,8 @@ type Session interface {
 	SetProgressTracker(tracker *progress.Tracker)
 }
 
+var ErrViewExists = errors.New("view already exists for session")
+
 // Overlay is the type for a file held in memory on a session.
 type Overlay interface {
 	VersionedFileHandle

--- a/cmd/govim/internal/golang_org_x_tools/lsp/tests/util.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/tests/util.go
@@ -551,3 +551,22 @@ func Diff(t *testing.T, want, got string) string {
 	}
 	return fmt.Sprintf("%q", diff.ToUnified("want", "got", want, d))
 }
+
+// StripSubscripts removes type parameter id subscripts.
+//
+// TODO(rfindley): remove this function once subscripts are removed from the
+// type parameter type string.
+func StripSubscripts(s string) string {
+	var runes []rune
+	for _, r := range s {
+		// For debugging/uniqueness purposes, TypeString on a type parameter adds a
+		// subscript corresponding to the type parameter's unique id. This is going
+		// to be removed, but in the meantime we skip the subscript runes to get a
+		// deterministic output.
+		if '₀' <= r && r < '₀'+10 {
+			continue // trim type parameter subscripts
+		}
+		runes = append(runes, r)
+	}
+	return string(runes)
+}

--- a/cmd/govim/internal/golang_org_x_tools/testenv/testenv.go
+++ b/cmd/govim/internal/golang_org_x_tools/testenv/testenv.go
@@ -297,9 +297,3 @@ func SkipAfterGo1Point(t Testing, x int) {
 		t.Skipf("running Go version %q is version 1.%d, newer than maximum 1.%d", runtime.Version(), Go1Point(), x)
 	}
 }
-
-// UsesGenerics reports if the standard library package stdlibPkg uses
-// generics.
-func UsesGenerics(stdlibPkg string) bool {
-	return stdlibPkg == "constraints"
-}

--- a/cmd/govim/internal/golang_org_x_tools/typeparams/genericfeatures/features.go
+++ b/cmd/govim/internal/golang_org_x_tools/typeparams/genericfeatures/features.go
@@ -1,0 +1,105 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The genericfeatures package provides utilities for detecting usage of
+// generic programming in Go packages.
+package genericfeatures
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/ast/inspector"
+	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/typeparams"
+)
+
+// Features is a set of flags reporting which features of generic Go code a
+// package uses, or 0.
+type Features int
+
+const (
+	// GenericTypeDecls indicates whether the package declares types with type
+	// parameters.
+	GenericTypeDecls Features = 1 << iota
+
+	// GenericFuncDecls indicates whether the package declares functions with
+	// type parameters.
+	GenericFuncDecls
+
+	// EmbeddedTypeSets indicates whether the package declares interfaces that
+	// contain structural type restrictions, i.e. are not fully described by
+	// their method sets.
+	EmbeddedTypeSets
+
+	// TypeInstantiation indicates whether the package instantiates any generic
+	// types.
+	TypeInstantiation
+
+	// FuncInstantiation indicates whether the package instantiates any generic
+	// functions.
+	FuncInstantiation
+)
+
+func (f Features) String() string {
+	var feats []string
+	if f&GenericTypeDecls != 0 {
+		feats = append(feats, "typeDecl")
+	}
+	if f&GenericFuncDecls != 0 {
+		feats = append(feats, "funcDecl")
+	}
+	if f&EmbeddedTypeSets != 0 {
+		feats = append(feats, "typeSet")
+	}
+	if f&TypeInstantiation != 0 {
+		feats = append(feats, "typeInstance")
+	}
+	if f&FuncInstantiation != 0 {
+		feats = append(feats, "funcInstance")
+	}
+	return "features{" + strings.Join(feats, ",") + "}"
+}
+
+// ForPackage computes which generic features are used directly by the
+// package being analyzed.
+func ForPackage(inspect *inspector.Inspector, info *types.Info) Features {
+	nodeFilter := []ast.Node{
+		(*ast.FuncType)(nil),
+		(*ast.InterfaceType)(nil),
+		(*ast.ImportSpec)(nil),
+		(*ast.TypeSpec)(nil),
+	}
+
+	var direct Features
+
+	inspect.Preorder(nodeFilter, func(node ast.Node) {
+		switch n := node.(type) {
+		case *ast.FuncType:
+			if tparams := typeparams.ForFuncType(n); tparams != nil {
+				direct |= GenericFuncDecls
+			}
+		case *ast.InterfaceType:
+			tv := info.Types[n]
+			if iface, _ := tv.Type.(*types.Interface); iface != nil && !typeparams.IsMethodSet(iface) {
+				direct |= EmbeddedTypeSets
+			}
+		case *ast.TypeSpec:
+			if tparams := typeparams.ForTypeSpec(n); tparams != nil {
+				direct |= GenericTypeDecls
+			}
+		}
+	})
+
+	instances := typeparams.GetInstances(info)
+	for _, inst := range instances {
+		switch inst.Type.(type) {
+		case *types.Named:
+			direct |= TypeInstantiation
+		case *types.Signature:
+			direct |= FuncInstantiation
+		}
+	}
+	return direct
+}

--- a/cmd/govim/internal/golang_org_x_tools/typeparams/typeparams_go117.go
+++ b/cmd/govim/internal/golang_org_x_tools/typeparams/typeparams_go117.go
@@ -137,6 +137,10 @@ func IsImplicit(*types.Interface) bool {
 	return false
 }
 
+// MarkImplicit does nothing, because this Go version does not have implicit
+// interfaces.
+func MarkImplicit(*types.Interface) {}
+
 // ForNamed returns an empty type parameter list, as type parameters are not
 // supported at this Go version.
 func ForNamed(*types.Named) *TypeParamList {

--- a/cmd/govim/internal/golang_org_x_tools/typeparams/typeparams_go118.go
+++ b/cmd/govim/internal/golang_org_x_tools/typeparams/typeparams_go118.go
@@ -130,6 +130,11 @@ func IsImplicit(iface *types.Interface) bool {
 	return iface.IsImplicit()
 }
 
+// MarkImplicit calls iface.MarkImplicit().
+func MarkImplicit(iface *types.Interface) {
+	iface.MarkImplicit()
+}
+
 // ForNamed extracts the (possibly empty) type parameter object list from
 // named.
 func ForNamed(named *types.Named) *TypeParamList {

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e
 	golang.org/x/text v0.3.7
-	golang.org/x/tools v0.1.8-0.20211015140901-98f6e0395b11
-	golang.org/x/tools/gopls v0.0.0-20211015140901-98f6e0395b11
+	golang.org/x/tools v0.1.8-0.20211025203635-bcc6fa839da5
+	golang.org/x/tools/gopls v0.0.0-20211025203635-bcc6fa839da5
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -91,10 +91,10 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.8-0.20211015140901-98f6e0395b11 h1:tH6DicuZbyfFY5UhxRxZP2ksWtFE8XLpoJX+YFzBIUI=
-golang.org/x/tools v0.1.8-0.20211015140901-98f6e0395b11/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
-golang.org/x/tools/gopls v0.0.0-20211015140901-98f6e0395b11 h1:6bmYt+2wZ6DzkRtpVZV8V4lpUTkWYsqqYTgOaY/re04=
-golang.org/x/tools/gopls v0.0.0-20211015140901-98f6e0395b11/go.mod h1:bDNcINisaBKgmiRTIThPZfiapVukxTB0gXqpSHRfhRc=
+golang.org/x/tools v0.1.8-0.20211025203635-bcc6fa839da5 h1:wqMDJRUUKQCBjGdhRXtMVmWPLqjlTxBirbdwYDW0QvI=
+golang.org/x/tools v0.1.8-0.20211025203635-bcc6fa839da5/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
+golang.org/x/tools/gopls v0.0.0-20211025203635-bcc6fa839da5 h1:+Y+JVhs4h2KI+gKqhkRE3fRS095f94wSpeeaqcTyCU8=
+golang.org/x/tools/gopls v0.0.0-20211025203635-bcc6fa839da5/go.mod h1:bDNcINisaBKgmiRTIThPZfiapVukxTB0gXqpSHRfhRc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* internal/typeparams: guard against generics in stdlib tests bcc6fa83
* go/internal/gcimporter: stub support importing/exporting constant kind fc8b4cae
* go/internal/gcimporter: add support for the Go 1.18 export data version 18096c5a
* internal/lsp: temporarily strip subscripts from generic hover affba500
* go/packages/packagestest: skip nested module directories in copying 316ba0b7
* internal/lsp: adjust extract function range if block statement 6f2254e6
* go/gcexportdata: limit reader to the export data section of the archive baf4e38f
* go/analysis/passes/deepequalerrors: add typeparams test 4100dac8
* gopls/doc: remove bad gopls cli link 9b675d04
* go/internal/gcimporter: avoid setting unnecessary lines in fakeFileSet cbf1d01b
* internal/lsp: don't add multiple views for the same folder 4ea6123e
* go/internal/gcimporter: remove support for type parameters subscripts 81f084ed
* gopls: update generics instructions to mention go.mod go directive 3a9f3903
* internal/lsp: fix data race in Templates code 9f721e8f
* internal/lsp/analysis/infertypeargs: reduce diagnostic range 1feb6830