### PR TITLE
deps: update x/tools and gopls to c882a49eac7c

### DIFF
--- a/cmd/govim/gopls_server.go
+++ b/cmd/govim/gopls_server.go
@@ -489,3 +489,24 @@ func (l loggingGoplsServer) Supertypes(ctxt context.Context, params *protocol.Ty
 	l.Logf("gopls.Supertypes() return; err: %v; res\n%v", err, pretty.Sprint(res))
 	return res, err
 }
+
+func (l loggingGoplsServer) InlineValues(ctxt context.Context, params *protocol.InlineValuesParams) ([]protocol.InlineValue, error) {
+	l.Logf("gopls.InlineValues() call; params:\n", pretty.Sprint(params))
+	res, err := l.u.InlineValues(ctxt, params)
+	l.Logf("gopls.InlineValues() return; err: %v; res:\n%v", err, pretty.Sprint(res))
+	return res, err
+}
+
+func (l loggingGoplsServer) InlineValuesRefresh(ctxt context.Context) error {
+	l.Logf("gopls.InlineValuesRefresh() call")
+	err := l.u.InlineValuesRefresh(ctxt)
+	l.Logf("gopls.InlineValues() return; err: %v", err)
+	return err
+}
+
+func (l loggingGoplsServer) ResolveWorkspaceSymbol(ctxt context.Context, params *protocol.WorkspaceSymbol) (*protocol.WorkspaceSymbol, error) {
+	l.Logf("gopls.ResolveWorkspaceSymbol() call; params:\n", pretty.Sprint(params))
+	res, err := l.u.ResolveWorkspaceSymbol(ctxt, params)
+	l.Logf("gopls.ResolveWorkspaceSymbol() return; err: %v; res:\n%v", err, pretty.Sprint(res))
+	return res, err
+}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/analysis/fillreturns/fillreturns.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/analysis/fillreturns/fillreturns.go
@@ -14,7 +14,6 @@ import (
 	"go/format"
 	"go/types"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
@@ -23,7 +22,7 @@ import (
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/typeparams"
 )
 
-const Doc = `suggested fixes for "wrong number of return values (want %d, got %d)"
+const Doc = `suggest fixes for errors due to an incorrect number of return values
 
 This checker provides suggested fixes for type errors of the
 type "wrong number of return values (want %d, got %d)". For example:
@@ -46,8 +45,6 @@ var Analyzer = &analysis.Analyzer{
 	RunDespiteErrors: true,
 }
 
-var wrongReturnNumRegex = regexp.MustCompile(`wrong number of return values \(want (\d+), got (\d+)\)`)
-
 func run(pass *analysis.Pass) (interface{}, error) {
 	info := pass.TypesInfo
 	if info == nil {
@@ -58,7 +55,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 outer:
 	for _, typeErr := range errors {
 		// Filter out the errors that are not relevant to this analyzer.
-		if !FixesError(typeErr.Msg) {
+		if !FixesError(typeErr) {
 			continue
 		}
 		var file *ast.File
@@ -79,20 +76,32 @@ outer:
 		}
 		typeErrEndPos := analysisinternal.TypeErrorEndPos(pass.Fset, buf.Bytes(), typeErr.Pos)
 
+		// TODO(rfindley): much of the error handling code below returns, when it
+		// should probably continue.
+
 		// Get the path for the relevant range.
 		path, _ := astutil.PathEnclosingInterval(file, typeErr.Pos, typeErrEndPos)
 		if len(path) == 0 {
 			return nil, nil
 		}
-		// Check to make sure the node of interest is a ReturnStmt.
-		ret, ok := path[0].(*ast.ReturnStmt)
-		if !ok {
+
+		// Find the enclosing return statement.
+		var ret *ast.ReturnStmt
+		var retIdx int
+		for i, n := range path {
+			if r, ok := n.(*ast.ReturnStmt); ok {
+				ret = r
+				retIdx = i
+				break
+			}
+		}
+		if ret == nil {
 			return nil, nil
 		}
 
 		// Get the function type that encloses the ReturnStmt.
 		var enclosingFunc *ast.FuncType
-		for _, n := range path {
+		for _, n := range path[retIdx+1:] {
 			switch node := n.(type) {
 			case *ast.FuncLit:
 				enclosingFunc = node.Type
@@ -109,7 +118,7 @@ outer:
 
 		// Skip any generic enclosing functions, since type parameters don't
 		// have 0 values.
-		// TODO(rstambler): We should be able to handle this if the return
+		// TODO(rfindley): We should be able to handle this if the return
 		// values are all concrete types.
 		if tparams := typeparams.ForFuncType(enclosingFunc); tparams != nil && tparams.NumFields() > 0 {
 			return nil, nil
@@ -127,7 +136,8 @@ outer:
 			return nil, nil
 		}
 
-		// Skip any return statements that contain function calls with multiple return values.
+		// Skip any return statements that contain function calls with multiple
+		// return values.
 		for _, expr := range ret.Results {
 			e, ok := expr.(*ast.CallExpr)
 			if !ok {
@@ -244,16 +254,23 @@ func matchingTypes(want, got types.Type) bool {
 	return types.AssignableTo(want, got) || types.ConvertibleTo(want, got)
 }
 
-func FixesError(msg string) bool {
-	matches := wrongReturnNumRegex.FindStringSubmatch(strings.TrimSpace(msg))
-	if len(matches) < 3 {
-		return false
+// Error messages have changed across Go versions. These regexps capture recent
+// incarnations.
+//
+// TODO(rfindley): once error codes are exported and exposed via go/packages,
+// use error codes rather than string matching here.
+var wrongReturnNumRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`wrong number of return values \(want (\d+), got (\d+)\)`),
+	regexp.MustCompile(`too many return values`),
+	regexp.MustCompile(`not enough return values`),
+}
+
+func FixesError(err types.Error) bool {
+	msg := strings.TrimSpace(err.Msg)
+	for _, rx := range wrongReturnNumRegexes {
+		if rx.MatchString(msg) {
+			return true
+		}
 	}
-	if _, err := strconv.Atoi(matches[1]); err != nil {
-		return false
-	}
-	if _, err := strconv.Atoi(matches[2]); err != nil {
-		return false
-	}
-	return true
+	return false
 }

--- a/cmd/govim/internal/golang_org_x_tools/lsp/analysis/infertypeargs/infertypeargs.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/analysis/infertypeargs/infertypeargs.go
@@ -16,11 +16,11 @@ const Doc = `check for unnecessary type arguments in call expressions
 Explicit type arguments may be omitted from call expressions if they can be
 inferred from function arguments, or from other type arguments:
 
-func f[T any](T) {}
-
-func _() {
-	f[string]("foo") // string could be inferred
-}
+	func f[T any](T) {}
+	
+	func _() {
+		f[string]("foo") // string could be inferred
+	}
 `
 
 var Analyzer = &analysis.Analyzer{

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/imports.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/imports.go
@@ -138,7 +138,7 @@ func (s *importsState) populateProcessEnv(ctx context.Context, snapshot *snapsho
 
 	// Take an extra reference to the snapshot so that its workspace directory
 	// (if any) isn't destroyed while we're using it.
-	release := snapshot.generation.Acquire(ctx)
+	release := snapshot.generation.Acquire()
 	_, inv, cleanupInvocation, err := snapshot.goCommandInvocation(ctx, source.LoadWorkspace, &gocommand.Invocation{
 		WorkingDir: snapshot.view.rootURI.Filename(),
 	})

--- a/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/cache/view.go
@@ -74,7 +74,7 @@ type View struct {
 	initCancelFirstAttempt context.CancelFunc
 
 	snapshotMu sync.Mutex
-	snapshot   *snapshot
+	snapshot   *snapshot // nil after shutdown has been called
 
 	// initialWorkspaceLoad is closed when the first workspace initialization has
 	// completed. If we failed to load, we only retry if the go.mod file changes,
@@ -505,7 +505,10 @@ func (v *View) shutdown(ctx context.Context) {
 	}
 	v.mu.Unlock()
 	v.snapshotMu.Lock()
-	go v.snapshot.generation.Destroy()
+	if v.snapshot != nil {
+		go v.snapshot.generation.Destroy("View.shutdown")
+		v.snapshot = nil
+	}
 	v.snapshotMu.Unlock()
 	v.importsState.destroy()
 }
@@ -551,13 +554,16 @@ func checkIgnored(suffix string) bool {
 }
 
 func (v *View) Snapshot(ctx context.Context) (source.Snapshot, func()) {
-	return v.getSnapshot(ctx)
+	return v.getSnapshot()
 }
 
-func (v *View) getSnapshot(ctx context.Context) (*snapshot, func()) {
+func (v *View) getSnapshot() (*snapshot, func()) {
 	v.snapshotMu.Lock()
 	defer v.snapshotMu.Unlock()
-	return v.snapshot, v.snapshot.generation.Acquire(ctx)
+	if v.snapshot == nil {
+		panic("getSnapshot called after shutdown")
+	}
+	return v.snapshot, v.snapshot.generation.Acquire()
 }
 
 func (s *snapshot) initialize(ctx context.Context, firstAttempt bool) {
@@ -670,6 +676,9 @@ func (s *snapshot) loadWorkspace(ctx context.Context, firstAttempt bool) {
 
 // invalidateContent invalidates the content of a Go file,
 // including any position and type information that depends on it.
+//
+// invalidateContent returns a non-nil snapshot for the new content, along with
+// a callback which the caller must invoke to release that snapshot.
 func (v *View) invalidateContent(ctx context.Context, changes map[span.URI]*fileChange, forceReloadMetadata bool) (*snapshot, func()) {
 	// Detach the context so that content invalidation cannot be canceled.
 	ctx = xcontext.Detach(ctx)
@@ -677,6 +686,10 @@ func (v *View) invalidateContent(ctx context.Context, changes map[span.URI]*file
 	// This should be the only time we hold the view's snapshot lock for any period of time.
 	v.snapshotMu.Lock()
 	defer v.snapshotMu.Unlock()
+
+	if v.snapshot == nil {
+		panic("invalidateContent called after shutdown")
+	}
 
 	// Cancel all still-running previous requests, since they would be
 	// operating on stale data.
@@ -694,9 +707,9 @@ func (v *View) invalidateContent(ctx context.Context, changes map[span.URI]*file
 			event.Error(ctx, "copying workspace dir", err)
 		}
 	}
-	go oldSnapshot.generation.Destroy()
+	go oldSnapshot.generation.Destroy("View.invalidateContent")
 
-	return v.snapshot, v.snapshot.generation.Acquire(ctx)
+	return v.snapshot, v.snapshot.generation.Acquire()
 }
 
 func (v *View) updateWorkspace(ctx context.Context) error {
@@ -714,7 +727,11 @@ func (v *View) updateWorkspace(ctx context.Context) error {
 // all changes to the workspace module, only that it is eventually consistent
 // with the workspace module of the latest snapshot.
 func (v *View) updateWorkspaceLocked(ctx context.Context) error {
-	release := v.snapshot.generation.Acquire(ctx)
+	if v.snapshot == nil {
+		return errors.New("view is shutting down")
+	}
+
+	release := v.snapshot.generation.Acquire()
 	defer release()
 	src, err := v.snapshot.getWorkspaceDir(ctx)
 	if err != nil {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsclient.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsclient.go
@@ -6,8 +6,8 @@ package protocol
 
 // Package protocol contains data types and code for LSP jsonrpcs
 // generated automatically from vscode-languageserver-node
-// commit: 10b56de150ad67c3c330da8e2df53ebf2cf347c4
-// last fetched Wed Sep 29 2021 12:31:31 GMT-0400 (Eastern Daylight Time)
+// commit: d959faf4be476a6e0a08d5612e91fcac14ff9929
+// last fetched Mon Nov 29 2021 15:51:05 GMT-0500 (Eastern Standard Time)
 
 // Code generated (see typescript/README.md) DO NOT EDIT.
 
@@ -26,7 +26,7 @@ type Client interface {
 	PublishDiagnostics(context.Context, *PublishDiagnosticsParams) error
 	Progress(context.Context, *ProgressParams) error
 	WorkspaceFolders(context.Context) ([]WorkspaceFolder /*WorkspaceFolder[] | null*/, error)
-	Configuration(context.Context, *ParamConfiguration) ([]interface{}, error)
+	Configuration(context.Context, *ParamConfiguration) ([]LSPAny, error)
 	WorkDoneProgressCreate(context.Context, *WorkDoneProgressCreateParams) error
 	ShowDocument(context.Context, *ShowDocumentParams) (*ShowDocumentResult, error)
 	RegisterCapability(context.Context, *RegistrationParams) error
@@ -160,8 +160,8 @@ func (s *clientDispatcher) WorkspaceFolders(ctx context.Context) ([]WorkspaceFol
 	return result, nil
 }
 
-func (s *clientDispatcher) Configuration(ctx context.Context, params *ParamConfiguration) ([]interface{}, error) {
-	var result []interface{}
+func (s *clientDispatcher) Configuration(ctx context.Context, params *ParamConfiguration) ([]LSPAny, error) {
+	var result []LSPAny
 	if err := s.sender.Call(ctx, "workspace/configuration", params, &result); err != nil {
 		return nil, err
 	}

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsprotocol.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/tsprotocol.go
@@ -4,8 +4,8 @@
 
 // Package protocol contains data types and code for LSP jsonrpcs
 // generated automatically from vscode-languageserver-node
-// commit: 10b56de150ad67c3c330da8e2df53ebf2cf347c4
-// last fetched Wed Sep 29 2021 12:31:31 GMT-0400 (Eastern Daylight Time)
+// commit: d959faf4be476a6e0a08d5612e91fcac14ff9929
+// last fetched Wed Dec 01 2021 09:27:34 GMT-0500 (Eastern Standard Time)
 package protocol
 
 // Code generated (see typescript/README.md) DO NOT EDIT.
@@ -145,7 +145,7 @@ type CallHierarchyItem struct {
 	 * A data entry field that is preserved between a call hierarchy prepare and
 	 * incoming calls or outgoing calls requests.
 	 */
-	Data interface{} `json:"data,omitempty"`
+	Data LSPAny `json:"data,omitempty"`
 }
 
 /**
@@ -359,7 +359,7 @@ type CodeAction struct {
 	 *
 	 * @since 3.16.0
 	 */
-	Data interface{} `json:"data,omitempty"`
+	Data LSPAny `json:"data,omitempty"`
 }
 
 /**
@@ -456,6 +456,12 @@ type CodeActionContext struct {
 	 * can omit computing them.
 	 */
 	Only []CodeActionKind `json:"only,omitempty"`
+	/**
+	 * The reason why code actions were requested.
+	 *
+	 * @since 3.17.0
+	 */
+	TriggerKind CodeActionTriggerKind `json:"triggerKind,omitempty"`
 }
 
 /**
@@ -505,6 +511,13 @@ type CodeActionParams struct {
 }
 
 /**
+ * The reason why code actions were requested.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type CodeActionTriggerKind float64
+
+/**
  * Structure to capture a description for an error code.
  *
  * @since 3.16.0
@@ -537,7 +550,7 @@ type CodeLens struct {
 	 * a [CodeLensRequest](#CodeLensRequest) and a [CodeLensResolveRequest]
 	 * (#CodeLensResolveRequest)
 	 */
-	Data interface{} `json:"data,omitempty"`
+	Data LSPAny `json:"data,omitempty"`
 }
 
 /**
@@ -800,7 +813,7 @@ type CompletionClientCapabilities struct {
 	 * when accepting a completion item that uses multi line
 	 * text in either `insertText` or `textEdit`.
 	 *
-	 * @since 3.17.0
+	 * @since 3.17.0 - proposed state
 	 */
 	InsertTextMode InsertTextMode `json:"insertTextMode,omitempty"`
 	/**
@@ -808,6 +821,25 @@ type CompletionClientCapabilities struct {
 	 * `textDocument/completion` request.
 	 */
 	ContextSupport bool `json:"contextSupport,omitempty"`
+	/**
+	 * The client supports the following `CompletionList` specific
+	 * capabilities.
+	 *
+	 * @since 3.17.0 - proposed state
+	 */
+	CompletionList struct {
+		/**
+		 * The client supports the the following itemDefaults on
+		 * a completion list.
+		 *
+		 * The value lists the supported property names of the
+		 * `CompletionList.itemDefaults` object. If omitted
+		 * no properties are supported.
+		 *
+		 * @since 3.17.0 - proposed state
+		 */
+		ItemDefaults []string `json:"itemDefaults,omitempty"`
+	} `json:"completionList,omitempty"`
 }
 
 /**
@@ -908,6 +940,8 @@ type CompletionItem struct {
 	 * The format of the insert text. The format applies to both the `insertText` property
 	 * and the `newText` property of a provided `textEdit`. If omitted defaults to
 	 * `InsertTextFormat.PlainText`.
+	 *
+	 * Please note that the insertTextFormat doesn't apply to `additionalTextEdits`.
 	 */
 	InsertTextFormat InsertTextFormat `json:"insertTextFormat,omitempty"`
 	/**
@@ -963,7 +997,7 @@ type CompletionItem struct {
 	 * A data entry field that is preserved on a completion item between a
 	 * [CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest](#CompletionResolveRequest).
 	 */
-	Data interface{} `json:"data,omitempty"`
+	Data LSPAny `json:"data,omitempty"`
 }
 
 /**
@@ -1006,6 +1040,47 @@ type CompletionList struct {
 	 * This list it not complete. Further typing results in recomputing this list.
 	 */
 	IsIncomplete bool `json:"isIncomplete"`
+	/**
+	 * In many cases the items of an actual completion result share the same
+	 * value for properties like `commitCharacters` or the range of a text
+	 * edit. A completion list can therefore define item defaults which will
+	 * be used if a completion item itself doesn't specify the value.
+	 *
+	 * If a completion list specifies a default value and a completion item
+	 * also specifies a corresponding value the one from the item is used.
+	 *
+	 * Servers are only allowed to return default values if the client
+	 * signals support for this via the `completionList.itemDefaults`
+	 * capability.
+	 *
+	 * @since 3.17.0 - proposed state
+	 */
+	ItemDefaults struct {
+		/**
+		 * A default commit character set.
+		 *
+		 * @since 3.17.0 - proposed state
+		 */
+		CommitCharacters []string `json:"commitCharacters,omitempty"`
+		/**
+		 * A default edit range
+		 *
+		 * @since 3.17.0 - proposed state
+		 */
+		EditRange Range/*Range | { insert: Range; replace: Range; }*/ `json:"editRange,omitempty"`
+		/**
+		 * A default insert text format
+		 *
+		 * @since 3.17.0 - proposed state
+		 */
+		InsertTextFormat InsertTextFormat `json:"insertTextFormat,omitempty"`
+		/**
+		 * A default insert text mode
+		 *
+		 * @since 3.17.0 - proposed state
+		 */
+		InsertTextMode InsertTextMode `json:"insertTextMode,omitempty"`
+	} `json:"itemDefaults,omitempty"`
 	/**
 	 * The completion items.
 	 */
@@ -1323,6 +1398,7 @@ type Diagnostic struct {
 	Code interface{}/*integer | string*/ `json:"code,omitempty"`
 	/**
 	 * An optional property to describe the error code.
+	 * Requires the code field (above) to be present/not null.
 	 *
 	 * @since 3.16.0
 	 */
@@ -1354,7 +1430,7 @@ type Diagnostic struct {
 	 *
 	 * @since 3.16.0
 	 */
-	Data interface{} `json:"data,omitempty"`
+	Data LSPAny `json:"data,omitempty"`
 }
 
 /**
@@ -1399,7 +1475,7 @@ type DidChangeConfigurationParams struct {
 	/**
 	 * The actual changed settings
 	 */
-	Settings interface{} `json:"settings"`
+	Settings LSPAny `json:"settings"`
 }
 
 /**
@@ -1697,7 +1773,7 @@ type DocumentLink struct {
 	 * A data entry field that is preserved on a document link between a
 	 * DocumentLinkRequest and a DocumentLinkResolveRequest.
 	 */
-	Data interface{} `json:"data,omitempty"`
+	Data LSPAny `json:"data,omitempty"`
 }
 
 /**
@@ -1851,7 +1927,7 @@ type DocumentSymbol struct {
 	 */
 	Kind SymbolKind `json:"kind"`
 	/**
-	 * Tags for this completion item.
+	 * Tags for this document symbol.
 	 *
 	 * @since 3.16.0
 	 */
@@ -2378,7 +2454,7 @@ type GeneralClientCapabilities struct {
 		/**
 		 * The list of requests for which the client
 		 * will retry the request if it receives a
-		 * response with error code `ContentModified``
+		 * response with error code `ContentModified`
 		 */
 		RetryOnContentModified []string `json:"retryOnContentModified"`
 	} `json:"staleRequestSupport,omitempty"`
@@ -2530,11 +2606,11 @@ type InitializeParams struct {
 	/**
 	 * User provided initialization options.
 	 */
-	InitializationOptions interface{} `json:"initializationOptions,omitempty"`
+	InitializationOptions LSPAny `json:"initializationOptions,omitempty"`
 	/**
 	 * The initial trace setting. If omitted trace is disabled ('off').
 	 */
-	Trace string/*'off' | 'messages' | 'verbose'*/ `json:"trace,omitempty"`
+	Trace string/* 'off' | 'messages' | 'compact' | 'verbose' */ `json:"trace,omitempty"`
 	/**
 	 * The actual configured workspace folders.
 	 */
@@ -2570,6 +2646,158 @@ type InitializedParams struct {
 }
 
 /**
+ * Inline value information can be provided by different means:
+ * - directly as a text value (class InlineValueText).
+ * - as a name to use for a variable lookup (class InlineValueVariableLookup)
+ * - as an evaluatable expression (class InlineValueEvaluatableExpression)
+ * The InlineValue types combines all inline value types into one type.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValue = interface{} /* InlineValueText | InlineValueVariableLookup | InlineValueEvaluatableExpression*/
+
+/**
+ * Provide an inline value through an expression evaluation.
+ * If only a range is specified, the expression will be extracted from the underlying document.
+ * An optional expression can be used to override the extracted expression.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValueEvaluatableExpression struct {
+	/**
+	 * The document range for which the inline value applies.
+	 * The range is used to extract the evaluatable expression from the underlying document.
+	 */
+	Range Range `json:"range"`
+	/**
+	 * If specified the expression overrides the extracted expression.
+	 */
+	Expression string `json:"expression,omitempty"`
+}
+
+/**
+ * Provide inline value as text.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValueText struct {
+	/**
+	 * The document range for which the inline value applies.
+	 */
+	Range Range `json:"range"`
+	/**
+	 * The text of the inline value.
+	 */
+	Text string `json:"text"`
+}
+
+/**
+ * Provide inline value through a variable lookup.
+ * If only a range is specified, the variable name will be extracted from the underlying document.
+ * An optional variable name can be used to override the extracted name.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValueVariableLookup struct {
+	/**
+	 * The document range for which the inline value applies.
+	 * The range is used to extract the variable name from the underlying document.
+	 */
+	Range Range `json:"range"`
+	/**
+	 * If specified the name of the variable to look up.
+	 */
+	VariableName string `json:"variableName,omitempty"`
+	/**
+	 * How to perform the lookup.
+	 */
+	CaseSensitiveLookup bool `json:"caseSensitiveLookup"`
+}
+
+/**
+ * Client capabilities specific to inline values.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesClientCapabilities struct {
+	/**
+	 * Whether implementation supports dynamic registration for inline value providers.
+	 */
+	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
+}
+
+/**
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesContext struct {
+	/**
+	 * The document range where execution has stopped.
+	 * Typically the end position of the range denotes the line where the inline values are shown.
+	 */
+	StoppedLocation Range `json:"stoppedLocation"`
+}
+
+/**
+ * Inline values options used during static registration.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesOptions struct {
+	WorkDoneProgressOptions
+}
+
+/**
+ * A parameter literal used in inline values requests.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesParams struct {
+	/**
+	 * The text document.
+	 */
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	/**
+	 * The visible document range for which inline values should be computed.
+	 */
+	ViewPort Range `json:"viewPort"`
+	/**
+	 * Additional information about the context in which inline values were
+	 * requested.
+	 */
+	Context InlineValuesContext `json:"context"`
+	WorkDoneProgressParams
+}
+
+/**
+ * Inline value options used during static or dynamic registration.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesRegistrationOptions struct {
+	InlineValuesOptions
+	TextDocumentRegistrationOptions
+	StaticRegistrationOptions
+}
+
+/**
+ * Client workspace capabilities specific to inline values.
+ *
+ * @since 3.17.0 - proposed state
+ */
+type InlineValuesWorkspaceClientCapabilities struct {
+	/**
+	 * Whether the client implementation supports a refresh request sent from the
+	 * server to the client.
+	 *
+	 * Note that this event is global and will force the client to refresh all
+	 * inline values currently shown. It should be used with absolute care and is
+	 * useful for situation where a server for example detect a project wide
+	 * change that requires such a calculation.
+	 */
+	RefreshSupport bool `json:"refreshSupport,omitempty"`
+}
+
+/**
  * A special text edit to provide an insert and a replace operation.
  *
  * @since 3.16.0
@@ -2602,6 +2830,27 @@ type InsertTextFormat float64
  * @since 3.16.0
  */
 type InsertTextMode float64
+
+/**
+ * The LSP any type
+ *
+ * @since 3.17.0
+ */
+type LSPAny = interface{} /* LSPObject | LSPArray | string | int32 | uint32 | Decimal | bool | float64*/
+
+/**
+ * LSP arrays.
+ *
+ * @since 3.17.0
+ */
+type LSPArray = []LSPAny
+
+/**
+ * LSP object definition.
+ *
+ * @since 3.17.0
+ */
+type LSPObject = map[string]interface{} /*[key: string]: LSPAny*/
 
 /**
  * Client capabilities for the linked editing range request.
@@ -2722,6 +2971,13 @@ type MarkdownClientCapabilities struct {
 	 * The version of the parser.
 	 */
 	Version string `json:"version,omitempty"`
+	/**
+	 * A list of HTML tags that the client allows / supports in
+	 * Markdown.
+	 *
+	 * @since 3.17.0
+	 */
+	AllowedTags []string `json:"allowedTags,omitempty"`
 }
 
 /**
@@ -3107,7 +3363,7 @@ type Registration struct {
 	/**
 	 * Options necessary for the registration.
 	 */
-	RegisterOptions interface{} `json:"registerOptions,omitempty"`
+	RegisterOptions LSPAny `json:"registerOptions,omitempty"`
 }
 
 type RegistrationParams struct {
@@ -3432,6 +3688,28 @@ type SemanticTokensClientCapabilities struct {
 	 * Whether the client supports tokens that can span multiple lines.
 	 */
 	MultilineTokenSupport bool `json:"multilineTokenSupport,omitempty"`
+	/**
+	 * Whether the client allows the server to actively cancel a
+	 * semantic token request, e.g. supports returning
+	 * LSPErrorCodes.ServerCancelled. If a server does the client
+	 * needs to retrigger the request.
+	 *
+	 * @since 3.17.0
+	 */
+	ServerCancelSupport bool `json:"serverCancelSupport,omitempty"`
+	/**
+	 * Whether the client uses semantic tokens to augment existing
+	 * syntax tokens. If set to `true` client side created syntax
+	 * tokens and semantic tokens are both used for colorization. If
+	 * set to `false` the client only uses the returned semantic tokens
+	 * for colorization.
+	 *
+	 * If the value is `undefined` then the client behavior is not
+	 * specified.
+	 *
+	 * @since 3.17.0
+	 */
+	AugmentsSyntaxTokens bool `json:"augmentsSyntaxTokens,omitempty"`
 }
 
 /**
@@ -3700,6 +3978,12 @@ type ServerCapabilities struct {
 	 */
 	TypeHierarchyProvider interface{}/* bool | TypeHierarchyOptions | TypeHierarchyRegistrationOptions*/ `json:"typeHierarchyProvider,omitempty"`
 	/**
+	 * The server provides inline values.
+	 *
+	 * @since 3.17.0 - proposed state
+	 */
+	InlineValuesProvider interface{}/* bool | InlineValuesOptions | InlineValuesOptions | InlineValuesRegistrationOptions*/ `json:"inlineValuesProvider,omitempty"`
+	/**
 	 * Experimental server capabilities.
 	 */
 	Experimental interface{} `json:"experimental,omitempty"`
@@ -3823,15 +4107,27 @@ type SignatureHelp struct {
 	 */
 	Signatures []SignatureInformation `json:"signatures"`
 	/**
-	 * The active signature. Set to `null` if no
-	 * signatures exist.
+	 * The active signature. If omitted or the value lies outside the
+	 * range of `signatures` the value defaults to zero or is ignored if
+	 * the `SignatureHelp` has no signatures.
+	 *
+	 * Whenever possible implementors should make an active decision about
+	 * the active signature and shouldn't rely on a default value.
+	 *
+	 * In future version of the protocol this property might become
+	 * mandatory to better express this.
 	 */
-	ActiveSignature uint32/*uinteger | null*/ `json:"activeSignature"`
+	ActiveSignature uint32 `json:"activeSignature,omitempty"`
 	/**
-	 * The active parameter of the active signature. Set to `null`
-	 * if the active signature has no parameters.
+	 * The active parameter of the active signature. If omitted or the value
+	 * lies outside the range of `signatures[activeSignature].parameters`
+	 * defaults to 0 if the active signature has parameters. If
+	 * the active signature has no parameters it is ignored.
+	 * In future version of the protocol this property might become
+	 * mandatory to better express the active parameter if the
+	 * active signature does have any.
 	 */
-	ActiveParameter uint32/*uinteger | null*/ `json:"activeParameter"`
+	ActiveParameter uint32 `json:"activeParameter,omitempty"`
 }
 
 /**
@@ -4188,6 +4484,12 @@ type TextDocumentClientCapabilities struct {
 	 * @since 3.17.0 - proposed state
 	 */
 	TypeHierarchy TypeHierarchyClientCapabilities `json:"typeHierarchy,omitempty"`
+	/**
+	 * Capabilities specific to the `textDocument/inlineValues` request.
+	 *
+	 * @since 3.17.0 - proposed state
+	 */
+	InlineValues InlineValuesClientCapabilities `json:"inlineValues,omitempty"`
 }
 
 /**
@@ -4369,7 +4671,7 @@ type TextEdit struct {
 
 type TokenFormat = string
 
-type TraceValues = string /*'off' | 'messages' | 'verbose'*/
+type TraceValues = string /* 'off' | 'messages' | 'compact' | 'verbose' */
 
 /**
  * Since 3.6.0
@@ -4458,7 +4760,7 @@ type TypeHierarchyItem struct {
 	 * type hierarchy in the server, helping improve the performance on
 	 * resolving supertypes and subtypes.
 	 */
-	Data interface{} `json:"data,omitempty"`
+	Data LSPAny `json:"data,omitempty"`
 }
 
 /**
@@ -4767,6 +5069,13 @@ type WorkspaceClientCapabilities struct {
 	 * Since 3.16.0
 	 */
 	FileOperations FileOperationClientCapabilities `json:"fileOperations,omitempty"`
+	/**
+	 * Capabilities specific to the inline values requests scoped to the
+	 * workspace.
+	 *
+	 * @since 3.17.0.
+	 */
+	InlineValues InlineValuesWorkspaceClientCapabilities `json:"inlineValues,omitempty"`
 }
 
 /**
@@ -4822,7 +5131,7 @@ type WorkspaceEdit struct {
 	/**
 	 * Holds changes to existing resources.
 	 */
-	Changes map[string][]TextEdit/*[uri: string]: TextEdit[];*/ `json:"changes,omitempty"`
+	Changes map[DocumentURI][]TextEdit/*[uri: DocumentUri]: TextEdit[];*/ `json:"changes,omitempty"`
 	/**
 	 * Depending on the client capability `workspace.workspaceEdit.resourceOperations` document changes
 	 * are either an array of `TextDocumentEdit`s to express changes to n different text documents
@@ -4844,7 +5153,7 @@ type WorkspaceEdit struct {
 	 *
 	 * @since 3.16.0
 	 */
-	ChangeAnnotations map[string]ChangeAnnotationIdentifier/*[id: string * ChangeAnnotationIdentifier *]: ChangeAnnotation;*/ `json:"changeAnnotations,omitempty"`
+	ChangeAnnotations map[string]ChangeAnnotationIdentifier/*[id: ChangeAnnotationIdentifier]: ChangeAnnotation;*/ `json:"changeAnnotations,omitempty"`
 }
 
 type WorkspaceEditClientCapabilities struct {
@@ -4958,6 +5267,25 @@ type WorkspaceFullDocumentDiagnosticReport struct {
 }
 
 /**
+ * A special workspace symbol that supports locations without a range
+ *
+ * @since 3.17.0 - proposed state
+ */
+type WorkspaceSymbol struct {
+	/**
+	 * The location of the symbol.
+	 *
+	 * See SymbolInformation#location for more details.
+	 */
+	Location Location/*Location | { uri: DocumentUri; }*/ `json:"location"`
+	/**
+	 * A data entry field that is preserved on a workspace symbol between a
+	 * workspace symbol request and a workspace symbol resolve request.
+	 */
+	Data LSPAny `json:"data,omitempty"`
+}
+
+/**
  * Client capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
  */
 type WorkspaceSymbolClientCapabilities struct {
@@ -4993,12 +5321,33 @@ type WorkspaceSymbolClientCapabilities struct {
 		 */
 		ValueSet []SymbolTag `json:"valueSet"`
 	} `json:"tagSupport,omitempty"`
+	/**
+	 * The client support partial workspace symbols. The client will send the
+	 * request `workspaceSymbol/resolve` to the server to resolve additional
+	 * properties.
+	 *
+	 * @since 3.17.0 - proposedState
+	 */
+	ResolveSupport struct {
+		/**
+		 * The properties that a client can resolve lazily. Usually
+		 * `location.range`
+		 */
+		Properties []string `json:"properties"`
+	} `json:"resolveSupport,omitempty"`
 }
 
 /**
  * Server capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
  */
 type WorkspaceSymbolOptions struct {
+	/**
+	 * The server provides support to resolve additional
+	 * information for a workspace symbol.
+	 *
+	 * @since 3.17.0 - proposed state
+	 */
+	ResolveProvider bool `json:"resolveProvider,omitempty"`
 	WorkDoneProgressOptions
 }
 
@@ -5109,32 +5458,45 @@ const (
 	 * @since 3.15.0
 	 */
 
-	SourceFixAll            CodeActionKind     = "source.fixAll"
-	TextCompletion          CompletionItemKind = 1
-	MethodCompletion        CompletionItemKind = 2
-	FunctionCompletion      CompletionItemKind = 3
-	ConstructorCompletion   CompletionItemKind = 4
-	FieldCompletion         CompletionItemKind = 5
-	VariableCompletion      CompletionItemKind = 6
-	ClassCompletion         CompletionItemKind = 7
-	InterfaceCompletion     CompletionItemKind = 8
-	ModuleCompletion        CompletionItemKind = 9
-	PropertyCompletion      CompletionItemKind = 10
-	UnitCompletion          CompletionItemKind = 11
-	ValueCompletion         CompletionItemKind = 12
-	EnumCompletion          CompletionItemKind = 13
-	KeywordCompletion       CompletionItemKind = 14
-	SnippetCompletion       CompletionItemKind = 15
-	ColorCompletion         CompletionItemKind = 16
-	FileCompletion          CompletionItemKind = 17
-	ReferenceCompletion     CompletionItemKind = 18
-	FolderCompletion        CompletionItemKind = 19
-	EnumMemberCompletion    CompletionItemKind = 20
-	ConstantCompletion      CompletionItemKind = 21
-	StructCompletion        CompletionItemKind = 22
-	EventCompletion         CompletionItemKind = 23
-	OperatorCompletion      CompletionItemKind = 24
-	TypeParameterCompletion CompletionItemKind = 25
+	SourceFixAll CodeActionKind = "source.fixAll"
+	/**
+	 * Code actions were explicitly requested by the user or by an extension.
+	 */
+
+	CodeActionInvoked CodeActionTriggerKind = 1
+	/**
+	 * Code actions were requested automatically.
+	 *
+	 * This typically happens when current selection in a file changes, but can
+	 * also be triggered when file content changes.
+	 */
+
+	CodeActionAutomatic     CodeActionTriggerKind = 2
+	TextCompletion          CompletionItemKind    = 1
+	MethodCompletion        CompletionItemKind    = 2
+	FunctionCompletion      CompletionItemKind    = 3
+	ConstructorCompletion   CompletionItemKind    = 4
+	FieldCompletion         CompletionItemKind    = 5
+	VariableCompletion      CompletionItemKind    = 6
+	ClassCompletion         CompletionItemKind    = 7
+	InterfaceCompletion     CompletionItemKind    = 8
+	ModuleCompletion        CompletionItemKind    = 9
+	PropertyCompletion      CompletionItemKind    = 10
+	UnitCompletion          CompletionItemKind    = 11
+	ValueCompletion         CompletionItemKind    = 12
+	EnumCompletion          CompletionItemKind    = 13
+	KeywordCompletion       CompletionItemKind    = 14
+	SnippetCompletion       CompletionItemKind    = 15
+	ColorCompletion         CompletionItemKind    = 16
+	FileCompletion          CompletionItemKind    = 17
+	ReferenceCompletion     CompletionItemKind    = 18
+	FolderCompletion        CompletionItemKind    = 19
+	EnumMemberCompletion    CompletionItemKind    = 20
+	ConstantCompletion      CompletionItemKind    = 21
+	StructCompletion        CompletionItemKind    = 22
+	EventCompletion         CompletionItemKind    = 23
+	OperatorCompletion      CompletionItemKind    = 24
+	TypeParameterCompletion CompletionItemKind    = 25
 	/**
 	 * Render a completion as obsolete, usually using a strike-out.
 	 */
@@ -5554,6 +5916,14 @@ type Workspace2Gn struct {
 	FileOperations *FileOperationClientCapabilities `json:"fileOperations,omitempty"`
 
 	/**
+	 * Capabilities specific to the inline values requests scoped to the
+	 * workspace.
+	 *
+	 * @since 3.17.0.
+	 */
+	InlineValues InlineValuesWorkspaceClientCapabilities `json:"inlineValues,omitempty"`
+
+	/**
 	 * The client has support for workspace folders
 	 *
 	 * @since 3.6.0
@@ -5622,6 +5992,14 @@ type Workspace3Gn struct {
 	 * Since 3.16.0
 	 */
 	FileOperations *FileOperationClientCapabilities `json:"fileOperations,omitempty"`
+
+	/**
+	 * Capabilities specific to the inline values requests scoped to the
+	 * workspace.
+	 *
+	 * @since 3.17.0.
+	 */
+	InlineValues InlineValuesWorkspaceClientCapabilities `json:"inlineValues,omitempty"`
 
 	/**
 	 * The client has support for workspace folders
@@ -5719,6 +6097,14 @@ type Workspace6Gn struct {
 	 * Since 3.16.0
 	 */
 	FileOperations *FileOperationClientCapabilities `json:"fileOperations,omitempty"`
+
+	/**
+	 * Capabilities specific to the inline values requests scoped to the
+	 * workspace.
+	 *
+	 * @since 3.17.0.
+	 */
+	InlineValues InlineValuesWorkspaceClientCapabilities `json:"inlineValues,omitempty"`
 
 	/**
 	 * The client has support for workspace folders

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/README.md
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/README.md
@@ -48,7 +48,7 @@ the generated files and stored in the variable `gitHash` in `go.ts`. It is check
 3. (There's a good chance that soon you will be asked to upgrade your new npm. `sudo npm install -g npm` is the command.)
 4. For either system, node and nvm should now be available. Running `node -v` and `npm -v` should produce version numbers.
 5. `npm install typescript`
-    1. This will likely give warning messages that indicate you've failed to set up a project. Ignore them.
+    1. This may give warning messages that indicate you've failed to set up a project. Ignore them.
     2. Your home directory will now have new directories `.npm` and `node_modules` (and a `package_lock.json` file)
     3. The typescript executable `tsc` will be in `node_modules/.bin`, so put that directory in your path.
     4. `tsc -v` should print "Version 4.2.4" (or later). If not you may (as I did) have an obsolete tsc earlier in your path.

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/code.ts
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/code.ts
@@ -532,6 +532,7 @@ function cleanData() { // middle pass
 function sameType(a: ts.TypeNode, b: ts.TypeNode): boolean {
   if (a.kind !== b.kind) return false;
   if (a.kind === ts.SyntaxKind.BooleanKeyword) return true;
+  if (a.kind === ts.SyntaxKind.StringKeyword) return true;
   if (ts.isTypeReferenceNode(a) && ts.isTypeReferenceNode(b) &&
     a.typeName.getText() === b.typeName.getText()) return true;
   if (ts.isArrayTypeNode(a) && ts.isArrayTypeNode(b)) return sameType(a.elementType, b.elementType);
@@ -540,7 +541,7 @@ function sameType(a: ts.TypeNode, b: ts.TypeNode): boolean {
     if (a.members.length === 1) return a.members[0].name.getText() === b.members[0].name.getText();
     if (loc(a) === loc(b)) return true;
   }
-  throw new Error(`546 sameType? ${strKind(a)} ${strKind(b)}`);
+  throw new Error(`544 sameType? ${strKind(a)} ${strKind(b)} ${a.getText()}`);
 }
 type CreateMutable<Type> = {
   -readonly [Property in keyof Type]: Type[Property];
@@ -721,6 +722,7 @@ function goInterface(d: Data, nm: string) {
   const f = function (n: ts.ExpressionWithTypeArguments) {
     if (!ts.isIdentifier(n.expression))
       throw new Error(`Interface ${nm} heritage ${strKind(n.expression)} `);
+    if (n.expression.getText() === 'Omit') return;  // Type modification type
     ans = ans.concat(goName(n.expression.getText()), '\n');
   };
   d.as.forEach((n: ts.HeritageClause) => n.types.forEach(f));
@@ -874,9 +876,8 @@ function goUnionType(n: ts.UnionTypeNode, nm: string): string {
       if (a == 'NumberKeyword' && b == 'StringKeyword') {  // ID
         return `interface{} ${help}`;
       }
-      if (b == 'NullKeyword' || n.types[1].getText() === 'null') {
-        // PJW: fix this. it looks like 'null' is now being parsed as LiteralType
-        // and check the other keyword cases
+      // for null, b is not useful (LiternalType)
+      if (n.types[1].getText() === 'null') {
         if (nm == 'textDocument/codeAction') {
           // (Command | CodeAction)[] | null
           return `[]CodeAction ${help}`;
@@ -896,9 +897,11 @@ function goUnionType(n: ts.UnionTypeNode, nm: string): string {
         return `*TextEdit ${help}`;
       }
       if (a == 'TypeReference') {
-        if (nm == 'edits') return `${goType(n.types[0], '715')} ${help}`;
+        if (nm == 'edits') return `${goType(n.types[0], '901')} ${help}`;
         if (a == b) return `interface{} ${help}`;
         if (nm == 'code') return `interface{} ${help}`;
+        if (nm == 'editRange') return `${goType(n.types[0], '904')} ${help}`;
+        if (nm === 'location') return `${goType(n.types[0], '905')} ${help}`;
       }
       if (a == 'StringKeyword') return `string ${help}`;
       if (a == 'TypeLiteral' && nm == 'TextDocumentContentChangeEvent') {
@@ -915,6 +918,7 @@ function goUnionType(n: ts.UnionTypeNode, nm: string): string {
       const aa = strKind(n.types[0]);
       const bb = strKind(n.types[1]);
       const cc = strKind(n.types[2]);
+      if (nm === 'workspace/symbol') return `${goType(n.types[0], '930')} ${help}`;
       if (nm == 'DocumentFilter') {
         // not really a union. the first is enough, up to a missing
         // omitempty but avoid repetitious comments
@@ -942,9 +946,11 @@ function goUnionType(n: ts.UnionTypeNode, nm: string): string {
     case 4:
       if (nm == 'documentChanges') return `TextDocumentEdit ${help} `;
       if (nm == 'textDocument/prepareRename') return `Range ${help} `;
-    // eslint-disable-next-line no-fallthrough
+      break;
+    case 8: // LSPany
+      break;
     default:
-      throw new Error(`goUnionType len=${n.types.length} nm=${nm}`);
+      throw new Error(`957 goUnionType len=${n.types.length} nm=${nm} ${n.getText()}`);
   }
 
   // Result will be interface{} with a comment
@@ -1048,7 +1054,7 @@ function isStructType(te: ts.TypeNode): boolean {
     case 'TypeReference': {
       if (!ts.isTypeReferenceNode(te)) throw new Error(`1047 impossible ${strKind(te)}`);
       const d = seenTypes.get(goName(te.typeName.getText()));
-      if (d === undefined) return false;
+      if (d === undefined || d.properties.length == 0) return false;
       if (d.properties.length > 1) return true;
       // alias or interface with a single property (The alias is Uinteger, which we ignore later)
       if (d.alias) return false;
@@ -1067,6 +1073,10 @@ function goTypeLiteral(n: ts.TypeLiteralNode, nm: string): string {
     if (ts.isPropertySignature(nx)) {
       let json = u.JSON(nx);
       let typ = goType(nx.type, nx.name.getText());
+      // }/*\n*/`json:v` is not legal, the comment is a newline
+      if (typ.includes('\n') && typ.indexOf('*/') === typ.length - 2) {
+        typ = typ.replace(/\n\t*/g, ' ');
+      }
       const v = getComments(nx) || '';
       starred.forEach(([a, b]) => {
         if (a != nm || b != typ.toLowerCase()) return;
@@ -1080,12 +1090,16 @@ function goTypeLiteral(n: ts.TypeLiteralNode, nm: string): string {
       const comment = nx.getText().replace(/[/]/g, '');
       if (nx.getText() == '[uri: string]: TextEdit[];') {
         res = 'map[string][]TextEdit';
-      } else if (nx.getText() == '[id: string /* ChangeAnnotationIdentifier */]: ChangeAnnotation;') {
+      } else if (nx.getText().startsWith('[id: ChangeAnnotationIdentifier]')) {
         res = 'map[string]ChangeAnnotationIdentifier';
       } else if (nx.getText().startsWith('[uri: string')) {
         res = 'map[string]interface{}';
+      } else if (nx.getText().startsWith('[uri: DocumentUri')) {
+        res = 'map[DocumentURI][]TextEdit';
+      } else if (nx.getText().startsWith('[key: string')) {
+        res = 'map[string]interface{}';
       } else {
-        throw new Error(`1088 handle ${nx.getText()} ${loc(nx)}`);
+        throw new Error(`1100 handle ${nx.getText()} ${loc(nx)}`);
       }
       res += ` /*${comment}*/`;
       ans.push(res);

--- a/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/util.ts
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/protocol/typescript/util.ts
@@ -15,7 +15,7 @@ export const fnames = [
   `${dir}/${srcDir}/protocol/src/browser/main.ts`, `${dir}${srcDir}/types/src/main.ts`,
   `${dir}${srcDir}/jsonrpc/src/node/main.ts`
 ];
-export const gitHash = '10b56de150ad67c3c330da8e2df53ebf2cf347c4';
+export const gitHash = 'd959faf4be476a6e0a08d5612e91fcac14ff9929';
 let outFname = 'tsprotocol.go';
 let fda: number, fdb: number, fde: number;  // file descriptors
 
@@ -112,7 +112,7 @@ export function constName(nm: string, type: string): string {
   let pref = new Map<string, string>([
     ['DiagnosticSeverity', 'Severity'], ['WatchKind', 'Watch'],
     ['SignatureHelpTriggerKind', 'Sig'], ['CompletionItemTag', 'Compl'],
-    ['Integer', 'INT_'], ['Uinteger', 'UINT_']
+    ['Integer', 'INT_'], ['Uinteger', 'UINT_'], ['CodeActionTriggerKind', 'CodeAction']
   ]);  // typeName->prefix
   let suff = new Map<string, string>([
     ['CompletionItemKind', 'Completion'], ['InsertTextFormat', 'TextFormat'],

--- a/cmd/govim/internal/golang_org_x_tools/lsp/server_gen.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/server_gen.go
@@ -144,6 +144,14 @@ func (s *Server) Initialized(ctx context.Context, params *protocol.InitializedPa
 	return s.initialized(ctx, params)
 }
 
+func (s *Server) InlineValues(context.Context, *protocol.InlineValuesParams) ([]protocol.InlineValue, error) {
+	return nil, notImplemented("InlineValues")
+}
+
+func (s *Server) InlineValuesRefresh(context.Context) error {
+	return notImplemented("InlineValuesRefresh")
+}
+
 func (s *Server) LinkedEditingRange(context.Context, *protocol.LinkedEditingRangeParams) (*protocol.LinkedEditingRanges, error) {
 	return nil, notImplemented("LinkedEditingRange")
 }
@@ -206,6 +214,10 @@ func (s *Server) ResolveCodeLens(context.Context, *protocol.CodeLens) (*protocol
 
 func (s *Server) ResolveDocumentLink(context.Context, *protocol.DocumentLink) (*protocol.DocumentLink, error) {
 	return nil, notImplemented("ResolveDocumentLink")
+}
+
+func (s *Server) ResolveWorkspaceSymbol(context.Context, *protocol.WorkspaceSymbol) (*protocol.WorkspaceSymbol, error) {
+	return nil, notImplemented("ResolveWorkspaceSymbol")
 }
 
 func (s *Server) SelectionRange(context.Context, *protocol.SelectionRangeParams) ([]protocol.SelectionRange, error) {

--- a/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/source/api_json.go
@@ -443,7 +443,7 @@ var GeneratedAPIJSON = &APIJSON{
 						},
 						{
 							Name:    "\"infertypeargs\"",
-							Doc:     "check for unnecessary type arguments in call expressions\n\nExplicit type arguments may be omitted from call expressions if they can be\ninferred from function arguments, or from other type arguments:\n\nfunc f[T any](T) {}\n\nfunc _() {\n\tf[string](\"foo\") // string could be inferred\n}\n",
+							Doc:     "check for unnecessary type arguments in call expressions\n\nExplicit type arguments may be omitted from call expressions if they can be\ninferred from function arguments, or from other type arguments:\n\n\tfunc f[T any](T) {}\n\t\n\tfunc _() {\n\t\tf[string](\"foo\") // string could be inferred\n\t}\n",
 							Default: "true",
 						},
 						{
@@ -563,7 +563,7 @@ var GeneratedAPIJSON = &APIJSON{
 						},
 						{
 							Name:    "\"fillreturns\"",
-							Doc:     "suggested fixes for \"wrong number of return values (want %d, got %d)\"\n\nThis checker provides suggested fixes for type errors of the\ntype \"wrong number of return values (want %d, got %d)\". For example:\n\tfunc m() (int, string, *bool, error) {\n\t\treturn\n\t}\nwill turn into\n\tfunc m() (int, string, *bool, error) {\n\t\treturn 0, \"\", nil, nil\n\t}\n\nThis functionality is similar to https://github.com/sqs/goreturns.\n",
+							Doc:     "suggest fixes for errors due to an incorrect number of return values\n\nThis checker provides suggested fixes for type errors of the\ntype \"wrong number of return values (want %d, got %d)\". For example:\n\tfunc m() (int, string, *bool, error) {\n\t\treturn\n\t}\nwill turn into\n\tfunc m() (int, string, *bool, error) {\n\t\treturn 0, \"\", nil, nil\n\t}\n\nThis functionality is similar to https://github.com/sqs/goreturns.\n",
 							Default: "true",
 						},
 						{
@@ -1021,7 +1021,7 @@ var GeneratedAPIJSON = &APIJSON{
 		},
 		{
 			Name:    "infertypeargs",
-			Doc:     "check for unnecessary type arguments in call expressions\n\nExplicit type arguments may be omitted from call expressions if they can be\ninferred from function arguments, or from other type arguments:\n\nfunc f[T any](T) {}\n\nfunc _() {\n\tf[string](\"foo\") // string could be inferred\n}\n",
+			Doc:     "check for unnecessary type arguments in call expressions\n\nExplicit type arguments may be omitted from call expressions if they can be\ninferred from function arguments, or from other type arguments:\n\n\tfunc f[T any](T) {}\n\t\n\tfunc _() {\n\t\tf[string](\"foo\") // string could be inferred\n\t}\n",
 			Default: true,
 		},
 		{
@@ -1141,7 +1141,7 @@ var GeneratedAPIJSON = &APIJSON{
 		},
 		{
 			Name:    "fillreturns",
-			Doc:     "suggested fixes for \"wrong number of return values (want %d, got %d)\"\n\nThis checker provides suggested fixes for type errors of the\ntype \"wrong number of return values (want %d, got %d)\". For example:\n\tfunc m() (int, string, *bool, error) {\n\t\treturn\n\t}\nwill turn into\n\tfunc m() (int, string, *bool, error) {\n\t\treturn 0, \"\", nil, nil\n\t}\n\nThis functionality is similar to https://github.com/sqs/goreturns.\n",
+			Doc:     "suggest fixes for errors due to an incorrect number of return values\n\nThis checker provides suggested fixes for type errors of the\ntype \"wrong number of return values (want %d, got %d)\". For example:\n\tfunc m() (int, string, *bool, error) {\n\t\treturn\n\t}\nwill turn into\n\tfunc m() (int, string, *bool, error) {\n\t\treturn 0, \"\", nil, nil\n\t}\n\nThis functionality is similar to https://github.com/sqs/goreturns.\n",
 			Default: true,
 		},
 		{

--- a/cmd/govim/internal/golang_org_x_tools/lsp/template/completion.go
+++ b/cmd/govim/internal/golang_org_x_tools/lsp/template/completion.go
@@ -78,13 +78,15 @@ func filterSyms(syms map[string]symbol, ns []symbol) {
 
 // return the starting position of the enclosing token, or -1 if none
 func inTemplate(fc *Parsed, pos protocol.Position) int {
+	// pos is the pos-th character. if the cursor is at the beginning
+	// of the file, pos is 0. That is, we've only seen characters before pos
 	// 1. pos might be in a Token, return tk.Start
 	// 2. pos might be after an elided but before a Token, return elided
 	// 3. return -1 for false
 	offset := fc.FromPosition(pos)
 	// this could be a binary search, as the tokens are ordered
 	for _, tk := range fc.tokens {
-		if tk.Start <= offset && offset < tk.End {
+		if tk.Start < offset && offset <= tk.End {
 			return tk.Start
 		}
 	}
@@ -244,7 +246,7 @@ func scan(buf []byte) []string {
 			ans[len(ans)-1] = "." + lit
 		} else if tok == token.IDENT && len(ans) > 0 && ans[len(ans)-1] == "$" {
 			ans[len(ans)-1] = "$" + lit
-		} else {
+		} else if lit != "" {
 			ans = append(ans, lit)
 		}
 	}

--- a/cmd/govim/internal/golang_org_x_tools/memoize/memoize.go
+++ b/cmd/govim/internal/golang_org_x_tools/memoize/memoize.go
@@ -62,6 +62,8 @@ type Generation struct {
 	destroyed uint32
 	store     *Store
 	name      string
+	// destroyedBy describes the caller that togged destroyed from 0 to 1.
+	destroyedBy string
 	// wg tracks the reference count of this generation.
 	wg sync.WaitGroup
 }
@@ -69,10 +71,16 @@ type Generation struct {
 // Destroy waits for all operations referencing g to complete, then removes
 // all references to g from cache entries. Cache entries that no longer
 // reference any non-destroyed generation are removed. Destroy must be called
-// exactly once for each generation.
-func (g *Generation) Destroy() {
+// exactly once for each generation, and destroyedBy describes the caller.
+func (g *Generation) Destroy(destroyedBy string) {
 	g.wg.Wait()
-	atomic.StoreUint32(&g.destroyed, 1)
+
+	prevDestroyedBy := g.destroyedBy
+	g.destroyedBy = destroyedBy
+	if ok := atomic.CompareAndSwapUint32(&g.destroyed, 0, 1); !ok {
+		panic("Destroy on generation " + g.name + " already destroyed by " + prevDestroyedBy)
+	}
+
 	g.store.mu.Lock()
 	defer g.store.mu.Unlock()
 	for k, e := range g.store.handles {
@@ -94,13 +102,10 @@ func (g *Generation) Destroy() {
 
 // Acquire creates a new reference to g, and returns a func to release that
 // reference.
-func (g *Generation) Acquire(ctx context.Context) func() {
+func (g *Generation) Acquire() func() {
 	destroyed := atomic.LoadUint32(&g.destroyed)
-	if ctx.Err() != nil {
-		return func() {}
-	}
 	if destroyed != 0 {
-		panic("acquire on destroyed generation " + g.name)
+		panic("acquire on generation " + g.name + " destroyed by " + g.destroyedBy)
 	}
 	g.wg.Add(1)
 	return g.wg.Done
@@ -175,7 +180,7 @@ func (g *Generation) Bind(key interface{}, function Function, cleanup func(inter
 		panic("the function passed to bind must not be nil")
 	}
 	if atomic.LoadUint32(&g.destroyed) != 0 {
-		panic("operation on destroyed generation " + g.name)
+		panic("operation on generation " + g.name + " destroyed by " + g.destroyedBy)
 	}
 	g.store.mu.Lock()
 	defer g.store.mu.Unlock()
@@ -233,7 +238,7 @@ func (s *Store) DebugOnlyIterate(f func(k, v interface{})) {
 func (g *Generation) Inherit(hs ...*Handle) {
 	for _, h := range hs {
 		if atomic.LoadUint32(&g.destroyed) != 0 {
-			panic("inherit on destroyed generation " + g.name)
+			panic("inherit on generation " + g.name + " destroyed by " + g.destroyedBy)
 		}
 
 		h.mu.Lock()
@@ -266,7 +271,7 @@ func (h *Handle) Cached(g *Generation) interface{} {
 // If the value is not yet ready, the underlying function will be invoked.
 // If ctx is cancelled, Get returns nil.
 func (h *Handle) Get(ctx context.Context, g *Generation, arg Arg) (interface{}, error) {
-	release := g.Acquire(ctx)
+	release := g.Acquire()
 	defer release()
 
 	if ctx.Err() != nil {
@@ -311,7 +316,7 @@ func (h *Handle) run(ctx context.Context, g *Generation, arg Arg) (interface{}, 
 	function := h.function // Read under the lock
 
 	// Make sure that the generation isn't destroyed while we're running in it.
-	release := g.Acquire(ctx)
+	release := g.Acquire()
 	go func() {
 		defer release()
 		// Just in case the function does something expensive without checking

--- a/cmd/govim/internal/golang_org_x_tools/typeparams/typeparams_go117.go
+++ b/cmd/govim/internal/golang_org_x_tools/typeparams/typeparams_go117.go
@@ -75,6 +75,7 @@ func ForFuncType(*ast.FuncType) *ast.FieldList {
 // this Go version. Its methods panic on use.
 type TypeParam struct{ types.Type }
 
+func (*TypeParam) Index() int             { unsupported(); return 0 }
 func (*TypeParam) Constraint() types.Type { unsupported(); return nil }
 func (*TypeParam) Obj() *types.TypeName   { unsupported(); return nil }
 

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
 	golang.org/x/text v0.3.7
-	golang.org/x/tools v0.1.8-0.20211123163920-1e71a25a932d
-	golang.org/x/tools/gopls v0.0.0-20211123163920-1e71a25a932d
+	golang.org/x/tools v0.1.9-0.20211203185511-c882a49eac7c
+	golang.org/x/tools/gopls v0.0.0-20211203185511-c882a49eac7c
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/go.sum
+++ b/go.sum
@@ -91,10 +91,10 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
-golang.org/x/tools v0.1.8-0.20211123163920-1e71a25a932d h1:dzN8FXPYPGj4r8qosdd+dmYx7KXVyd+SiTj/jzoTo5Y=
-golang.org/x/tools v0.1.8-0.20211123163920-1e71a25a932d/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
-golang.org/x/tools/gopls v0.0.0-20211123163920-1e71a25a932d h1:xofARez8qcuVy8HKq5fzHP3gGzGRZLhO4h39J+HwbN0=
-golang.org/x/tools/gopls v0.0.0-20211123163920-1e71a25a932d/go.mod h1:HuW2ffRPosfZynRszmhhhUXcUtH35UKt9AvsJcLrj60=
+golang.org/x/tools v0.1.9-0.20211203185511-c882a49eac7c h1:8aIxlM91qI41mNQcCwJqlFHhRBMlLYNLgcWSomSpWSY=
+golang.org/x/tools v0.1.9-0.20211203185511-c882a49eac7c/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/tools/gopls v0.0.0-20211203185511-c882a49eac7c h1:U+9viqEOyctkOG1ahbYA+COweNXVw/ZQExy0Ll7kjZo=
+golang.org/x/tools/gopls v0.0.0-20211203185511-c882a49eac7c/go.mod h1:HuW2ffRPosfZynRszmhhhUXcUtH35UKt9AvsJcLrj60=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Note that this also contains updates to gopls_server.go to match latest
protocol changes.

* gopls/doc: fix rendering of example for the infertypeargs analyzer c882a49e
* internal/lsp/analysis/fillreturns: update fillreturns for new type errs f64c0f46
* internal/memoize: do not allow (*Generation).Acquire to fail e212aff8
* go/types/typeutil: add support for mapping generic types 2ac48c60
* go/internal/gcimporter: allow reusing empty interfaces on the RHS of type decls df48029e
* internal/lsp/protocol: fix whitespace in comments d99d6fae
* gopls/internal/regtest/misc: temporarily skip TestGenerateProgress 3c63f308
* internal/lsp/protocol: bring the LSP stubs up to date 615f9a6b
* refactor/importgraph: set env from packagestest.Export and check errors from Build 1fd30d29
* internal/memoize: record the caller of Destroy 2c9b078f
* x/tools: temporarily skip a couple of tests 6e52f51f
* internal/lsp/template: fix error that causes crashes a6189239
* cmd/godoc: remove extra // characters from deprecation notice cb80a01b
* go/ssa: remove deprecated FindTests and CreateTestMainPackage 7cf1f382