### PR TITLE
ci: update Ubuntu version used in GitHub actions

### DIFF
--- a/.github/workflows/docker-based_tests.yml
+++ b/.github/workflows/docker-based_tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         go_version: ["go1.18.5", "go1.19"]
         vim_flavor: ["vim", "gvim"]
         vim_version: ["v8.1.1711", "v8.1.2056", "v8.2.4698"]

--- a/.github/workflows/vim_main.yml
+++ b/.github/workflows/vim_main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         go-version: ["1.19.0"]
     runs-on: ${{ matrix.os }}
     env:

--- a/internal/cmd/genconfig/genconfig.go
+++ b/internal/cmd/genconfig/genconfig.go
@@ -193,7 +193,7 @@ func writeDockerWorkflow() {
 			vimVersions = append(vimVersions, b.vimversion)
 		}
 	}
-	var entries = struct {
+	entries := struct {
 		GoVersions  string
 		VimFlavors  string
 		VimVersions string
@@ -312,7 +312,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         go_version: {{{ .GoVersions }}}
         vim_flavor: {{{ .VimFlavors }}}
         vim_version: {{{ .VimVersions }}}
@@ -351,7 +351,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         go-version: ["{{{.MaxRealGoVersion}}}"]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
GitHub dropped support for 18.04 as of 2023-04-03. This change updates the version to 20.04.

See actions/runner-images#6002.