### PR TITLE
cmd/govim: add signaturehelp support for type parameters

### DIFF
--- a/cmd/govim/signature_help.go
+++ b/cmd/govim/signature_help.go
@@ -11,6 +11,7 @@ import (
 	"github.com/govim/govim/cmd/govim/config"
 	"github.com/govim/govim/cmd/govim/internal/golang_org_x_tools/lsp/protocol"
 	"github.com/govim/govim/cmd/govim/internal/types"
+	"golang.org/x/exp/typeparams"
 	"golang.org/x/tools/go/ast/astutil"
 )
 
@@ -97,7 +98,7 @@ FindCall:
 	// hence we need to adjust accordingly
 	var placePos token.Pos
 	switch f := callExpr.Fun.(type) {
-	case *ast.Ident, *ast.FuncLit:
+	case *ast.Ident, *ast.FuncLit, *ast.IndexExpr, *typeparams.IndexListExpr:
 		placePos = callExpr.Pos()
 	case *ast.SelectorExpr:
 		placePos = f.Sel.Pos()

--- a/cmd/govim/testdata/scenario_default/signature_typeparam.txt
+++ b/cmd/govim/testdata/scenario_default/signature_typeparam.txt
@@ -1,0 +1,43 @@
+# Test case that verifies signature help for functions with type parameters.
+
+[!go1.18] skip 'type parameters requires at least Go 1.18'
+
+# Open main.go
+vim ex 'e main.go'
+
+# Move cursor to the *ast.IndexExpr node
+vim ex 'call cursor(7,10)'
+
+# Trigger signature help
+vim ex ':GOVIMExperimentalSignatureHelp'
+
+# Trivial check to see if a popup is created
+errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\{.*\"text\":\"func\(x int\)\"'
+
+# Move cursor to the *ast.IndexListExpr node
+vim ex 'call cursor(8,15)'
+
+# Trigger signature help
+vim ex ':GOVIMExperimentalSignatureHelp'
+
+# Trivial check to see if a popup is created
+errlogmatch 'sendJSONMsg: .*\"call\",\"popup_create\",\[\{.*\"text\":\"func\(\)\"'
+
+# Assert that we have received no error (Type: 1) or warning (Type: 2) log messages
+# Disabled pending resolution to https://github.com/golang/go/issues/34103
+# errlogmatch -start -count=0 'LogMessage callback: &protocol\.LogMessageParams\{Type:(1|2), Message:".*'
+
+-- go.mod --
+module mod.com
+
+go 1.18
+-- main.go --
+package main
+
+func foo[T any](x T)  {}
+func bar[T, T2 any]() {}
+
+func main() {
+	foo[int](1)
+	bar[int, int]()
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/kr/pretty v0.3.0
 	github.com/myitcv/vbash v0.0.4
 	github.com/rogpeppe/go-internal v1.8.1
+	golang.org/x/exp/typeparams v0.0.0-20220328175248-053ad81199eb
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/exp/typeparams v0.0.0-20220328175248-053ad81199eb h1:fP6C8Xutcp5AlakmT/SkQot0pMicROAsEX7OfNPuG10=
+golang.org/x/exp/typeparams v0.0.0-20220328175248-053ad81199eb/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=


### PR DESCRIPTION
Go 1.18 introduced two new ast nodes that our signature help didn't
recognize, which led to panics. Those have added along with a new test.