### PR TITLE
deps: use updated versions of staticcheck and stringer

### DIFF
--- a/_scripts/dockerRun.sh
+++ b/_scripts/dockerRun.sh
@@ -84,7 +84,7 @@ then
 fi
 
 go vet $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
-go run honnef.co/go/tools/cmd/staticcheck $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
+go run honnef.co/go/tools/cmd/staticcheck@v0.4.7 $(go list ./... | grep -v 'govim/internal/golang_org_x_tools')
 
 if [ "${CI:-}" == "true" ] && [ "${GITHUB_EVENT_NAME:-}" != "schedule" ]
 then

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	golang.org/x/tools/gopls v0.0.0-20240514024235-59d9797072e7
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
-	honnef.co/go/tools v0.4.7
 )
 
 require (
@@ -29,6 +28,7 @@ require (
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/vuln v1.0.4 // indirect
+	honnef.co/go/tools v0.4.7 // indirect
 	mvdan.cc/gofumpt v0.6.0 // indirect
 	mvdan.cc/sh/v3 v3.0.0-alpha1 // indirect
 	mvdan.cc/xurls/v2 v2.5.0 // indirect

--- a/govim.go
+++ b/govim.go
@@ -22,7 +22,7 @@ import (
 	"gopkg.in/tomb.v2"
 )
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=GenAttr,Complete,Range,Event,NArgs,Flavor -linecomment -output gen_stringers_stringer.go
+//go:generate go run golang.org/x/tools/cmd/stringer@v0.21.1-0.20240514182804-e8808ed57e2b -type=GenAttr,Complete,Range,Event,NArgs,Flavor -linecomment -output gen_stringers_stringer.go
 //go:generate go run github.com/govim/govim/internal/cmd/genconfig
 
 const (

--- a/tools.go
+++ b/tools.go
@@ -5,7 +5,5 @@ package tools
 
 import (
 	_ "github.com/myitcv/vbash"
-	_ "golang.org/x/tools/cmd/stringer"
 	_ "golang.org/x/tools/gopls"
-	_ "honnef.co/go/tools/cmd/staticcheck"
 )


### PR DESCRIPTION
Using the go run $pkg@$version to remove them from our deps list.