### PR TITLE
deps: update x/tools and gopls to 1e71a25a

### DIFF
--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/snapshot.go
@@ -159,7 +159,7 @@ func (s *snapshot) ModFiles() []span.URI {
 }
 
 func (s *snapshot) Templates() map[span.URI]source.VersionedFileHandle {
-	if !s.view.Options().TemplateSupport {
+	if len(s.view.Options().TemplateExtensions) == 0 {
 		return nil
 	}
 
@@ -2290,7 +2290,8 @@ func buildWorkspaceModFile(ctx context.Context, modFiles map[span.URI]struct{}, 
 		if file == nil || parsed.Module == nil {
 			return nil, fmt.Errorf("no module declaration for %s", modURI)
 		}
-		if parsed.Go != nil && semver.Compare(goVersion, parsed.Go.Version) < 0 {
+		// Prepend "v" to go versions to make them valid semver.
+		if parsed.Go != nil && semver.Compare("v"+goVersion, "v"+parsed.Go.Version) < 0 {
 			goVersion = parsed.Go.Version
 		}
 		path := parsed.Module.Mod.Path

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
@@ -347,7 +347,7 @@ func fileHasExtension(path string, suffixes []string) bool {
 }
 
 func (s *snapshot) locateTemplateFiles(ctx context.Context) {
-	if !s.view.Options().TemplateSupport {
+	if len(s.view.Options().TemplateExtensions) == 0 {
 		return
 	}
 	suffixes := s.view.Options().TemplateExtensions

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -45,19 +45,6 @@ var GeneratedAPIJSON = &APIJSON{
 				Hierarchy:  "build",
 			},
 			{
-				Name: "templateSupport",
-				Type: "bool",
-				Doc:  "templateSupport can be used to turn off support for template files.\n",
-				EnumKeys: EnumKeys{
-					ValueType: "",
-					Keys:      nil,
-				},
-				EnumValues: nil,
-				Default:    "true",
-				Status:     "",
-				Hierarchy:  "build",
-			},
-			{
 				Name: "templateExtensions",
 				Type: "[]string",
 				Doc:  "templateExtensions gives the extensions of file names that are treateed\nas template files. (The extension\nis the part of the file name after the final dot.)\n",

--- a/cmd/govim/internal/golang_org_x_tools/lsp/template/implementations.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/template/implementations.go
@@ -66,7 +66,7 @@ func Diagnose(f source.VersionedFileHandle) []*source.Diagnostic {
 }
 
 func skipTemplates(s source.Snapshot) bool {
-	return !s.View().Options().TemplateSupport
+	return len(s.View().Options().TemplateExtensions) == 0
 }
 
 // Definition finds the definitions of the symbol at loc. It

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
 	golang.org/x/text v0.3.7
-	golang.org/x/tools v0.1.8-0.20211117191604-43b469a3a904
-	golang.org/x/tools/gopls v0.0.0-20211117191604-43b469a3a904
+	golang.org/x/tools v0.1.8-0.20211123163920-1e71a25a932d
+	golang.org/x/tools/gopls v0.0.0-20211123163920-1e71a25a932d
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -91,10 +91,10 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
-golang.org/x/tools v0.1.8-0.20211117191604-43b469a3a904 h1:s4emb63QTWCDcsTNcv1ZfWk11YDGoqlqbeFQMyt/OZQ=
-golang.org/x/tools v0.1.8-0.20211117191604-43b469a3a904/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
-golang.org/x/tools/gopls v0.0.0-20211117191604-43b469a3a904 h1:2mMIRPUSmSWwlfl27H2DDJWbXgcBjsLds9oTtJoKHrs=
-golang.org/x/tools/gopls v0.0.0-20211117191604-43b469a3a904/go.mod h1:HuW2ffRPosfZynRszmhhhUXcUtH35UKt9AvsJcLrj60=
+golang.org/x/tools v0.1.8-0.20211123163920-1e71a25a932d h1:dzN8FXPYPGj4r8qosdd+dmYx7KXVyd+SiTj/jzoTo5Y=
+golang.org/x/tools v0.1.8-0.20211123163920-1e71a25a932d/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/tools/gopls v0.0.0-20211123163920-1e71a25a932d h1:xofARez8qcuVy8HKq5fzHP3gGzGRZLhO4h39J+HwbN0=
+golang.org/x/tools/gopls v0.0.0-20211123163920-1e71a25a932d/go.mod h1:HuW2ffRPosfZynRszmhhhUXcUtH35UKt9AvsJcLrj60=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
* gopls:  template suffix flags and documentation 1e71a25a
* go/callgraph/vta/internal/trie: fix build with go1.12 c2c92fd2
* internal/lsp/cache: fix resolution of the go directive in multi-module workspaces d0c72119