### PR TITLE
cmd/govim: use "g:"-prefix for global callbacks and filter

### DIFF
--- a/cmd/govim/progress.go
+++ b/cmd/govim/progress.go
@@ -44,7 +44,7 @@ func (v *vimstate) handleProgress(popup *types.ProgressPopup, kind, title, messa
 			"maxheight": progressMaxHeight,
 			"firstline": firstline,
 			"scrollbar": false,
-			"callback":  "GOVIM" + config.FunctionProgressClosed,
+			"callback":  "g:GOVIM" + config.FunctionProgressClosed,
 		}
 		popup.ID = v.ParseInt(v.ChannelCall("popup_create", lines, opts))
 		v.lastProgressText = &popup.Text

--- a/cmd/govim/suggested_fixes.go
+++ b/cmd/govim/suggested_fixes.go
@@ -101,9 +101,9 @@ func (v *vimstate) suggestFixes(flags govim.CommandFlags, args ...string) error 
 		opts["drag"] = 1
 		opts["mapping"] = 0
 		opts["cursorline"] = 1
-		opts["filter"] = "GOVIM_internal_SuggestedFixesFilter"
+		opts["filter"] = "g:GOVIM_internal_SuggestedFixesFilter"
 		opts["title"] = resolvableDiags[i].title
-		opts["callback"] = "GOVIM" + config.FunctionPopupSelection
+		opts["callback"] = "g:GOVIM" + config.FunctionPopupSelection
 		if i > 0 {
 			opts["hidden"] = 1
 		}


### PR DESCRIPTION
As of vim v8.2.4260 global function callbacks now require to be prefixed
with "g:". If the callback function cannot be found vim will report an
error when the initial package load popup closes, something that
happened when using v8.2.4260+ and had ExperimentalProgressPopups
enabled.