### PR TITLE
cmd/govim: disable allowModfileModifications by default

### DIFF
--- a/cmd/govim/config/config.go
+++ b/cmd/govim/config/config.go
@@ -319,7 +319,7 @@ type Config struct {
 	// whereas prior to Go 1.16 the default was -mod=mod (equivalent to setting
 	// this option to true).
 	//
-	// Default: true
+	// Default: false
 	ExperimentalAllowModfileModifications *bool `json:",omitempty"`
 
 	// ExperimentalWorkspaceModule opts a user into the experimental gopls

--- a/cmd/govim/main.go
+++ b/cmd/govim/main.go
@@ -239,19 +239,18 @@ func newplugin(goplspath string, goplsEnv []string, defaults, user *config.Confi
 	tmpDir := getEnvVal(goplsEnv, "TMPDIR", os.TempDir())
 	if defaults == nil {
 		defaults = &config.Config{
-			FormatOnSave:                          vimconfig.FormatOnSaveVal(config.FormatOnSaveGoImportsGoFmt),
-			QuickfixAutoDiagnostics:               vimconfig.BoolVal(true),
-			QuickfixSigns:                         vimconfig.BoolVal(true),
-			Staticcheck:                           vimconfig.BoolVal(false),
-			HighlightDiagnostics:                  vimconfig.BoolVal(true),
-			HighlightReferences:                   vimconfig.BoolVal(true),
-			HoverDiagnostics:                      vimconfig.BoolVal(true),
-			TempModfile:                           vimconfig.BoolVal(false),
-			ExperimentalAutoreadLoadedBuffers:     vimconfig.BoolVal(false),
-			SymbolMatcher:                         vimconfig.SymbolMatcherVal(config.SymbolMatcherFuzzy),
-			SymbolStyle:                           vimconfig.SymbolStyleVal(config.SymbolStyleFull),
-			OpenLastProgressWith:                  vimconfig.StringVal("below 10split"),
-			ExperimentalAllowModfileModifications: vimconfig.BoolVal(true),
+			FormatOnSave:                      vimconfig.FormatOnSaveVal(config.FormatOnSaveGoImportsGoFmt),
+			QuickfixAutoDiagnostics:           vimconfig.BoolVal(true),
+			QuickfixSigns:                     vimconfig.BoolVal(true),
+			Staticcheck:                       vimconfig.BoolVal(false),
+			HighlightDiagnostics:              vimconfig.BoolVal(true),
+			HighlightReferences:               vimconfig.BoolVal(true),
+			HoverDiagnostics:                  vimconfig.BoolVal(true),
+			TempModfile:                       vimconfig.BoolVal(false),
+			ExperimentalAutoreadLoadedBuffers: vimconfig.BoolVal(false),
+			SymbolMatcher:                     vimconfig.SymbolMatcherVal(config.SymbolMatcherFuzzy),
+			SymbolStyle:                       vimconfig.SymbolStyleVal(config.SymbolStyleFull),
+			OpenLastProgressWith:              vimconfig.StringVal("below 10split"),
 		}
 	}
 	// Overlay the initial user values on the defaults

--- a/cmd/govim/testdata/scenario_default/go_to_def_upper_case.txt
+++ b/cmd/govim/testdata/scenario_default/go_to_def_upper_case.txt
@@ -28,7 +28,10 @@ module mod.com
 
 go 1.12
 
-require example.com/blah v1.0.0
+require example.com/blaH v1.0.0
+-- go.sum --
+example.com/blaH v1.0.0 h1:iXP7NTq9zM+XteJ+LOgQ4/86Qk9gcwGy7izwrf03Hng=
+example.com/blaH v1.0.0/go.mod h1:2yAkoKJQQy5q8VEphynudWTTk7rzAUrdv+/+RxewcXI=
 -- p.go --
 package p
 


### PR DESCRIPTION
The previous default value for for the config setting
ExperimentalAllowModfileModifications was "true", which isn't the
default value for gopls.

Enabling this setting causes issues with the new workspace mode in
gopls as described in #1112 and referred golang/go#48186. It also seem
to cause issues in upcoming Go 1.18, see golang/go#51056.

Closes #1112