### PR TITLE
cmd/govim: Support setting gopls memory mode

### DIFF
--- a/autoload/govim/config.vim
+++ b/autoload/govim/config.vim
@@ -206,6 +206,14 @@ function! s:validExperimentalWorkspaceModule(v)
   return s:validBool(a:v)
 endfunction
 
+function! s:validExperimentalGoplsMemoryMode(v)
+  let valid = ["Normal", "DegradeClosed"]
+  if index(valid, a:v) < 0
+    return [v:false, "must be one of: ".string(valid)]
+  endif
+  return [v:true, ""]
+endfunction
+
 let s:validators = {
       \ "FormatOnSave": function("s:validFormatOnSave"),
       \ "QuickfixAutoDiagnostics": function("s:validQuickfixAutoDiagnostics"),
@@ -234,4 +242,5 @@ let s:validators = {
       \ "ExperimentalProgressPopups": function("s:validExperimentalProgressPopups"),
       \ "ExperimentalAllowModfileModifications": function("s:validExperimentalProgressPopups"),
       \ "ExperimentalWorkspaceModule": function("s:validExperimentalWorkspaceModule"),
+      \ "ExperimentalGoplsMemoryMode": function("s:validExperimentalGoplsMemoryMode"),
       \ }

--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -325,6 +325,24 @@ type Config struct {
 	// ExperimentalWorkspaceModule opts a user into the experimental gopls
 	// support for multi-module workspaces
 	ExperimentalWorkspaceModule *bool `json:",omitempty"`
+
+	// ExperimentalGoplsMemoryMode is used to configures gopls experimental
+	// feature "memoryMode". As of gopls v0.7.3 there are two options:
+	//
+	// * "Normal"        - default
+	// * "DegradeClosed" - gopls will collect less information about packages
+	//                     without open files. As a result, features like
+	//                     Find References and Rename will miss results in
+	//                     such packages.
+	//
+	// For details see:
+	// https://github.com/golang/tools/blob/master/gopls/doc/settings.md#memorymode-enum
+	//
+	// Note that this is an experimental feature in gopls that might go away
+	// in the future.
+	//
+	// Default: "Normal"
+	ExperimentalGoplsMemoryMode *GoplsMemoryMode `json:",omitempty"`
 }
 
 type Command string
@@ -549,6 +567,20 @@ const (
 	// SymbolStyleDynamic specifies that gopls should dynamic name-qualify
 	// workspace symbol candidates
 	SymbolStyleDynamic SymbolStyle = "dynamic"
+)
+
+// GoplsMemoryMode typed constants defined the set of valid values that
+// Config.GoplsMemoryMode can take
+type GoplsMemoryMode string
+
+const (
+	// GoplsMemoryModeNormal specifies that gopls should use the default
+	// memory model setting
+	GoplsMemoryModeNormal GoplsMemoryMode = "Normal"
+
+	// GoplsMemoryModeDegradeClosed specifies that gopls should use
+	// a degraded mode for packages without any open files
+	GoplsMemoryModeDegradeClosed GoplsMemoryMode = "DegradeClosed"
 )
 
 // Highlight typed constants define the different highlight groups used by govim.

--- a/cmd/govim/config/gen_applygen.go
+++ b/cmd/govim/config/gen_applygen.go
@@ -82,4 +82,7 @@ func (r *Config) Apply(v *Config) {
 	if v.ExperimentalWorkspaceModule != nil {
 		r.ExperimentalWorkspaceModule = v.ExperimentalWorkspaceModule
 	}
+	if v.ExperimentalGoplsMemoryMode != nil {
+		r.ExperimentalGoplsMemoryMode = v.ExperimentalGoplsMemoryMode
+	}
 }

--- a/cmd/govim/gopls_client.go
+++ b/cmd/govim/gopls_client.go
@@ -36,6 +36,7 @@ const (
 	goplsGofumpt                     = "gofumpt"
 	goplsExperimentalWorkspaceModule = "experimentalWorkspaceModule"
 	goplsDirectoryFilters            = "directoryFilters"
+	goplsMemoryMode                  = "memoryMode"
 )
 
 var _ protocol.Client = (*govimplugin)(nil)
@@ -180,6 +181,9 @@ func (g *govimplugin) Configuration(ctxt context.Context, params *protocol.Param
 	}
 	if conf.ExperimentalWorkspaceModule != nil {
 		goplsConfig[goplsExperimentalWorkspaceModule] = *conf.ExperimentalWorkspaceModule
+	}
+	if conf.ExperimentalGoplsMemoryMode != nil {
+		goplsConfig[goplsMemoryMode] = *conf.ExperimentalGoplsMemoryMode
 	}
 	if os.Getenv(string(config.EnvVarGoplsVerbose)) == "true" {
 		goplsConfig[goplsVerboseOutput] = true

--- a/cmd/govim/internal/vimconfig/vimconfig.go
+++ b/cmd/govim/internal/vimconfig/vimconfig.go
@@ -34,6 +34,7 @@ type VimConfig struct {
 	ExperimentalProgressPopups                   *int
 	ExperimentalAllowModfileModifications        *int
 	ExperimentalWorkspaceModule                  *int
+	ExperimentalGoplsMemoryMode                  *config.GoplsMemoryMode
 }
 
 func (c *VimConfig) ToConfig(d config.Config) config.Config {
@@ -65,6 +66,7 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 		ExperimentalProgressPopups:                   boolVal(c.ExperimentalProgressPopups, d.ExperimentalProgressPopups),
 		ExperimentalAllowModfileModifications:        boolVal(c.ExperimentalAllowModfileModifications, d.ExperimentalAllowModfileModifications),
 		ExperimentalWorkspaceModule:                  boolVal(c.ExperimentalWorkspaceModule, d.ExperimentalWorkspaceModule),
+		ExperimentalGoplsMemoryMode:                  c.ExperimentalGoplsMemoryMode,
 	}
 	if v.FormatOnSave == nil {
 		v.FormatOnSave = d.FormatOnSave
@@ -77,6 +79,9 @@ func (c *VimConfig) ToConfig(d config.Config) config.Config {
 	}
 	if v.SymbolStyle == nil {
 		v.SymbolStyle = d.SymbolStyle
+	}
+	if v.ExperimentalGoplsMemoryMode == nil {
+		v.ExperimentalGoplsMemoryMode = d.ExperimentalGoplsMemoryMode
 	}
 	return v
 }

--- a/cmd/govim/testdata/scenario_goplsmemmode_degradeclosed/rename.txt
+++ b/cmd/govim/testdata/scenario_goplsmemmode_degradeclosed/rename.txt
@@ -1,0 +1,66 @@
+# Test that "degradeClosed" memory mode works by renaming a identifier
+# used in another package with no open files (in a non exported context).
+#
+# The test isn't foolproof since there is no fixed rules of how gopls
+# should degrade. It acts as a canary for detecting changes that breaks
+# the ability to set memory mode.
+
+# Rename a const in package a that is used by both b and c, without opening package c
+vim ex 'e b/b.go'
+vim ex 'call cursor(6,8)'
+vim ex 'call execute(\"GOVIMRename Foo\")'
+vim ex 'silent noautocmd wall'
+cmp a/a.go a.go.Foo
+cmp b/b.go b.go.Foo
+
+# Ensure that package c wasn't updated since it didn't have any open files
+cmp c/c.go c.go.orginal
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.12
+-- a/a.go --
+package a
+
+const Aa = 1
+-- b/b.go --
+package b
+
+import "mod.com/a"
+
+func bb() {
+	_ = a.Aa
+}
+-- c/c.go --
+package c
+
+import "mod.com/a"
+
+func cc() {
+	_ = a.Aa
+}
+-- a.go.Foo --
+package a
+
+const Foo = 1
+-- b.go.Foo --
+package b
+
+import "mod.com/a"
+
+func bb() {
+	_ = a.Foo
+}
+-- c.go.orginal --
+package c
+
+import "mod.com/a"
+
+func cc() {
+	_ = a.Aa
+}

--- a/cmd/govim/testdata/scenario_goplsmemmode_degradeclosed/user_config.json
+++ b/cmd/govim/testdata/scenario_goplsmemmode_degradeclosed/user_config.json
@@ -1,0 +1,3 @@
+{
+	"ExperimentalGoplsMemoryMode": "DegradeClosed"
+}


### PR DESCRIPTION
In gopls there is an experimental feature that can be used to reduce the
memory footprint by degrade features in packages without any open files.
This can be useful in large single-moduled mono repos that otherwise
consume lots of resources.

We support the both modes defined in gopls, "Normal" and "DegradeClosed"
where "Normal" is the default behaviour. To use "DegradeClosed" add a
line to your .vimrc:

```
call govim#config#Set("ExperimentalGoplsMemoryMode","DegradeClosed")
```