### PR TITLE
plugin: disable GOWORK during installation of gopls

### DIFF
--- a/plugin/govim.vim
+++ b/plugin/govim.vim
@@ -430,7 +430,7 @@ function s:install(force)
     echom "Installing govim and gopls"
     call feedkeys(" ") " to prevent press ENTER to continue
     " TODO: make work on Windows
-    let install = system("env GO111MODULE=on GOBIN=".shellescape(targetdir)." go install github.com/govim/govim/cmd/govim golang.org/x/tools/gopls 2>&1")
+    let install = system("env GO111MODULE=on GOBIN=".shellescape(targetdir)." GOWORK=off go install github.com/govim/govim/cmd/govim golang.org/x/tools/gopls 2>&1")
     if v:shell_error
       throw install
     endif


### PR DESCRIPTION
The automatic installation of gopls used any present GOWORK which
made the installation fail. We now explicitly disable it.