### PR TITLE
testdriver: add support for setting window height in vim during tests

### DIFF
--- a/cmd/govim/main_test.go
+++ b/cmd/govim/main_test.go
@@ -33,9 +33,7 @@ const (
 	EnvInstallScripts = "GOVIM_RUN_INSTALL_TESTSCRIPTS"
 )
 
-var (
-	fGoplsPath = flag.String("gopls", "", "Path to the gopls binary for use in scenario tests. If unset, gopls is built from a tagged version.")
-)
+var fGoplsPath = flag.String("gopls", "", "Path to the gopls binary for use in scenario tests. If unset, gopls is built from a tagged version.")
 
 func init() {
 	exposeTestAPI = true

--- a/cmd/govim/testdata/scenario_bufferlifecycle/window_height_large_buffer.txt
+++ b/cmd/govim/testdata/scenario_bufferlifecycle/window_height_large_buffer.txt
@@ -1,0 +1,35 @@
+# Test that pty window height can be set to a smaller value than the loaded file
+
+vim ex 'e foo.txt'
+
+# Window height
+vim expr 'winheight(0)'
+stdout '^10$'
+! stderr .+
+
+# Last visible line in window
+vim expr 'line(\"w$\")'
+stdout '^10$'
+! stderr .+
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- foo.txt --
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+-- vim_config.json --
+{
+        "WindowHeight": 10
+}

--- a/cmd/govim/testdata/scenario_bufferlifecycle/window_height_small_buffer.txt
+++ b/cmd/govim/testdata/scenario_bufferlifecycle/window_height_small_buffer.txt
@@ -1,0 +1,35 @@
+# Test that pty window height can be set to a larger value than the loaded file
+
+vim ex 'e foo.txt'
+
+# Window height
+vim expr 'winheight(0)'
+stdout '^20$'
+! stderr .+
+
+# Last visible line in window
+vim expr 'line(\"w$\")'
+stdout '^12$'
+! stderr .+
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- foo.txt --
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+-- vim_config.json --
+{
+        "WindowHeight": 20
+}


### PR DESCRIPTION
This is a preparation change for semantic token support. Semantic token
support intends to use the visible area in vim to be able to limit
ranged calls to the visible parts of a buffer. Testing this will require
that we can control the window size in vim.