### PR TITLE
cmd/govim: populate clientinfo in initialize params sent to gopls

### DIFF
--- a/cmd/govim/gopls.go
+++ b/cmd/govim/gopls.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -165,6 +166,13 @@ func (g *govimplugin) startGopls() error {
 	initParams.Capabilities.Workspace.DidChangeWatchedFiles.DynamicRegistration = true
 
 	initParams.Capabilities.Window.WorkDoneProgress = true
+
+	initParams.ClientInfo = &protocol.Msg_XInitializeParams_clientInfo{
+		Name: "govim",
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		initParams.ClientInfo.Version = bi.Main.Version
+	}
 
 	// Session-level config should be able to be set post initialize, but that
 	// is not currently supported by gopls. So for now a restart is required


### PR DESCRIPTION
LSP 3.15.0 added support for sending information about the client as part of the InitializeParams message. This change will make govim send it's name and version as a part of that message to gopls.

Also see golang/go#61038.