### PR TITLE
cmd/govim: ignore signaturehelp requests for non-tracked buffers

### DIFF
--- a/cmd/govim/signature_help.go
+++ b/cmd/govim/signature_help.go
@@ -15,10 +15,17 @@ import (
 )
 
 func (v *vimstate) signatureHelp(flags govim.CommandFlags, args ...string) error {
-	b, p, err := v.bufCursorPos()
+	p, err := v.cursorPos()
 	if err != nil {
 		return fmt.Errorf("failed to get current cursor position: %v", err)
 	}
+	if p.Point == nil {
+		// If p.Point is nil govim isn't tracking the buffer. This can happen
+		// when a user has the automatic signature help triggered before a buffer
+		// is loaded, for example as a CursorHold autocommand.
+		return nil
+	}
+	b := p.Buffer()
 	params := &protocol.SignatureHelpParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{


### PR DESCRIPTION
There was a race where an user could trigger a signaturehelp call to
gopls before the buffer wasn't tracked by govim, for example by having
an autocommand for CursorHold.

This is now prevented by ignoring signature calls for buffers that isn't
tracked by govim.